### PR TITLE
Add simulator & controller support for open-loop FiO2 control by valves

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Algorithms.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Algorithms.h
@@ -1,0 +1,30 @@
+/*
+ * Algorithms.h
+ *
+ *  Created on: June 6, 2020
+ *      Author: Ethan Li
+ *
+ *  Control algorithms
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace Pufferfish::Driver::BreathingCircuit {
+
+class PI {
+ public:
+  void transform(float measurement, float setpoint, float &actuation);
+
+ private:
+  static constexpr float p_gain = 0.00001;
+  static constexpr float i_gain = 0.0002;
+  static constexpr float i_max = 200 * i_gain;
+  static constexpr float i_min = 0;
+
+  float error_ = 0;
+  float error_integral_ = 0;
+};
+
+}  // namespace Pufferfish::Driver::BreathingCircuit

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/ControlLoop.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/ControlLoop.h
@@ -40,16 +40,19 @@ class HFNCControlLoop : public ControlLoop {
       SensorMeasurements &sensor_measurements,
       Driver::I2C::SFM3019::Sensor &sfm3019_air,
       Driver::I2C::SFM3019::Sensor &sfm3019_o2,
-      HAL::PWM &valve)
+      HAL::PWM &valve_air,
+      HAL::PWM &valve_o2)
       : parameters_(parameters),
         sensor_measurements_(sensor_measurements),
         sfm3019_air_(sfm3019_air),
         sfm3019_o2_(sfm3019_o2),
-        valve_(valve) {}
+        valve_air_(valve_air),
+        valve_o2_(valve_o2) {}
 
   void update(uint32_t current_time) override;
 
   [[nodiscard]] const SensorVars &sensor_vars() const;
+  [[nodiscard]] const ActuatorSetpoints &actuator_setpoints() const;
   [[nodiscard]] const ActuatorVars &actuator_vars() const;
 
  private:
@@ -63,9 +66,13 @@ class HFNCControlLoop : public ControlLoop {
   Driver::I2C::SFM3019::Sensor &sfm3019_air_;
   Driver::I2C::SFM3019::Sensor &sfm3019_o2_;
 
+  // Setpoints
+  ActuatorSetpoints actuator_setpoints_{};
+
   // ActuatorVars
   ActuatorVars actuator_vars_{};
-  HAL::PWM &valve_;
+  HAL::PWM &valve_air_;
+  HAL::PWM &valve_o2_;
 };
 
 }  // namespace Pufferfish::Driver::BreathingCircuit

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Controller.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Controller.h
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 
+#include "Algorithms.h"
 #include "Pufferfish/Application/States.h"
 
 namespace Pufferfish::Driver::BreathingCircuit {
@@ -20,9 +21,18 @@ struct SensorVars {
   float flow_o2;
 };
 
-struct ActuatorVars {
-  float valve_opening;
+struct ActuatorSetpoints {
+  float flow_air;
+  float flow_o2;
 };
+
+struct ActuatorVars {
+  float valve_air_opening;
+  float valve_o2_opening;
+};
+
+static const uint8_t fio2_min = 21;
+static const uint8_t fio2_max = 100;
 
 class Controller {
  public:
@@ -31,6 +41,7 @@ class Controller {
       const Parameters &parameters,
       const SensorVars &sensor_vars,
       const SensorMeasurements &sensor_measurements,
+      ActuatorSetpoints &actuator_setpoints,
       ActuatorVars &actuator_vars) = 0;
 };
 
@@ -41,16 +52,12 @@ class HFNCController : public Controller {
       const Parameters &parameters,
       const SensorVars &sensor_vars,
       const SensorMeasurements &sensor_measurements,
+      ActuatorSetpoints &actuator_setpoints,
       ActuatorVars &actuator_vars) override;
 
  private:
-  static constexpr float p_gain = 0.00001;
-  static constexpr float i_gain = 0.0002;
-  static constexpr float i_max = 200 * i_gain;
-  static constexpr float i_min = 0;
-
-  float error_ = 0;
-  float error_integral_ = 0;
+  PI valve_o2_{};
+  PI valve_air_{};
 };
 
 }  // namespace Pufferfish::Driver::BreathingCircuit

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/ParametersService.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/ParametersService.h
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 
+#include "Controller.h"
 #include "Pufferfish/Application/States.h"
 
 namespace Pufferfish::Driver::BreathingCircuit {
@@ -22,10 +23,6 @@ class ParametersService {
 
  protected:
   static void transform_fio2(float fio2_request, float &fio2);
-
- private:
-  static constexpr float fio2_min = 21;   // % FiO2
-  static constexpr float fio2_max = 100;  // % FiO2
 };
 
 class PCACParameters : public ParametersService {

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Simulator.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Simulator.h
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 
+#include "Controller.h"
 #include "Pufferfish/Application/States.h"
 
 namespace Pufferfish::Driver::BreathingCircuit {
@@ -20,6 +21,7 @@ class Simulator {
   void input_clock(uint32_t current_time);
   virtual void transform(
       const Parameters &parameters,
+      const SensorVars &sensor_vars,
       SensorMeasurements &sensor_measurements,
       CycleMeasurements &cycle_measurements) = 0;
 
@@ -46,6 +48,7 @@ class PCACSimulator : public Simulator {
  public:
   void transform(
       const Parameters &parameters,
+      const SensorVars &sensor_vars,
       SensorMeasurements &sensor_measurements,
       CycleMeasurements &cycle_measurements) override;
 
@@ -78,6 +81,7 @@ class HFNCSimulator : public Simulator {
  public:
   void transform(
       const Parameters &parameters,
+      const SensorVars &sensor_vars,
       SensorMeasurements &sensor_measurements,
       CycleMeasurements &cycle_measurements) override;
 
@@ -102,6 +106,7 @@ class Simulators {
   void transform(
       uint32_t current_time,
       const Parameters &parameters,
+      const SensorVars &sensor_vars,
       SensorMeasurements &sensor_measurements,
       CycleMeasurements &cycle_measurements);
 

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Algorithms.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Algorithms.cpp
@@ -1,0 +1,33 @@
+/*
+ * BreathingCircuit.tpp
+ *
+ *  Created on: June 6, 2020
+ *      Author: Ethan Li
+ */
+
+#include "Pufferfish/Driver/BreathingCircuit/Algorithms.h"
+
+namespace Pufferfish::Driver::BreathingCircuit {
+
+// PI
+
+void PI::transform(float measurement, float setpoint, float &actuation) {
+  error_ = setpoint - measurement;
+  error_integral_ += error_;
+  if (error_integral_ < i_min) {
+    error_integral_ = i_min;
+  }
+  if (error_integral_ < i_max) {
+    error_integral_ = i_max;
+  }
+
+  actuation = error_ * p_gain + error_integral_ * i_gain;
+  if (actuation < 0) {
+    actuation = 0;
+  }
+  if (actuation > 1) {
+    actuation = 1;
+  }
+}
+
+}  // namespace Pufferfish::Driver::BreathingCircuit

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/ControlLoop.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/ControlLoop.cpp
@@ -52,10 +52,16 @@ void HFNCControlLoop::update(uint32_t current_time) {
 
   // Update controller
   controller_.transform(
-      current_time, parameters_, sensor_vars_, sensor_measurements_, actuator_vars_);
+      current_time,
+      parameters_,
+      sensor_vars_,
+      sensor_measurements_,
+      actuator_setpoints_,
+      actuator_vars_);
 
   // Update actuators
