### PR TITLE
Import protobufs from pez-globo/pufferfish-software-prototype-v1

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,85 @@
+# Protocol Buffers
+
+We are using Google Protocol Buffers to standardize presentation-layer data
+serialization in the communication protocols between the MCU firmware and the
+backend server and between the GUI frontend and the backend server.
+
+## Firmware/Backend
+
+The message schemas for communication between the backend server and the  MCU
+firmware are defined in `mcu_pb.proto`. To update, you will need to modify that
+file and then regenerate the C++ classes for the MCU firmware and the Python
+classes for the backend.
+
+To update the Python classes at `backend/ventserver/protocols/protobuf/mcu_pb.py`,
+first install the `betterproto` package using pip, then run, from this directory:
+
+```bash
+$ export $PROTOC=/path/to/local/bin/protoc  # replace the path with the one for your computer
+
+$ # Generate Python Code
+$ $PROTOC -I=. --python_betterproto_out=../backend/ventserver/protocols/protobuf mcu_pb.proto
+```
+
+Note that if you installed the `protobuf-compiler` package on Ubuntu, then you
+should replace `$PROTOC` with `protoc`.
+
+To update the C++ classes at
+`firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/mcu_pb.pb.h` and
+`firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Protocols/mcu_pb.pb.c`,
+the easiest way is to install nanopb with pip, and run, from this directory:
+
+```bash
+$ export $PROTOC=/path/to/local/bin/protoc
+
+$ # Generate C++ Code
+$ nanopb_generator -I=. --output-dir="../firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols" mcu_pb.proto
+```
+
+Note that after generating these files, you will need to move
+`firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/mcu_pb.pb.c`
+to `firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Protocols/mcu_pb.pb.c`.
+
+## Frontend/Backend
+
+The message schemas for communication between the backend demo and the frontend
+demo are defined in both `mcu_pb.proto` and `frontend_pb.proto`. Currently these
+are separated so that backend/frontend-specific protocol buffers don't get compiled
+into the firmware.
+
+To update the Python classes at `backend/ventserver/protocols/protobuf`,
+first install the `betterproto` package using pip, then run:
+
+```bash
+$ export $PROTOC=/path/to/local/bin/protoc  # replace the path with the one for your computer
+
+$ # Generate Python Code
+$ $PROTOC -I=. --python_betterproto_out=../backend/ventserver/protocols/protobuf mcu_pb.proto
+$ $PROTOC -I=. --python_betterproto_out=../backend/ventserver/protocols/protobuf frontend_pb.proto
+```
+
+Note that if you installed the `protobuf-compiler` package on Ubuntu, then you
+should replace `$PROTOC` with `protoc`.
+
+To update the TypeScript classes at `frontend/src/store/controller/proto`,
+first install the `typescript`, `google-protobuf`, and `protoc-gen-ts` packages
+globally using npm:
+
+```bash
+$ npm install -g typescript
+$ npm install -g google-protobuf
+$ npm install -g protoc-gen-ts
+```
+
+Then run, from this directory:
+
+```bash
+$ export $PROTOC=/path/to/local/bin/protoc  # replace the path with the one for your computer
+
+$ # Generate TypeScript Code (make sure to run yarn install in frontend first)
+$ $PROTOC -I=. --ts_proto_out=../frontend/src/store/controller/proto --plugin="../frontend/node_modules/ts-proto/protoc-gen-ts_proto" mcu_pb.proto
+$ $PROTOC -I=. --ts_proto_out=../frontend/src/store/controller/proto --plugin="../frontend/node_modules/ts-proto/protoc-gen-ts_proto" frontend_pb.proto
+```
+
+Note that if you installed the `protobuf-compiler` package on Ubuntu, then you
+should replace `$PROTOC` with `protoc`.

--- a/proto/frontend_pb.proto
+++ b/proto/frontend_pb.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+message RotaryEncoder {
+  uint32 angle = 1;
+  float last_angle_change = 2;
+  bool button_pressed = 3;
+  float last_button_down = 4;
+  float last_button_up = 5;
+}

--- a/proto/mcu_pb.options
+++ b/proto/mcu_pb.options
@@ -1,0 +1,1 @@
+Announcement.announcement     max_size:64

--- a/proto/mcu_pb.proto
+++ b/proto/mcu_pb.proto
@@ -1,0 +1,75 @@
+syntax = "proto3";
+
+message Alarms {
+  uint32 time = 1;
+  bool alarm_one = 2;
+  bool alarm_two = 3;
+}
+
+message SensorMeasurements {
+  uint32 time = 1;
+  float paw = 2;
+  float flow = 3;
+  float volume = 4;
+  float fio2 = 5;
+}
+
+message CycleMeasurements {
+  uint32 time = 1;
+  float vt = 2;
+  float rr = 3;
+  float peep = 4;
+  float pip = 5;
+  float ip = 6;
+  float ve = 7;
+}
+
+enum SpontaneousSupport {
+  ac = 0;
+  simv = 1;
+}
+
+enum VentilationCycling {
+  pc = 0;
+  vc = 1;
+  psv = 2;
+}
+
+message VentilationMode {
+  SpontaneousSupport support = 1;
+  VentilationCycling cycling = 2;
+}
+
+message Parameters {
+  uint32 time = 1;
+  VentilationMode mode = 2;
+  float pip = 3;
+  float peep = 4;
+  float vt = 5;
+  float rr = 6;
+  float ie = 7;
+  float fio2 = 8;
+}
+
+message ParametersRequest {
+  uint32 time = 1;
+  VentilationMode mode = 2;
+  float pip = 3;
+  float peep = 4;
+  float vt = 5;
+  float rr = 6;
+  float ie = 7;
+  float fio2 = 8;
+}
+
+// Testing messages
+
+message Ping {
+  uint32 time = 1;
+  uint32 id = 2;
+}
+
+message Announcement {
+  uint32 time = 1;
+  bytes announcement = 2;
+}


### PR DESCRIPTION
This PR imports the Protocol Buffer definitions from the `pez-globo/pufferfish-software-prototype-v1` repository. For now, it requires testing for clarity of documentation for regenerating protocol buffer definitions for the frontend.