### PR TITLE
Split up backend checks into separate jobs

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -36,7 +36,7 @@ jobs:
         poetry run pip install --upgrade pip
         poetry run pip install tox
 
-    - name: Check Type Hints
+    - name: Check type annotations
       run: poetry run tox -e types
 
   lint:
@@ -60,7 +60,7 @@ jobs:
         poetry run pip install --upgrade pip
         poetry run pip install tox
 
-    - name: Check Code Quality
+    - name: Run linter
       run: poetry run tox -e lint
 
   tests:
@@ -84,5 +84,11 @@ jobs:
         poetry run pip install --upgrade pip
         poetry run pip install tox
 
-    - name: Run Unit Tests
-      run: poetry run tox -e py37,coverage
+    - name: Run unit tests
+      run: poetry run tox -e py37
+
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-coverage-report
+        path: backend/htmlcov

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -15,10 +15,9 @@ defaults:
     working-directory: backend
 
 jobs:
-  build:
+  types:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
         python-version: [3.7]
 
@@ -35,13 +34,55 @@ jobs:
       run: |
         pip install poetry
         poetry run pip install --upgrade pip
-        poetry install -v
+        poetry run pip install tox
 
     - name: Check Type Hints
       run: poetry run tox -e types
 
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+      name: Checkout repository
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        pip install poetry
+        poetry run pip install --upgrade pip
+        poetry run pip install tox
+
     - name: Check Code Quality
       run: poetry run tox -e lint
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+      name: Checkout repository
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        pip install poetry
+        poetry run pip install --upgrade pip
+        poetry run pip install tox
 
     - name: Run Unit Tests
       run: poetry run tox -e py37,coverage

--- a/backend/README.md
+++ b/backend/README.md
@@ -67,7 +67,7 @@ common IDEs:
 * Atom: https://atom.io/packages/linter-pylint
 * Vim: https://github.com/dense-analysis/ale
 
-To run the pylint commands, do:
+To run the linter, do:
 
 ```bash
 (ventserver) $ poetry run pylint ventserver
@@ -87,7 +87,7 @@ type-checking, do:
 Unit testing is done utilizing [pytest](https://docs.pytest.org/en/latest/) and
 [tox](https://tox.readthedocs.io/en/latest/) for automation.
 
-To execute the test suite, run:
+To execute the test suite together with type-checkng and linting, run:
 
 ```bash
 (ventserver) $ poetry run tox

--- a/backend/README.md
+++ b/backend/README.md
@@ -87,7 +87,7 @@ type-checking, do:
 Unit testing is done utilizing [pytest](https://docs.pytest.org/en/latest/) and
 [tox](https://tox.readthedocs.io/en/latest/) for automation.
 
-To execute the test suite together with type-checkng and linting, run:
+To execute the test suite together with type-checkng and linting and html coverage reporting, run:
 
 ```bash
 (ventserver) $ poetry run tox

--- a/backend/tox.ini
+++ b/backend/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = types, lint, py37, coverage-report
+envlist = types, lint, py37
 isolated_build = True
 
 [gh-actions]
@@ -18,6 +18,9 @@ commands =
     poetry install -v
     coverage erase
     coverage run --parallel -m pytest --basetemp={envtmpdir} --verbose tests
+    coverage combine
+    coverage report
+    coverage html
 
 [testenv:types]
 basepython = python
@@ -38,11 +41,3 @@ commands =
     poetry install -v
     pylint ventserver
     pylint tests --disable=duplicate-code
-
-[testenv:coverage-report]
-whitelist_externals:
-    coverage
-commands =
-    coverage combine
-    coverage report
-    coverage html


### PR DESCRIPTION
This PR closes #72 by running the type-checking, linting, and unit testing as parallel jobs, and by skipping installation of dependencies before the tox commands (since the tox commands install dependencies themselves anyways). This cuts down the Github Actions testing time from ~5 min to ~2 min.

This PR also makes test coverage reports downloadable from Github Actions.