-  valve_.set_duty_cycle(actuator_vars_.valve_opening);
+  valve_air_.set_duty_cycle(actuator_vars_.valve_air_opening);
+  valve_o2_.set_duty_cycle(actuator_vars_.valve_o2_opening);
 
   advance_step_time(current_time);
 }

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Controller.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Controller.cpp
@@ -14,30 +14,24 @@ namespace Pufferfish::Driver::BreathingCircuit {
 void HFNCController::transform(
     uint32_t /*current_time*/,
     const Parameters &parameters,
-    const SensorVars & /*sensor_vars*/,
-    const SensorMeasurements &sensor_measurements,
+    const SensorVars &sensor_vars,
+    const SensorMeasurements & /*sensor_measurements*/,
+    ActuatorSetpoints &actuator_setpoints,
     ActuatorVars &actuator_vars) {
   if (parameters.mode != VentilationMode_hfnc) {
     return;
   }
 
-  // PI Controller
-  error_ = parameters.flow - sensor_measurements.flow;
-  error_integral_ += error_;
-  if (error_integral_ < i_min) {
-    error_integral_ = i_min;
-  }
-  if (error_integral_ < i_max) {
-    error_integral_ = i_max;
-  }
+  // Open-loop setpoints
+  float flow_o2_ratio = (parameters.fio2 - fio2_min) / (fio2_max - fio2_min);
+  actuator_setpoints.flow_o2 = flow_o2_ratio * parameters.flow;
+  actuator_setpoints.flow_air = parameters.flow - actuator_setpoints.flow_o2;
 
-  actuator_vars.valve_opening = error_ * p_gain + error_integral_ * i_gain;
-  if (actuator_vars.valve_opening < 0) {
-    actuator_vars.valve_opening = 0;
-  }
-  if (actuator_vars.valve_opening > 1) {
-    actuator_vars.valve_opening = 1;
-  }
+  // PI Controller
+  valve_air_.transform(
+      sensor_vars.flow_air, actuator_setpoints.flow_air, actuator_vars.valve_air_opening);
+  valve_o2_.transform(
+      sensor_vars.flow_o2, actuator_setpoints.flow_o2, actuator_vars.valve_o2_opening);
 }
 
 }  // namespace Pufferfish::Driver::BreathingCircuit

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -328,7 +328,12 @@ int interface_test_millis = 0;
 
 // Breathing Circuit Control
 PF::Driver::BreathingCircuit::HFNCControlLoop hfnc(
-    all_states.parameters(), all_states.sensor_measurements(), sfm3019_air, sfm3019_o2, drive1_ch1);
+    all_states.parameters(),
+    all_states.sensor_measurements(),
+    sfm3019_air,
+    sfm3019_o2,
+    drive1_ch1,
+    drive1_ch2);
 
 /* USER CODE END PV */
 
