### PR TITLE
Remove Templates/system_stm32h7xx.c

### DIFF
--- a/firmware/ventilator-controller-stm32/.cproject
+++ b/firmware/ventilator-controller-stm32/.cproject
@@ -92,7 +92,7 @@
 					</folderInfo>
 					<sourceEntries>
 						<entry excluding="Test" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Core"/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Drivers"/>
+						<entry excluding="CMSIS/Device/ST/STM32H7xx/Source/Templates|CMSIS/Device/ST/STM32H7xx/Source/Templates/system_stm32h7xx.c" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Drivers"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
@@ -187,7 +187,7 @@
 					</folderInfo>
 					<sourceEntries>
 						<entry excluding="Test" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Core"/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Drivers"/>
+						<entry excluding="CMSIS/Device/ST/STM32H7xx/Source/Templates|CMSIS/Device/ST/STM32H7xx/Source/Templates/system_stm32h7xx.c" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Drivers"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/firmware/ventilator-controller-stm32/Drivers/CMSIS/Device/ST/STM32H7xx/Source/Templates/system_stm32h7xx.c
+++ b/firmware/ventilator-controller-stm32/Drivers/CMSIS/Device/ST/STM32H7xx/Source/Templates/system_stm32h7xx.c
@@ -52,11 +52,11 @@
 #endif /* HSE_VALUE */
 
 #if !defined  (CSI_VALUE)
-  #define CSI_VALUE    ((uint32_t)4000000) /*!< Value of the Internal oscillator in Hz*/
+#define CSI_VALUE    ((uint32_t)4000000) /*!< Value of the Internal oscillator in Hz*/
 #endif /* CSI_VALUE */
 
 #if !defined  (HSI_VALUE)
-  #define HSI_VALUE    ((uint32_t)64000000) /*!< Value of the Internal oscillator in Hz*/
+#define HSI_VALUE    ((uint32_t)64000000) /*!< Value of the Internal oscillator in Hz*/
 #endif /* HSI_VALUE */
 
 
@@ -102,17 +102,17 @@
 /** @addtogroup STM32H7xx_System_Private_Variables
   * @{
   */
-  /* This variable is updated in three ways:
-      1) by calling CMSIS function SystemCoreClockUpdate()
-      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
-      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
-         Note: If you use this function to configure the system clock; then there
-               is no need to call the 2 first functions listed above, since SystemCoreClock
-               variable is updated automatically.
-  */
-  uint32_t SystemCoreClock = 64000000;
-  uint32_t SystemD2Clock = 64000000;
-  const  uint8_t D1CorePrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+/* This variable is updated in three ways:
+    1) by calling CMSIS function SystemCoreClockUpdate()
+    2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+    3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
+       Note: If you use this function to configure the system clock; then there
+             is no need to call the 2 first functions listed above, since SystemCoreClock
+             variable is updated automatically.
+*/
+uint32_t SystemCoreClock = 64000000;
+uint32_t SystemD2Clock = 64000000;
+const uint8_t D1CorePrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
 
 /**
   * @}
@@ -137,16 +137,15 @@
   * @param  None
   * @retval None
   */
