### PR TITLE
Integrate Nonin OEM III into firmware

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -80,8 +80,8 @@ jobs:
       run: |
         sudo apt-get install gcc-arm-none-eabi cmake
         sudo apt-get remove -y libllvm10
-        sudo add-apt-repository -y -s 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository -y -s 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
         sudo apt-get update
         sudo apt-get install clang-tools
 
@@ -104,8 +104,8 @@ jobs:
       run: |
         sudo apt-get install gcc-arm-none-eabi cmake
         sudo apt-get remove -y libllvm10
-        sudo add-apt-repository -y -s 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository -y -s 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
         sudo apt-get update
         sudo apt-get install clang-tidy
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Nonin/Device.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Nonin/Device.h
@@ -1,4 +1,4 @@
-/// NoninOEM3.h
+/// Device.h
 /// This file has class and methods to output the sensor measurements
 /// of NoninOEM 3 sensor based on packet received.
 
@@ -31,13 +31,13 @@ namespace Serial {
 namespace Nonin {
 
 /**
- * NoninOEM class to receive a byte from Nonin OEM III using UART and calculates
+ * Device class to receive a byte from Nonin OEM III using UART and calculates
  * the measurements on complete packet availability and returns the measurements
  */
-class NoninOEM {
+class Device {
  public:
   /* PacketReceiver Input status */
-  enum class NoninPacketStatus {
+  enum class PacketStatus {
     available = 0,  /// Packet/measurements is available
     waiting,        /// Packet/measurements is waiting to receive more bytes of data
     not_available,  /// Packet/measurements are not available
@@ -46,10 +46,10 @@ class NoninOEM {
   };
 
   /**
-   * Constructor for NoninOEM
+   * Constructor for Device
    * @param  noninOEMUART BufferredUART with 512 bytes reception buffer
    */
-  explicit NoninOEM(volatile HAL::BufferedUART &uart) : nonin_uart_(uart) {}
+  explicit Device(volatile HAL::BufferedUART &uart) : nonin_uart_(uart) {}
 
   /**
    * @brief  Method inputs the byte to packet and reads the packet measurements
@@ -57,7 +57,7 @@ class NoninOEM {
    * @param  sensorMeasurements is updated on available of packet/measurements
    * @return returns the status of Nonin OEM III packet measurements
    */
-  NoninPacketStatus output(PacketMeasurements &sensor_measurements);
+  PacketStatus output(PacketMeasurements &sensor_measurements);
 
  private:
   /* Create an object bufferredUART with 512 bytes of reception buffer */

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Nonin/Device.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Nonin/Device.h
@@ -47,7 +47,7 @@ class Device {
 
   /**
    * Constructor for Device
-   * @param  noninOEMUART BufferredUART with 512 bytes reception buffer
+   * @param  noninOEMUART BufferedUART with 512 bytes reception buffer
    */
   explicit Device(volatile HAL::BufferedUART &uart) : nonin_uart_(uart) {}
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Nonin/Sensor.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Nonin/Sensor.h
@@ -1,0 +1,37 @@
+/*
+ * Sensor.h
+ *
+ *  Created on: June 6, 2020
+ *      Author: Ethan Li
+ *
+ *  High-level measurement driver for the Nonin OEM III.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include "Device.h"
+#include "Pufferfish/Driver/Initializable.h"
+#include "Pufferfish/HAL/Interfaces/Time.h"
+#include "Pufferfish/Types.h"
+
+namespace Pufferfish::Driver::Serial::Nonin {
+
+/**
+ * High-level (stateful) driver for Nonin OEM III SpO2 sensor
+ */
+class Sensor : public Initializable {
+ public:
+  Sensor(Device &device) : device_(device) {}
+
+  InitializableState setup() override;
+  InitializableState output(float &spo2);
+
+ private:
+  Device &device_;
+
+  PacketMeasurements measurements_{};
+};
+
+}  // namespace Pufferfish::Driver::Serial::Nonin

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Nonin/Sensor.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Nonin/Sensor.h
@@ -23,7 +23,7 @@ namespace Pufferfish::Driver::Serial::Nonin {
  */
 class Sensor : public Initializable {
  public:
-  Sensor(Device &device) : device_(device) {}
+  explicit Sensor(Device &device) : device_(device) {}
 
   InitializableState setup() override;
   InitializableState output(float &spo2);

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/HAL/Mock/MockBufferedUART.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/HAL/Mock/MockBufferedUART.h
@@ -41,7 +41,7 @@ template <AtomicSize rx_buffer_size, AtomicSize tx_buffer_size>
 class MockBufferedUART : public BufferedUART {
  public:
   /**
-   * Mock constructor for BufferredUART
+   * Mock constructor for BufferedUART
    */
   explicit MockBufferedUART();
 
@@ -125,7 +125,7 @@ using MockLargeBufferedUART =
     MockBufferedUART<mock_large_uart_buffer_size, mock_large_uart_buffer_size>;
 
 static const size_t mock_read_only_uart_buffer_size = 512;
-using MockReadOnlyBufferredUART = MockBufferedUART<mock_read_only_uart_buffer_size, 1>;
+using MockReadOnlyBufferedUART = MockBufferedUART<mock_read_only_uart_buffer_size, 1>;
 
 }  // namespace Pufferfish::HAL
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/HAL/STM32/HALBufferedUART.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/HAL/STM32/HALBufferedUART.h
@@ -151,7 +151,7 @@ static const size_t large_uart_buffer_size = 4096;
 using LargeBufferedUART = HALBufferedUART<large_uart_buffer_size, large_uart_buffer_size>;
 
 static const size_t read_only_uart_buffer_size = 512;
-using ReadOnlyBufferredUART = HALBufferedUART<read_only_uart_buffer_size, 1>;
+using ReadOnlyBufferedUART = HALBufferedUART<read_only_uart_buffer_size, 1>;
 
 }  // namespace Pufferfish::HAL
 

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/Nonin/Sensor.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/Nonin/Sensor.cpp
@@ -14,6 +14,8 @@
 
 namespace Pufferfish::Driver::Serial::Nonin {
 
+static const uint8_t value_unavailable = 127;
+
 // Sensor
 
 InitializableState Sensor::setup() {
@@ -23,7 +25,7 @@ InitializableState Sensor::setup() {
 
 InitializableState Sensor::output(float &spo2) {
   if (device_.output(measurements_) == Device::PacketStatus::available) {
-    if (measurements_.spo2 == 127) {
+    if (measurements_.spo2 == value_unavailable) {
       spo2 = NAN;
     } else {
       spo2 = measurements_.spo2;

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/Nonin/Sensor.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/Nonin/Sensor.cpp
@@ -1,0 +1,35 @@
+/*
+ * StateMachine.cpp
+ *
+ *  Created on: June 6, 2020
+ *      Author: Ethan Li
+ */
+
+#include "Pufferfish/Driver/Serial/Nonin/Sensor.h"
+
+#include <cmath>
+
+#include "Pufferfish/HAL/Interfaces/Time.h"
+#include "Pufferfish/Util/Timeouts.h"
+
+namespace Pufferfish::Driver::Serial::Nonin {
+
+// Sensor
+
+InitializableState Sensor::setup() {
+  float spo2 = NAN;
+  return output(spo2);
+}
+
+InitializableState Sensor::output(float &spo2) {
+  if (device_.output(measurements_) == Device::PacketStatus::available) {
+    if (measurements_.spo2 == 127) {
+      spo2 = NAN;
+    } else {
+      spo2 = measurements_.spo2;
+    }
+  }
+  return InitializableState::ok;
+}
+
+}  // namespace Pufferfish::Driver::Serial::Nonin

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -113,7 +113,7 @@ PF::HAL::HALTime time;
 
 // Buffered UARTs
 volatile Pufferfish::HAL::LargeBufferedUART buffered_uart3(huart3, time);
-volatile Pufferfish::HAL::ReadOnlyBufferredUART nonin_oem_uart(huart4, time);
+volatile Pufferfish::HAL::ReadOnlyBufferedUART nonin_oem_uart(huart4, time);
 
 // UART Serial Communication
 PF::Driver::Serial::Backend::UARTBackend backend(buffered_uart3, crc32c, all_states);

--- a/firmware/ventilator-controller-stm32/Core/Src/stm32h7xx_it.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/stm32h7xx_it.cpp
@@ -24,8 +24,7 @@
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 #include "Pufferfish/HAL/STM32/HALBufferedUART.h"
-/* Nonin TODO: Include NoninOEM3.h for UART IRQ handler */
-#include "Pufferfish/Driver/Serial/Nonin/NoninOEM3.h"
+#include "Pufferfish/Driver/Serial/Nonin/Device.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/

--- a/firmware/ventilator-controller-stm32/Core/Src/stm32h7xx_it.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/stm32h7xx_it.cpp
@@ -46,7 +46,7 @@
 /* USER CODE BEGIN PV */
 /// Buffered UART
 extern volatile Pufferfish::HAL::LargeBufferedUART buffered_uart3;
-extern volatile Pufferfish::HAL::ReadOnlyBufferredUART nonin_oem_uart;
+extern volatile Pufferfish::HAL::ReadOnlyBufferedUART nonin_oem_uart;
 /* USER CODE END PV */
 
 /* Private function prototypes -----------------------------------------------*/

--- a/firmware/ventilator-controller-stm32/Core/Src/stm32h7xx_it.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/stm32h7xx_it.cpp
@@ -23,8 +23,8 @@
 #include "stm32h7xx_it.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-#include "Pufferfish/HAL/STM32/HALBufferedUART.h"
 #include "Pufferfish/Driver/Serial/Nonin/Device.h"
+#include "Pufferfish/HAL/STM32/HALBufferedUART.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Driver/Serial/TestNoninOEM3.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Driver/Serial/TestNoninOEM3.cpp
@@ -18,34 +18,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "Pufferfish/Driver/Serial/Nonin/NoninOEM3.h"
+#include "Pufferfish/Driver/Serial/Nonin/Device.h"
 #include "Pufferfish/HAL/Mock/MockBufferedUART.h"
 #include "catch2/catch.hpp"
 
 namespace PF = Pufferfish;
 
-PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus waiting_status =
-    PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus::waiting;
+PF::Driver::Serial::Nonin::Device::PacketStatus waiting_status =
+    PF::Driver::Serial::Nonin::Device::PacketStatus::waiting;
 
-PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus available_status =
-    PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus::available;
+PF::Driver::Serial::Nonin::Device::PacketStatus available_status =
+    PF::Driver::Serial::Nonin::Device::PacketStatus::available;
 
-PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus missed_data_status =
-    PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus::missed_data;
+PF::Driver::Serial::Nonin::Device::PacketStatus missed_data_status =
+    PF::Driver::Serial::Nonin::Device::PacketStatus::missed_data;
 
-PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus framing_error_status =
-    PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus::framing_error;
+PF::Driver::Serial::Nonin::Device::PacketStatus framing_error_status =
+    PF::Driver::Serial::Nonin::Device::PacketStatus::framing_error;
 
-SCENARIO("No input data received from BufferredUART", "[NoninOEM3]") {
-  PF::HAL::MockReadOnlyBufferredUART mock_uart;
-  PF::Driver::Serial::Nonin::NoninOEM nonin_uart(mock_uart);
+SCENARIO("No input data received from BufferedUART", "[NoninOEM3]") {
+  PF::HAL::MockReadOnlyBufferedUART mock_uart;
+  PF::Driver::Serial::Nonin::Device nonin_uart(mock_uart);
   PF::Driver::Serial::Nonin::PacketMeasurements sensor_measurements;
-  PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus return_status;
+  PF::Driver::Serial::Nonin::Device::PacketStatus return_status;
 
   GIVEN("Input data received from BufferedUART is empty") {
-    WHEN("NoninOEM::output is invoked") {
+    WHEN("Device::output is invoked") {
       return_status = nonin_uart.output(sensor_measurements);
-      THEN("NoninOEM output shall return waiting status") {
+      THEN("Device output shall return waiting status") {
         REQUIRE(return_status == waiting_status);
       }
     }
@@ -53,19 +53,19 @@ SCENARIO("No input data received from BufferredUART", "[NoninOEM3]") {
 }
 
 SCENARIO("Complete packet is not available", "[NoninOEM3]") {
-  PF::HAL::MockReadOnlyBufferredUART mock_uart;
-  PF::Driver::Serial::Nonin::NoninOEM nonin_uart(mock_uart);
+  PF::HAL::MockReadOnlyBufferedUART mock_uart;
+  PF::Driver::Serial::Nonin::Device nonin_uart(mock_uart);
   PF::Driver::Serial::Nonin::PacketMeasurements sensor_measurements;
-  PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus return_status;
+  PF::Driver::Serial::Nonin::Device::PacketStatus return_status;
 
-  GIVEN("4 bytes of BufferredUART data") {
+  GIVEN("4 bytes of BufferedUART data") {
     uint8_t uart_data[4] = {0x01, 0x81, 0x00, 0x00};
     uint8_t index;
     for (index = 0; index < 4; index++) {
       mock_uart.set_read(uart_data[index]);
     }
     WHEN("4 bytes of data received from BufferedUART") {
-      THEN("NoninOEM::output shall return waiting status") {
+      THEN("Device::output shall return waiting status") {
         for (index = 0; index < 4; index++) {
           return_status = nonin_uart.output(sensor_measurements);
           REQUIRE(return_status == waiting_status);
@@ -74,14 +74,14 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
     }
   }
 
-  GIVEN("2 valid frames of data from BufferredUART data") {
+  GIVEN("2 valid frames of data from BufferedUART data") {
     uint8_t uart_data[10] = {0x01, 0x81, 0x01, 0x00, 0x83, 0x01, 0x80, 0x01, 0x48, 0xCA};
     uint8_t index;
     for (index = 0; index < 10; index++) {
       mock_uart.set_read(uart_data[index]);
     }
     WHEN("4 bytes of data received from BufferedUART") {
-      THEN("NoninOEM::output shall return waiting status") {
+      THEN("Device::output shall return waiting status") {
         for (index = 0; index < 4; index++) {
           return_status = nonin_uart.output(sensor_measurements);
           REQUIRE(return_status == waiting_status);
@@ -92,7 +92,7 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
       for (index = 0; index < 4; index++) {
         return_status = nonin_uart.output(sensor_measurements);
       }
-      THEN("return_status of NoninOEM::output shall be waiting") {
+      THEN("return_status of Device::output shall be waiting") {
         return_status = nonin_uart.output(sensor_measurements);
         REQUIRE(return_status == waiting_status);
       }
@@ -101,7 +101,7 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
       for (index = 0; index < 5; index++) {
         return_status = nonin_uart.output(sensor_measurements);
       }
-      THEN("return_status of NoninOEM::output shall be waiting") {
+      THEN("return_status of Device::output shall be waiting") {
         for (index = 5; index < 10; index++) {
           return_status = nonin_uart.output(sensor_measurements);
           REQUIRE(return_status == waiting_status);
@@ -110,7 +110,7 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
     }
   }
 
-  GIVEN("2 frames of data from BufferredUART data with checksum error in 2nd frame") {
+  GIVEN("2 frames of data from BufferedUART data with checksum error in 2nd frame") {
     uint8_t uart_data[10] = {0x01, 0x81, 0x01, 0x00, 0x83, 0x01, 0x80, 0x01, 0x48, 0xCB};
     uint8_t index;
     for (index = 0; index < 10; index++) {
@@ -118,7 +118,7 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
     }
 
     WHEN("4 bytes of data received from BufferedUART") {
-      THEN("NoninOEM::output shall return waiting status") {
+      THEN("Device::output shall return waiting status") {
         for (index = 0; index < 4; index++) {
           return_status = nonin_uart.output(sensor_measurements);
           REQUIRE(return_status == waiting_status);
@@ -129,7 +129,7 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
       for (index = 0; index < 4; index++) {
         return_status = nonin_uart.output(sensor_measurements);
       }
-      THEN("return_status of NoninOEM::output shall be waiting") {
+      THEN("return_status of Device::output shall be waiting") {
         return_status = nonin_uart.output(sensor_measurements);
         REQUIRE(return_status == waiting_status);
       }
@@ -138,7 +138,7 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
       for (index = 0; index < 5; index++) {
         return_status = nonin_uart.output(sensor_measurements);
       }
-      THEN("return_status of NoninOEM::output shall be waiting") {
+      THEN("return_status of Device::output shall be waiting") {
         for (index = 5; index < 9; index++) {
           return_status = nonin_uart.output(sensor_measurements);
           REQUIRE(return_status == waiting_status);
@@ -149,14 +149,14 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
       for (index = 0; index < 9; index++) {
         return_status = nonin_uart.output(sensor_measurements);
       }
-      THEN("return_status of NoninOEM::output shall be framing_error on checksum error") {
+      THEN("return_status of Device::output shall be framing_error on checksum error") {
         return_status = nonin_uart.output(sensor_measurements);
         REQUIRE(return_status == framing_error_status);
       }
     }
   }
 
-  GIVEN("BufferredUART data with status byte error (Bit-7 is low) in 2nd frame") {
+  GIVEN("BufferedUART data with status byte error (Bit-7 is low) in 2nd frame") {
     uint8_t uart_data[10] = {0x01, 0x81, 0x01, 0x00, 0x83, 0x01, 0x7F, 0x01, 0x48, 0xCA};
     uint8_t index;
     for (index = 0; index < 10; index++) {
@@ -164,7 +164,7 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
     }
 
     WHEN("4 bytes of data received from BufferedUART") {
-      THEN("NoninOEM::output shall return waiting status") {
+      THEN("Device::output shall return waiting status") {
         for (index = 0; index < 4; index++) {
           return_status = nonin_uart.output(sensor_measurements);
           REQUIRE(return_status == waiting_status);
@@ -175,7 +175,7 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
       for (index = 0; index < 4; index++) {
         return_status = nonin_uart.output(sensor_measurements);
       }
-      THEN("return_status of NoninOEM::output shall be waiting") {
+      THEN("return_status of Device::output shall be waiting") {
         return_status = nonin_uart.output(sensor_measurements);
         REQUIRE(return_status == waiting_status);
       }
@@ -184,7 +184,7 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
       for (index = 0; index < 5; index++) {
         return_status = nonin_uart.output(sensor_measurements);
       }
-      THEN("return_status of NoninOEM::output shall be waiting") {
+      THEN("return_status of Device::output shall be waiting") {
         for (index = 5; index < 9; index++) {
           return_status = nonin_uart.output(sensor_measurements);
           REQUIRE(return_status == waiting_status);
@@ -195,7 +195,7 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
       for (index = 0; index < 9; index++) {
         return_status = nonin_uart.output(sensor_measurements);
       }
-      THEN("return_status of NoninOEM::output shall be framing_error on status byte error") {
+      THEN("return_status of Device::output shall be framing_error on status byte error") {
         return_status = nonin_uart.output(sensor_measurements);
         REQUIRE(return_status == framing_error_status);
       }
@@ -204,10 +204,10 @@ SCENARIO("Complete packet is not available", "[NoninOEM3]") {
 }
 
 SCENARIO("Validate the Nonin OEM III with invalid data received from BufferedUART") {
-  PF::HAL::MockReadOnlyBufferredUART mock_uart;
-  PF::Driver::Serial::Nonin::NoninOEM nonin_uart(mock_uart);
+  PF::HAL::MockReadOnlyBufferedUART mock_uart;
+  PF::Driver::Serial::Nonin::Device nonin_uart(mock_uart);
   PF::Driver::Serial::Nonin::PacketMeasurements sensor_measurements;
-  PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus return_status;
+  PF::Driver::Serial::Nonin::Device::PacketStatus return_status;
   GIVEN("Valid 24 frames with 23 Frames of first packet and 1 frame of second packet ") {
     const uint8_t uart_data[120] = {
         0x01,
@@ -337,7 +337,7 @@ SCENARIO("Validate the Nonin OEM III with invalid data received from BufferedUAR
       mock_uart.set_read(uart_data[index]);
     }
     WHEN("0 to 115 bytes of data receiving from bufferedUART") {
-      THEN("NoninOEM::output shall return waiting status for each frame received 0f 23 frames") {
+      THEN("Device::output shall return waiting status for each frame received 0f 23 frames") {
         for (index = 0; index < 115; index++) {
           if ((index > 0) && (index % 5 == 0)) {
             REQUIRE(return_status == waiting_status);
@@ -361,7 +361,7 @@ SCENARIO("Validate the Nonin OEM III with invalid data received from BufferedUAR
 }
 
 SCENARIO("Validate NoninOEM3 for valid packet data", "[NoninOEM3]") {
-  GIVEN("125 bytes of BufferredUART data") {
+  GIVEN("125 bytes of BufferedUART data") {
     uint8_t uart_data[125] = {
         0x01, 0x81, 0x01, 0x00, 0x83,  /// HR MSB
         0x01, 0x80, 0x01, 0x48, 0xCA,  /// HR LSB
@@ -389,17 +389,17 @@ SCENARIO("Validate NoninOEM3 for valid packet data", "[NoninOEM3]") {
         0x01, 0x80, 0x01, 0x00, 0x82,  /// reserved
         0x01, 0x80, 0x01, 0x00, 0x82   /// reserved
     };
-    PF::HAL::MockReadOnlyBufferredUART mock_uart;
+    PF::HAL::MockReadOnlyBufferedUART mock_uart;
     uint8_t index;
     for (index = 0; index < 125; index++) {
       mock_uart.set_read(uart_data[index]);
     }
-    PF::Driver::Serial::Nonin::NoninOEM nonin_uart(mock_uart);
+    PF::Driver::Serial::Nonin::Device nonin_uart(mock_uart);
     PF::Driver::Serial::Nonin::PacketMeasurements sensor_measurements;
-    PF::Driver::Serial::Nonin::NoninOEM::NoninPacketStatus return_status;
+    PF::Driver::Serial::Nonin::Device::PacketStatus return_status;
 
-    WHEN("NoninOEM::output is invoked for 124 bytes valid bytes read") {
-      THEN("NoninOEM::output shall return waiting status") {
+    WHEN("Device::output is invoked for 124 bytes valid bytes read") {
+      THEN("Device::output shall return waiting status") {
         for (index = 0; index < 124; index++) {
           return_status = nonin_uart.output(sensor_measurements);
           REQUIRE(return_status == waiting_status);


### PR DESCRIPTION
This PR:

- Integrates SpO2 sensing into the main loop of the firmware
- Slightly renames some types in the Nonin OEM III driver
- Slightly refactors/adapts the driver into the uniform low-level **Device** and higher-level **Sensor** interface pattern which we have started using with the SFM3019 driver.
- Solves a new problem in Github Actions firmware checks (missing public key for installing LLVM and clang from LLVM's website rather than Github's custom distribution which is unable to install clang-tools)