### PR TITLE
Avoid setup code in SFM3019::Sensor::output when setup was skipped

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/I2C/SFM3019/Sensor.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/I2C/SFM3019/Sensor.cpp
@@ -57,11 +57,6 @@ bool StateMachine::finished_waiting(uint32_t timeout_us) const {
 // Sensor
 
 InitializableState Sensor::setup() {
-  float flow = NAN;
-  return output(flow);
-}
-
-InitializableState Sensor::output(float &flow) {
   switch (next_action_) {
     case Action::initialize:
       return initialize(time_.micros());
@@ -70,6 +65,15 @@ InitializableState Sensor::output(float &flow) {
       return InitializableState::setup;
     case Action::check_range:
       return check_range(time_.micros());
+    case Action::measure:
+    case Action::wait_measurement:
+      return InitializableState::ok;
+  }
+  return InitializableState::failed;
+}
+
+InitializableState Sensor::output(float &flow) {
+  switch (next_action_) {
     case Action::measure:
       return measure(time_.micros(), flow);
     case Action::wait_measurement:

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -490,7 +490,7 @@ int main(void)
   // Setup
   static const uint32_t setup_indicator_duration = 2000;
 
-  board_led1.write(false);
+  board_led1.write(true);
   while (true) {
     // Run setup on all initializables
     for (size_t i = 0; i < initializables.size(); ++i) {


### PR DESCRIPTION
This PR fixes a bug in the `SFM3019::Sensor` code in which the calling code is able to skip `setup` but call `output`. When this happened, `SFM3019::Sensor` would simply attempt to run the setup code, which is incorrect behavior. If the setup code was configured to do many retries, then it would prevent the firmware from doing any other work. Now I have removed setup code from the `output` method so that it can only be reached by calling the `setup` method.