### PR TITLE
Fix new issue with typescript versioning

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3",
     "reselect": "^4.0.0",
-    "typescript": "~3.7.2"
+    "typescript": "^3.9.7"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/frontend/src/modules/dashboard/components/Loop.tsx
+++ b/frontend/src/modules/dashboard/components/Loop.tsx
@@ -73,13 +73,15 @@ export const Loop = ({
     return yScale;
   }
 
+  // TODO: we need to remove the exclamation points, which are claiming that the
+  // values are never undefined
   return (
     <svg width={width} height={height}>
       <Group>
         <LinePath
           data={data}
-          x={(d) => xScale(x(d)) + margin.left}
-          y={(d) => yScale(y(d)) + margin.top}
+          x={(d) => xScale(x(d)!)! + margin.left}
+          y={(d) => yScale(y(d)!)! + margin.top}
           stroke={theme.palette.info.main}
           strokeWidth={strokeWidth}
           curve={curveLinear}

--- a/frontend/src/modules/dashboard/components/Waveform.tsx
+++ b/frontend/src/modules/dashboard/components/Waveform.tsx
@@ -84,6 +84,8 @@ export const Waveform = ({
     return 'rgba(0,0,0,0)';
   }
 
+  // TODO: we need to remove the exclamation points, which are claiming that the
+  // values are never undefined
   return (
     <svg width={width} height={height}>
       <LinearGradient
@@ -95,8 +97,8 @@ export const Waveform = ({
       <Group>
         <AreaClosed
           data={data}
-          x={(d) => xScale(x(d)) + margin.left}
-          y={(d) => yScale(y(d)) + margin.top}
+          x={(d) => xScale(x(d)!)! + margin.left}
+          y={(d) => yScale(y(d)!)! + margin.top}
           yScale={findAxis(type)}
           fill={fillF(fill)}
           strokeWidth={strokeWidth}
@@ -104,8 +106,8 @@ export const Waveform = ({
         />
         <LinePath
           data={data}
-          x={(d) => xScale(x(d)) + margin.left}
-          y={(d) => yScale(y(d)) + margin.top}
+          x={(d) => xScale(x(d)!)! + margin.left}
+          y={(d) => yScale(y(d)!)! + margin.top}
           stroke={theme.palette.info.main}
           strokeWidth={strokeWidth}
           curve={curveLinear}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12693,10 +12693,10 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@~3.7.2:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@^3.8.0:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
A new issue appears to have popped up when I run `yarn install` as of today, where some kind of typescript syntax error appears when running `yarn start` - it appears to be the same issue as was reported in https://github.com/facebook/create-react-app/issues/8714 . As reported in that issue, it is resolved by upgrading Typescript to 3.8 or above, so I've done that version bump here. @Sudhir-dev Can you check about whether this TypeScript upgrade appears to have broken anything?

This also caused some additional complaints about possibly undefined items `xScale`, `x`, and, `y`, in `Axes.tsx` and `Loop.tsx` - I did a quick-and-dirty workaround by asserting (using the `!` operator) that they are never undefined, because I'm not sure yet what's the right way to actually address the issue