### PR TITLE
disable unnecessary services

### DIFF
--- a/deploy/scripts/disable_services.sh
+++ b/deploy/scripts/disable_services.sh
@@ -7,9 +7,6 @@ sudo systemctl mask bluetooth.service
 sudo systemctl mask hciuart.service
 sudo systemctl mask bluealsa.service
 sudo systemctl mask bthelper@.service
-sudo systemctl mask alsa-restore.service
-sudo systemctl mask alsa-state.service
-sudo systemctl mask alsa-utils.service
 sudo systemctl mask apt-daily-upgrade.service
 sudo systemctl mask apt-daily.service
 sudo systemctl mask bluetooth.target


### PR DESCRIPTION
Disabling unnecessary services
The services that are disabled are `bluetooth`, `printer`, `smartcard`, `alsa`, `daily updates`, `daily upgrades`, and all the dependent services.
Services like `avahi daemon` and `ssh` are not disabled in this script as they will be a part of the network security script.