-void SystemInit (void)
-{
+void SystemInit(void) {
 #if defined (DATA_IN_D2_SRAM)
- __IO uint32_t tmpreg;
+  __IO uint32_t tmpreg;
 #endif /* DATA_IN_D2_SRAM */
 
   /* FPU settings ------------------------------------------------------------*/
-  #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-    SCB->CPACR |= ((3UL << (10*2))|(3UL << (11*2)));  /* set CP10 and CP11 Full Access */
-  #endif
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  SCB->CPACR |= ((3UL << (10*2))|(3UL << (11*2)));  /* set CP10 and CP11 Full Access */
+#endif
   /* Reset the RCC clock configuration to the default reset state ------------*/
   /* Set HSION bit */
   RCC->CR |= RCC_CR_HSION;
@@ -206,41 +205,40 @@ void SystemInit (void)
 
 #if (STM32H7_DEV_ID == 0x450UL)
   /* dual core CM7 or single core line */
-  if((DBGMCU->IDCODE & 0xFFFF0000U) < 0x20000000U)
-  {
+  if ((DBGMCU->IDCODE & 0xFFFF0000U) < 0x20000000U) {
     /* if stm32h7 revY*/
     /* Change  the switch matrix read issuing capability to 1 for the AXI SRAM target (Target 7) */
-    *((__IO uint32_t*)0x51008108) = 0x000000001U;
+    *((__IO uint32_t *) 0x51008108) = 0x000000001U;
   }
 #endif
 
 #if defined (DATA_IN_D2_SRAM)
-  /* in case of initialized data in D2 SRAM (AHB SRAM) , enable the D2 SRAM clock (AHB SRAM clock) */
+    /* in case of initialized data in D2 SRAM (AHB SRAM) , enable the D2 SRAM clock (AHB SRAM clock) */
 #if defined(RCC_AHB2ENR_D2SRAM3EN)
-  RCC->AHB2ENR |= (RCC_AHB2ENR_D2SRAM1EN | RCC_AHB2ENR_D2SRAM2EN | RCC_AHB2ENR_D2SRAM3EN);
+    RCC->AHB2ENR |= (RCC_AHB2ENR_D2SRAM1EN | RCC_AHB2ENR_D2SRAM2EN | RCC_AHB2ENR_D2SRAM3EN);
 #elif defined(RCC_AHB2ENR_D2SRAM2EN)
-  RCC->AHB2ENR |= (RCC_AHB2ENR_D2SRAM1EN | RCC_AHB2ENR_D2SRAM2EN);
+    RCC->AHB2ENR |= (RCC_AHB2ENR_D2SRAM1EN | RCC_AHB2ENR_D2SRAM2EN);
 #else
-  RCC->AHB2ENR |= (RCC_AHB2ENR_AHBSRAM1EN | RCC_AHB2ENR_AHBSRAM2EN);
+    RCC->AHB2ENR |= (RCC_AHB2ENR_AHBSRAM1EN | RCC_AHB2ENR_AHBSRAM2EN);
 #endif /* RCC_AHB2ENR_D2SRAM3EN */
 
-  tmpreg = RCC->AHB2ENR;
-  (void) tmpreg;
+    tmpreg = RCC->AHB2ENR;
+    (void) tmpreg;
 #endif /* DATA_IN_D2_SRAM */
 
 #if defined(DUAL_CORE) && defined(CORE_CM4)
-  /* Configure the Vector Table location add offset address for cortex-M4 ------------------*/
+    /* Configure the Vector Table location add offset address for cortex-M4 ------------------*/
 #ifdef VECT_TAB_SRAM
-  SCB->VTOR = D2_AHBSRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
+    SCB->VTOR = D2_AHBSRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-  SCB->VTOR = FLASH_BANK2_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+    SCB->VTOR = FLASH_BANK2_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif /* VECT_TAB_SRAM */
 
 #else
 
-  /* Configure the Vector Table location add offset address for cortex-M7 ------------------*/
+    /* Configure the Vector Table location add offset address for cortex-M7 ------------------*/
 #ifdef VECT_TAB_SRAM
-  SCB->VTOR = D1_AXISRAM_BASE  | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal AXI-RAM */
+    SCB->VTOR = D1_AXISRAM_BASE  | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal AXI-RAM */
 #else
   SCB->VTOR = FLASH_BANK1_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif
@@ -286,8 +284,7 @@ void SystemInit (void)
   * @param  None
   * @retval None
   */
-void SystemCoreClockUpdate (void)
-{
+void SystemCoreClockUpdate(void) {
   uint32_t pllp, pllsource, pllm, pllfracen, hsivalue, tmp;
   uint32_t common_system_clock;
   float_t fracn1, pllvco;
@@ -295,76 +292,75 @@ void SystemCoreClockUpdate (void)
 
   /* Get SYSCLK source -------------------------------------------------------*/
 
-  switch (RCC->CFGR & RCC_CFGR_SWS)
-  {
-  case RCC_CFGR_SWS_HSI:  /* HSI used as system clock source */
-    common_system_clock = (uint32_t) (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3));
-    break;
+  switch (RCC->CFGR & RCC_CFGR_SWS) {
+    case RCC_CFGR_SWS_HSI:  /* HSI used as system clock source */
+      common_system_clock = (uint32_t) (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV) >> 3));
+      break;
 
-  case RCC_CFGR_SWS_CSI:  /* CSI used as system clock  source */
-    common_system_clock = CSI_VALUE;
-    break;
+    case RCC_CFGR_SWS_CSI:  /* CSI used as system clock  source */
+      common_system_clock = CSI_VALUE;
+      break;
 
-  case RCC_CFGR_SWS_HSE:  /* HSE used as system clock  source */
-    common_system_clock = HSE_VALUE;
-    break;
+    case RCC_CFGR_SWS_HSE:  /* HSE used as system clock  source */
+      common_system_clock = HSE_VALUE;
+      break;
 
-  case RCC_CFGR_SWS_PLL1:  /* PLL1 used as system clock  source */
+    case RCC_CFGR_SWS_PLL1:  /* PLL1 used as system clock  source */
 
-    /* PLL_VCO = (HSE_VALUE or HSI_VALUE or CSI_VALUE/ PLLM) * PLLN
-    SYSCLK = PLL_VCO / PLLR
-    */
-    pllsource = (RCC->PLLCKSELR & RCC_PLLCKSELR_PLLSRC);
-    pllm = ((RCC->PLLCKSELR & RCC_PLLCKSELR_DIVM1)>> 4)  ;
-    pllfracen = ((RCC->PLLCFGR & RCC_PLLCFGR_PLL1FRACEN)>>RCC_PLLCFGR_PLL1FRACEN_Pos);
-    fracn1 = (float_t)(uint32_t)(pllfracen* ((RCC->PLL1FRACR & RCC_PLL1FRACR_FRACN1)>> 3));
+      /* PLL_VCO = (HSE_VALUE or HSI_VALUE or CSI_VALUE/ PLLM) * PLLN
+      SYSCLK = PLL_VCO / PLLR
+      */
+      pllsource = (RCC->PLLCKSELR & RCC_PLLCKSELR_PLLSRC);
+      pllm = ((RCC->PLLCKSELR & RCC_PLLCKSELR_DIVM1) >> 4);
+      pllfracen = ((RCC->PLLCFGR & RCC_PLLCFGR_PLL1FRACEN) >> RCC_PLLCFGR_PLL1FRACEN_Pos);
+      fracn1 = (float_t) (uint32_t) (pllfracen * ((RCC->PLL1FRACR & RCC_PLL1FRACR_FRACN1) >> 3));
 
-    if (pllm != 0U)
-    {
-      switch (pllsource)
-      {
-        case RCC_PLLCKSELR_PLLSRC_HSI:  /* HSI used as PLL clock source */
+      if (pllm != 0U) {
+        switch (pllsource) {
+          case RCC_PLLCKSELR_PLLSRC_HSI:  /* HSI used as PLL clock source */
 
-        hsivalue = (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3)) ;
-        pllvco = ( (float_t)hsivalue / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+            hsivalue = (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV) >> 3));
+            pllvco = ((float_t) hsivalue / (float_t) pllm)
+                * ((float_t) (uint32_t) (RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1 / (float_t) 0x2000) + (float_t) 1);
 
-        break;
+            break;
 
-        case RCC_PLLCKSELR_PLLSRC_CSI:  /* CSI used as PLL clock source */
-          pllvco = ((float_t)CSI_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
-        break;
+          case RCC_PLLCKSELR_PLLSRC_CSI:  /* CSI used as PLL clock source */
+            pllvco = ((float_t) CSI_VALUE / (float_t) pllm)
+                * ((float_t) (uint32_t) (RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1 / (float_t) 0x2000) + (float_t) 1);
+            break;
 
-        case RCC_PLLCKSELR_PLLSRC_HSE:  /* HSE used as PLL clock source */
-          pllvco = ((float_t)HSE_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
-        break;
+          case RCC_PLLCKSELR_PLLSRC_HSE:  /* HSE used as PLL clock source */
+            pllvco = ((float_t) HSE_VALUE / (float_t) pllm)
+                * ((float_t) (uint32_t) (RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1 / (float_t) 0x2000) + (float_t) 1);
+            break;
 
-      default:
-          pllvco = ((float_t)CSI_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
-        break;
+          default:
+            pllvco = ((float_t) CSI_VALUE / (float_t) pllm)
+                * ((float_t) (uint32_t) (RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1 / (float_t) 0x2000) + (float_t) 1);
+            break;
+        }
+        pllp = (((RCC->PLL1DIVR & RCC_PLL1DIVR_P1) >> 9) + 1U);
+        common_system_clock = (uint32_t) (float_t) (pllvco / (float_t) pllp);
+      } else {
+        common_system_clock = 0U;
       }
-      pllp = (((RCC->PLL1DIVR & RCC_PLL1DIVR_P1) >>9) + 1U ) ;
-      common_system_clock =  (uint32_t)(float_t)(pllvco/(float_t)pllp);
-    }
-    else
-    {
-      common_system_clock = 0U;
-    }
-    break;
+      break;
 
-  default:
-    common_system_clock = CSI_VALUE;
-    break;
+    default:common_system_clock = CSI_VALUE;
+      break;
   }
 
   /* Compute SystemClock frequency --------------------------------------------------*/
 #if defined (RCC_D1CFGR_D1CPRE)
-  tmp = D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_D1CPRE)>> RCC_D1CFGR_D1CPRE_Pos];
+  tmp = D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_D1CPRE) >> RCC_D1CFGR_D1CPRE_Pos];
 
   /* common_system_clock frequency : CM7 CPU frequency  */
   common_system_clock >>= tmp;
 
   /* SystemD2Clock frequency : CM4 CPU, AXI and AHBs Clock frequency  */
-  SystemD2Clock = (common_system_clock >> ((D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_HPRE)>> RCC_D1CFGR_HPRE_Pos]) & 0x1FU));
+  SystemD2Clock =
+      (common_system_clock >> ((D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_HPRE) >> RCC_D1CFGR_HPRE_Pos]) & 0x1FU));
 
 #else
   tmp = D1CorePrescTable[(RCC->CDCFGR1 & RCC_CDCFGR1_CDCPRE)>> RCC_CDCFGR1_CDCPRE_Pos];


### PR DESCRIPTION
This PR removes `Templates/system_stm32h7xx.c` from the firmware project, to fix the build error.