### PR TITLE
Reduce I2C traffic from SDPSensor

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/I2C/SDP.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/I2C/SDP.h
@@ -96,7 +96,7 @@ class SDPSensor : public Testable {
   I2CDeviceStatus reset() override;
   I2CDeviceStatus test() override;
   
-  I2CDeviceStatus readPressureSample(SDPSample &sample);
+  I2CDeviceStatus readPressureSample(int16_t differentialPressureScale, float &differentialPressure);
  private:
   SensirionSensor mSensirion;
   bool mMeasuring = false;

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/I2C/SDP.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/I2C/SDP.cpp
@@ -251,7 +251,7 @@ I2CDeviceStatus SDPSensor::test() {
 }
 
 
-I2CDeviceStatus SDPSensor::readPressureSample(SDPSample &sample){
+I2CDeviceStatus SDPSensor::readPressureSample(int16_t differentialPressureScale, float &differentialPressure){
 
   const uint8_t DATA_LEN = 2;
   uint8_t data[DATA_LEN] = { 0 };
@@ -266,7 +266,7 @@ I2CDeviceStatus SDPSensor::readPressureSample(SDPSample &sample){
   }
  int16_t pressuresample = static_cast<int16_t>(data[0] << 8 | data[1]);
 
- sample.differentialPressure = pressuresample/ static_cast<float>(sample.differentialPressureScale);
+ differentialPressure = pressuresample/ static_cast<float>(differentialPressureScale);
 
  return I2CDeviceStatus::ok;
 }


### PR DESCRIPTION
Updated SDP.cpp and SDP.h files for reducing I2C traffic from SDPSensor by making separate method (SDPSensor::readPressureSample) to read only 2 bytes of data instead of full 6 bytes of data.