### PR TITLE
Fix bug where the error integral was always set to max value

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Algorithms.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Algorithms.h
@@ -18,6 +18,8 @@ class PI {
   void transform(float measurement, float setpoint, float &actuation);
 
  private:
+  static constexpr float out_max = 1;
+  static constexpr float out_min = 0;
   static constexpr float p_gain = 0.00001;
   static constexpr float i_gain = 0.0002;
   static constexpr float i_max = 200 * i_gain;

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Algorithms.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Algorithms.h
@@ -22,8 +22,8 @@ class PI {
   static constexpr float out_min = 0;
   static constexpr float p_gain = 0.00001;
   static constexpr float i_gain = 0.0002;
-  static constexpr float i_max = 200 * i_gain;
-  static constexpr float i_min = 0;
+  static constexpr float i_max = out_max / i_gain;
+  static constexpr float i_min = out_min / i_gain;
 
   float error_ = 0;
   float error_integral_ = 0;

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Algorithms.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Algorithms.cpp
@@ -17,16 +17,16 @@ void PI::transform(float measurement, float setpoint, float &actuation) {
   if (error_integral_ < i_min) {
     error_integral_ = i_min;
   }
-  if (error_integral_ < i_max) {
+  if (error_integral_ > i_max) {
     error_integral_ = i_max;
   }
 
   actuation = error_ * p_gain + error_integral_ * i_gain;
-  if (actuation < 0) {
-    actuation = 0;
+  if (actuation < out_min) {
+    actuation = out_min;
   }
-  if (actuation > 1) {
-    actuation = 1;
+  if (actuation > out_max) {
+    actuation = out_max;
   }
 }
 


### PR DESCRIPTION
This PR:

- Fixes a bug from when I had copy-pasted bounds-checking code for the error integral term in the PI controller. In this bug, the error integral term was allowed to grow without limits, even though I had defined an upper limit; effectively it made the upper limit behave like a **lower** limit. This should probably fix the issues with overshooting after saturation observed by the BF team in testing today.
- Changes the PI controller output limits into `static const` parameters rather than leaving them hard-coded into the implementation of the `transform` method.