### PR TITLE
Refactor FDO2 Sensor for longer setup (up to 5 sec) & non-blocking I/O

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/FDO2/Device.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/FDO2/Device.h
@@ -61,9 +61,6 @@ class Device {
 
   static const uint16_t broadcast_interval = 100;  // ms
 
-  static constexpr Responses::Bcst expected_bcst{broadcast_interval};
-  static constexpr Responses::Vers expected_vers{8, 1, 341, 15};
-
   explicit Device(volatile HAL::BufferedUART &uart) : uart_(uart) {}
 
   /**

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/FDO2/Sensor.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/FDO2/Sensor.h
@@ -18,6 +18,29 @@
 
 namespace Pufferfish::Driver::Serial::FDO2 {
 
+class StateMachine {
+ public:
+  enum class Action {
+    request_version,
+    check_version,
+    start_broadcast,
+    check_broadcast,
+    wait_measurement
+  };
+
+  [[nodiscard]] Action update(uint32_t current_time, bool passed_check = false);
+
+ private:
+  static const uint32_t response_timeout = 50;  // ms
+
+  Action next_action_ = Action::request_version;
+  uint32_t request_time_ = 0;
+  uint32_t current_time_ = 0;
+
+  void start_request();
+  [[nodiscard]] bool timed_out() const;
+};
+
 /**
  * High-level (stateful) driver for FDO2 sensor
  */
@@ -29,18 +52,21 @@ class Sensor : public Initializable {
   InitializableState output(uint32_t &po2);
 
  private:
-  static const uint32_t setup_timeout = 1000;        // ms
-  static const uint32_t setup_request_timeout = 50;  // ms
+  using Action = StateMachine::Action;
+
+  static constexpr Responses::Vers expected_vers{8, 1, 341, 15};
+  static constexpr Responses::Bcst expected_bcst{Device::broadcast_interval};
+  static const size_t max_retries_setup = 100;   // max retries for all setup steps combined
 
   Device &device_;
+  StateMachine fsm_;
   HAL::Time &time_;
+  Action next_action_ = Action::request_version;
+  size_t retry_count_ = 0;
 
-  uint32_t setup_start_time_ = 0;  // ms
-  uint32_t request_time_ = 0;      // ms
-  bool setup_completed_ = false;
-
-  bool check_version();
-  bool start_broadcast();
+  bool get_response(CommandTypes type, Response &response);
+  InitializableState check_version(uint32_t current_time);
+  InitializableState check_broadcast(uint32_t current_time);
 };
 
 }  // namespace Pufferfish::Driver::Serial::FDO2

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/FDO2/Sensor.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/FDO2/Sensor.h
@@ -56,7 +56,7 @@ class Sensor : public Initializable {
 
   static constexpr Responses::Vers expected_vers{8, 1, 341, 15};
   static constexpr Responses::Bcst expected_bcst{Device::broadcast_interval};
-  static const size_t max_retries_setup = 100;   // max retries for all setup steps combined
+  static const size_t max_retries_setup = 100;  // max retries for all setup steps combined
 
   Device &device_;
   StateMachine fsm_;

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/I2C/SFM3019/Sensor.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/I2C/SFM3019/Sensor.cpp
@@ -26,8 +26,6 @@ StateMachine::Action StateMachine::update(uint32_t current_time_us) {
     case Action::wait_warmup:
       if (finished_waiting(warming_up_duration_us)) {
         next_action_ = Action::check_range;
-      } else {
-        next_action_ = Action::wait_warmup;
       }
       break;
     case Action::check_range:
@@ -38,8 +36,6 @@ StateMachine::Action StateMachine::update(uint32_t current_time_us) {
     case Action::wait_measurement:
       if (finished_waiting(measuring_duration_us)) {
         next_action_ = Action::measure;
-      } else {
-        next_action_ = Action::wait_measurement;
       }
       break;
   }
@@ -141,7 +137,7 @@ InitializableState Sensor::check_range(uint32_t current_time_us) {
     return InitializableState::failed;
   }
 
-  return InitializableState::ok;
+  return InitializableState::setup;
 }
 
 InitializableState Sensor::measure(uint32_t current_time_us, float &flow) {

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/FDO2/Sensor.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/FDO2/Sensor.cpp
@@ -24,36 +24,81 @@
 
 namespace Pufferfish::Driver::Serial::FDO2 {
 
+// StateMachine
+
+StateMachine::Action StateMachine::update(uint32_t current_time, bool passed_check) {
+  current_time_ = current_time;
+  switch (next_action_) {
+    case Action::request_version:
+      start_request();
+      next_action_ = Action::check_version;
+      break;
+    case Action::check_version:
+      if (passed_check) {
+        next_action_ = Action::start_broadcast;
+      } else if (timed_out()) {
+        next_action_ = Action::request_version;
+      }
+      break;
+    case Action::start_broadcast:
+      start_request();
+      next_action_ = Action::check_broadcast;
+      break;
+    case Action::check_broadcast:
+      if (passed_check) {
+        next_action_ = Action::wait_measurement;
+      } else if (timed_out()) {
+        next_action_ = Action::start_broadcast;
+      }
+    case Action::wait_measurement:
+      break;
+  }
+  return next_action_;
+}
+
+void StateMachine::start_request() {
+  request_time_ = current_time_;
+}
+
+bool StateMachine::timed_out() const {
+  return !Util::within_timeout(request_time_, response_timeout, current_time_);
+}
+
 RESPONSE_TAGGED_COMPARISON(Responses::Vers, vers)
 RESPONSE_TAGGED_COMPARISON(Responses::Bcst, bcst)
 
 // Sensor
 
 InitializableState Sensor::setup() {
-  if (setup_completed_) {
-    return InitializableState::ok;
-  }
-
-  if (setup_start_time_ == 0) {
-    setup_start_time_ = time_.millis();
-  }
-  if (!Util::within_timeout(setup_start_time_, setup_timeout, time_.millis())) {
+  if (retry_count_ > max_retries_setup) {
     return InitializableState::failed;
   }
 
-  if (!check_version()) {
-    return InitializableState::setup;
+  switch (next_action_) {
+    case Action::request_version:
+      device_.request_version();
+      next_action_ = fsm_.update(time_.millis());
+      return InitializableState::setup;
+    case Action::check_version:
+      return check_version(time_.millis());
+    case Action::start_broadcast:
+      device_.start_broadcast();
+      next_action_ = fsm_.update(time_.millis());
+      return InitializableState::setup;
+    case Action::check_broadcast:
+      return check_broadcast(time_.millis());
+    case Action::wait_measurement:
+      next_action_ = fsm_.update(time_.millis());
+      return InitializableState::ok;
   }
-
-  if (!start_broadcast()) {
-    return InitializableState::setup;
-  }
-
-  setup_completed_ = true;
-  return InitializableState::ok;
+  return InitializableState::failed;
 }
 
 InitializableState Sensor::output(uint32_t &po2) {
+  if (next_action_ != Action::wait_measurement) {
+    return InitializableState::failed;
+  }
+
   Response response;
   device_.receive(response);
   // This is a tagged union access
@@ -63,28 +108,56 @@ InitializableState Sensor::output(uint32_t &po2) {
   return InitializableState::ok;
 }
 
-bool Sensor::check_version() {
-  device_.request_version();
-  request_time_ = time_.millis();
-  while (Util::within_timeout(request_time_, setup_request_timeout, time_.millis())) {
-    Response response;
-    if (device_.receive(response) == Device::Status::ok && response.tag == CommandTypes::vers) {
-      return response == Device::expected_vers;
+bool Sensor::get_response(CommandTypes type, Response &response) {
+  while (true) {
+    if (device_.receive(response) != Device::Status::ok) {
+      return false;
+    }
+
+    if (response.tag == type) {
+      return true;
     }
   }
-  return false;
 }
 
-bool Sensor::start_broadcast() {
-  device_.start_broadcast();
-  request_time_ = time_.millis();
-  while (Util::within_timeout(request_time_, setup_request_timeout, time_.millis())) {
-    Response response;
-    if (device_.receive(response) == Device::Status::ok && response.tag == CommandTypes::bcst) {
-      return response == Device::expected_bcst;
+InitializableState Sensor::check_version(uint32_t current_time) {
+  Response response;
+  if (!get_response(CommandTypes::vers, response)) {
+    next_action_ = fsm_.update(current_time);
+    if (next_action_ != Action::check_version) {
+      ++retry_count_;
     }
+    return InitializableState::setup;
   }
-  return false;
+
+  if (response == expected_vers) {
+    next_action_ = fsm_.update(current_time, true);
+  } else {
+    next_action_ = fsm_.update(current_time);
+    ++retry_count_;
+  }
+  return InitializableState::setup;
+}
+
+InitializableState Sensor::check_broadcast(uint32_t current_time) {
+  using namespace std::rel_ops;
+
+  Response response;
+  if (!get_response(CommandTypes::bcst, response)) {
+    next_action_ = fsm_.update(current_time);
+    if (next_action_ != Action::check_broadcast) {
+      ++retry_count_;
+    }
+    return InitializableState::setup;
+  }
+
+  if (response == expected_bcst) {
+    next_action_ = fsm_.update(current_time, true);
+  } else {
+    next_action_ = fsm_.update(current_time);
+    ++retry_count_;
+  }
+  return InitializableState::setup;
 }
 
 }  // namespace Pufferfish::Driver::Serial::FDO2

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/FDO2/Sensor.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/FDO2/Sensor.cpp
@@ -140,8 +140,6 @@ InitializableState Sensor::check_version(uint32_t current_time) {
 }
 
 InitializableState Sensor::check_broadcast(uint32_t current_time) {
-  using namespace std::rel_ops;
-
   Response response;
   if (!get_response(CommandTypes::bcst, response)) {
     next_action_ = fsm_.update(current_time);


### PR DESCRIPTION
This PR:

- Refactors the FDO2 `Sensor` to use non-blocking I/O by decomposing management of states and state transitions into a `StateMachine`.
- Fixes problems observed in FDO2 sensor initialization when the Nucleo-H743ZI2 board was reset using the RESET button rather than by unplugging and plugging in the USB cable: in some cases, setup would fail. What I have observed in the logic analyzer is that sometimes multiple start-broadcast requests need to be sent before a response is received in a reasonable time. The fix is to increase the duration of time that the setup routine retries sending requests before giving up and reporting a failure. I have adjusted this to increase from 1 sec to 5 sec, though in testing I have always seen the sensor either complete setup quickly (<1 sec) or take ~3 sec to complete setup successfully.