### PR TITLE
install.sh syntax error fix

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -15,7 +15,7 @@
 # Setup yarn and install required libraries
 ./scripts/yarn.sh
 
-if [ "$@" != "deploy" ]
+if [[ "$@" != "deploy" ]]
 then
     echo -n "Reboot required for changes to take effect. Do you want to reboot now? [y/N]: "
     read answer


### PR DESCRIPTION
The problem with conditional statement in `install.sh` script has been fixed.