### PR TITLE
New I2C Device List for Control Board v1

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/HAL/STM32/HALI2CDevice.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/HAL/STM32/HALI2CDevice.h
@@ -17,7 +17,7 @@ namespace HAL {
 class HALI2CDevice : public I2CDevice {
  public:
   // maximum default time to wait for response from I2C, in ms
-  const static uint32_t default_timeout = 500U;
+  const static uint32_t default_timeout = 100U;
 
   /**
    * Constructs an HAL I2C object

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -182,24 +182,24 @@ PF::Driver::I2C::TCA9548A i2c_mux1(i2c_hal_mux1);
 PF::Driver::I2C::TCA9548A i2c_mux2(i2c_hal_mux2);
 
 // Extended I2C Device
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press1(i2c_ext_press1, i2c_mux2, 0);
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press2(i2c_ext_press2, i2c_mux2, 2);
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press3(i2c_ext_press3, i2c_mux2, 4);
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press7(i2c_ext_press7, i2c_mux2, 1);
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press8(i2c_ext_press8, i2c_mux2, 3);
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press9(i2c_ext_press9, i2c_mux2, 5);
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press1(i2c_hal_press1, i2c_mux2, 0);
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press2(i2c_hal_press2, i2c_mux2, 2);
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press3(i2c_hal_press3, i2c_mux2, 4);
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press7(i2c_hal_press7, i2c_mux2, 1);
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press8(i2c_hal_press8, i2c_mux2, 3);
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press9(i2c_hal_press9, i2c_mux2, 5);
 
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press13(i2c_ext_press13, i2c_mux1,
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press13(i2c_hal_press13, i2c_mux1,
                                                    0);
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press14(i2c_ext_press14, i2c_mux1,
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press14(i2c_hal_press14, i2c_mux1,
                                                    2);
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press15(i2c_ext_press15, i2c_mux1,
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press15(i2c_hal_press15, i2c_mux1,
                                                    4);
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press16(i2c_ext_press16, i2c_mux1,
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press16(i2c_hal_press16, i2c_mux1,
                                                    1);
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press17(i2c_ext_press17, i2c_mux1,
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press17(i2c_hal_press17, i2c_mux1,
                                                    3);
-PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press18(i2c_ext_press18, i2c_mux1,
+PF::Driver::I2C::ExtendedI2CDevice i2c_ext_press18(i2c_hal_press18, i2c_mux1,
                                                    5);
 
 // Actual usable sensor
@@ -310,8 +310,8 @@ int main(void)
   /* USER CODE BEGIN 2 */
   PF::HAL::micros_delay_init();
   // active low pins, will be fixed in interface board PR
-  i2c1_reset.write(false);
-  i2c2_reset.write(false);
+  i2c1_reset.write(true);
+  i2c2_reset.write(true);
   /* USER CODE END 2 */
 
   /* Infinite loop */


### PR DESCRIPTION
This PR defines a new I2C device list to work with control board v1
