### PR TITLE
Fix/backend file I/O directory

### DIFF
--- a/backend/ventserver/application.py
+++ b/backend/ventserver/application.py
@@ -52,7 +52,7 @@ async def main() -> None:
         except exceptions.ProtocolError as err:
             exception = (
                 "Unable to connect the rotary encoder, please check the "
-                "serial connection. Check if the pigpiod service is running: "
+                "serial connection. Check if the pigpiod service is running: %s"
             )
             rotary_encoder = None
             logger.error(exception, err)

--- a/backend/ventserver/integration/_trio.py
+++ b/backend/ventserver/integration/_trio.py
@@ -97,8 +97,8 @@ async def send_all_file(
             await filehandler.open()
             async with filehandler:
                 await filehandler.send(message.data)
-        except OSError:
-            logger.error("Handler: ")
+        except OSError as err:
+            logger.error("Handler: %s", err)
 
 
 async def process_protocol_send_output(

--- a/backend/ventserver/integration/_trio.py
+++ b/backend/ventserver/integration/_trio.py
@@ -350,6 +350,7 @@ async def load_file_states(
             await filehandler.open()
             async with  filehandler:
                 message = await filehandler.receive()
+                logger.info("State initialized from file: %s", state.__name__)
                 protocol.receive.input(
                     server.ReceiveEvent(
                         file_receive=file.StateData(

--- a/backend/ventserver/io/trio/fileio.py
+++ b/backend/ventserver/io/trio/fileio.py
@@ -45,7 +45,7 @@ class Handler(endpoints.IOEndpoint[bytes, bytes]):
                                "if one is already open." +
                                "Please close the old file instance."
                               )
-        
+
         _filepath = os.path.join(self.rootdir, self.props.filedir)
         if not os.path.exists(_filepath):
             self._logger.info("No such directory: %s", _filepath)

--- a/backend/ventserver/io/trio/fileio.py
+++ b/backend/ventserver/io/trio/fileio.py
@@ -61,7 +61,7 @@ class Handler(endpoints.IOEndpoint[bytes, bytes]):
         except OSError as err:
             raise OSError("Handler: {}".format(err)) from err
 
-        self._logger.info('File %s opened.', self.props.filename)
+        self._logger.debug('File %s opened.', self.props.filename)
         self._connected.set()
 
     @property
@@ -77,7 +77,7 @@ class Handler(endpoints.IOEndpoint[bytes, bytes]):
         assert self._fileobject is not None
         await self._fileobject.aclose()
         self._fileobject = None
-        self._logger.info('File %s closed.', self.props.filename)
+        self._logger.debug('File %s closed.', self.props.filename)
         self._connected = trio.Event()
 
     async def receive(self) -> bytes:

--- a/backend/ventserver/io/trio/fileio.py
+++ b/backend/ventserver/io/trio/fileio.py
@@ -45,14 +45,18 @@ class Handler(endpoints.IOEndpoint[bytes, bytes]):
                                "if one is already open." +
                                "Please close the old file instance."
                               )
+        
+        _filepath = os.path.join(self.rootdir, self.props.filedir)
+        if not os.path.exists(_filepath):
+            self._logger.info("No such directory: %s", _filepath)
+            os.mkdir(_filepath)
+            self._logger.info("Created directory: %s", _filepath)
 
-        _filepath = os.path.join(
-            self.rootdir, self.props.filedir, self.props.filename
-        )
         try:
             # raises OSError
             self._fileobject = await trio.open_file(    # type: ignore
-                _filepath, str(self.props.mode)
+                os.path.join(_filepath, self.props.filename),
+                str(self.props.mode)
             )
         except OSError as err:
             raise OSError("Handler: {}".format(err)) from err


### PR DESCRIPTION
Fixes issues where there is no `statestore` directory in the location. Also fixes empty `Handler: ` exception logs.