### PR TITLE
script to configure user and network security

### DIFF
--- a/deploy/scripts/security.sh
+++ b/deploy/scripts/security.sh
@@ -25,6 +25,9 @@ sudo cp /etc/fail2ban/jail.conf /etc/fail2ban/jail.local
 
 sudo systemctl daemon-reload
 
+# Add configuration to disable wifi
+echo -e "\ndtoverlay=disable-wifi" | sudo tee -a /boot/config.txt
+
 # Lock pi and root user
 sudo passwd -l pi
 sudo passwd -l root


### PR DESCRIPTION
I've implemented some security measures for user as well as on the network side as listed below.
1. Locks `pi` & `root` user
2. Removes `pi` from sudoer
3. Disables SSH
4. Installs `ufw` and `fail2ban`
5. Blocks all incoming traffic
6. Firewall exceptions for `http` and `https`
7. Deny ssh access on user basis as well for `pi` & `root`
8. Masks services `ssh` and `avahi-daemon`
9. Uses default `fail2ban` configuration.
10. Disables `wifi`