### PR TITLE
script to setup internal watchdog

### DIFF
--- a/deploy/configs/watchdog_config.txt
+++ b/deploy/configs/watchdog_config.txt
@@ -1,0 +1,11 @@
+# Device to use
+watchdog-device = /dev/watchdog
+
+# Timeout before reboot
+watchdog-timeout = 15
+
+# Interval of heartbeat
+interval = 5
+
+# Max load average acceptable
+max-load-1 = 24

--- a/deploy/scripts/setup_watchdog.sh
+++ b/deploy/scripts/setup_watchdog.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "********** Setting up Watchdog **********"
+
+# Loading internal watchdog kernel module
+sudo modprobe bcm2835_wdt
+echo "bcm2835_wdt" | sudo tee -a /etc/modules
+
+# Installing watchdog
+sudo apt-get install watchdog -y
+
+# Adding watchdog config
+cd ~/pufferfish-vent-software/deploy
+cat configs/pyenv_config.txt | sudo tee -a /etc/watchdog.conf
+
+# Starting watchdog service
+sudo systemctl start watchdog
+sudo systemctl daemon-reload


### PR DESCRIPTION
Used the config given below.
```
# Device to use
watchdog-device = /dev/watchdog

# Timeout before reboot
watchdog-timeout = 15

# Interval of heartbeat
interval = 5

# Max load average acceptable
max-load-1 = 24
```

Tested it with fork bomb using command:
```
$ :(){ :|:& };:
```
and with NULL pointer dereference using command:
```
$ echo c > /proc/sysrq-trigger
```