@@ -465,6 +470,7 @@ int main(void)
 
   // Solenoid valve
   drive1_ch1.start();
+  drive1_ch2.start();
 
   // Nonin OEM III sensor
   nonin_oem_uart.setup_irq();
@@ -525,6 +531,7 @@ int main(void)
     simulator.transform(
         current_time,
         all_states.parameters(),
+        hfnc.sensor_vars(),
         all_states.sensor_measurements(),
         all_states.cycle_measurements());
 
@@ -535,18 +542,18 @@ int main(void)
     hfnc.update(current_time);
     // Indicators for debugging
     /*static constexpr float valve_opening_indicator_threshold = 0.5;
-    if (actuator_vars.valve_opening > valve_opening_indicator_threshold) {
+    if (hfnc.actuator_vars().valve_air_opening > valve_opening_indicator_threshold) {
       board_led1.write(true);
     } else {
       board_led1.write(dimmer.output());
     }*/
-    /*if (hfnc.sensor_vars().flow_o2 > 1 || hfnc.sensor_vars().flow_air > 1) {
+    if (hfnc.sensor_vars().flow_o2 > 1 || hfnc.sensor_vars().flow_air > 1) {
       board_led1.write(true);
     } else if (hfnc.sensor_vars().flow_o2 < -1 || hfnc.sensor_vars().flow_air < -1) {
       board_led1.write(dimmer.output());
     } else {
       board_led1.write(false);
-    }*/
+    }
 
     // Backend Communication Protocol
     backend.receive();


### PR DESCRIPTION
This PR:

- Adds support for closed-loop control of two valves.
- Decomposes the PI control algorithm out into its own class.
- Uses the two SFM3019 sensors for closed-loop control of the flow rates of two valves (the O2 branch valve and the air branch valve).
- Computes the setpoints of the two valves based on the desired flow rate and FiO2, for open-loop control of FiO2.
- Exposes `ActuatorSetpoints` as an internal piece of state used by `Controller`s and exposed by `ControlLoop`s for monitoring.
- Adds support in the `HFNCSimulator` for use of flow values in `SensorVars` to simulate FiO2 (if flow is non-zero), rather than simulating FiO2 directly from the FiO2 parameter.
- Demonstrates hardware integration with two PWM solenoid valves and two SFM3019 flow sensors.