### PR TITLE
Fix setup indicator LED to account for blocking I/O in setup functions

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/FDO2/Sensor.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/FDO2/Sensor.h
@@ -29,12 +29,14 @@ class Sensor : public Initializable {
   InitializableState output(uint32_t &po2);
 
  private:
+  static const uint32_t setup_timeout = 1000;        // ms
   static const uint32_t setup_request_timeout = 50;  // ms
 
   Device &device_;
   HAL::Time &time_;
 
-  uint32_t request_time_ = 0;  // us
+  uint32_t setup_start_time_ = 0;  // ms
+  uint32_t request_time_ = 0;      // ms
   bool setup_completed_ = false;
 
   bool check_version();

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/FDO2/Sensor.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/FDO2/Sensor.cpp
@@ -34,12 +34,19 @@ InitializableState Sensor::setup() {
     return InitializableState::ok;
   }
 
-  if (!check_version()) {
+  if (setup_start_time_ == 0) {
+    setup_start_time_ = time_.millis();
+  }
+  if (!Util::within_timeout(setup_start_time_, setup_timeout, time_.millis())) {
     return InitializableState::failed;
   }
 
+  if (!check_version()) {
+    return InitializableState::setup;
+  }
+
   if (!start_broadcast()) {
-    return InitializableState::failed;
+    return InitializableState::setup;
   }
 
   setup_completed_ = true;


### PR DESCRIPTION
This PR makes the indicator LED behave more correctly in the firmware during setup. Previously, the indicator LED was using software PWM (assuming non-blocking I/O in the setup functions), while the setup functions themselves were using blocking I/O and blocking delays. Thus, the indicator LED wouldn't actually flash or blink during failure or setup. Now, setup phase has a solid on indicator LED, while failure blocks for flashing for ~2 seconds. Also, now the "setup succeeded" indicator is a slow blink for 2 seconds rather than a solid on.