### PR TITLE
Ensure that valves are closed at initialization

### DIFF
--- a/backend/ventserver/application.py
+++ b/backend/ventserver/application.py
@@ -60,7 +60,7 @@ async def main() -> None:
         server.ReceiveOutputEvent
     ] = channels.TrioChannel()
 
-    # Initialize State
+    # Initialize state with defaults
     all_states = protocol.receive.backend.all_states
     for state in all_states:
         if state is mcu_pb.ParametersRequest:
@@ -71,6 +71,7 @@ async def main() -> None:
         else:
             all_states[state] = state()
 
+    # Load state from file
     states: List[Type[betterproto.Message]] = [
         mcu_pb.Parameters, mcu_pb.CycleMeasurements,
         mcu_pb.SensorMeasurements, mcu_pb.ParametersRequest
@@ -78,6 +79,11 @@ async def main() -> None:
     await _trio.load_file_states(
         states, protocol, filehandler
     )
+
+    # Turn off ventilation
+    parameters_request = all_states[mcu_pb.ParametersRequest]
+    if parameters_request is not None:
+        parameters_request.ventilating = False
 
     try:
         async with channel.push_endpoint:

--- a/backend/ventserver/application.py
+++ b/backend/ventserver/application.py
@@ -65,7 +65,8 @@ async def main() -> None:
     for state in all_states:
         if state is mcu_pb.ParametersRequest:
             all_states[state] = mcu_pb.ParametersRequest(
-                mode=mcu_pb.VentilationMode.hfnc, rr=30, fio2=60, flow=6
+                mode=mcu_pb.VentilationMode.hfnc, ventilating=False,
+                rr=30, fio2=60, flow=6
             )
         else:
             all_states[state] = state()

--- a/backend/ventserver/protocols/protobuf/mcu_pb.py
+++ b/backend/ventserver/protocols/protobuf/mcu_pb.py
@@ -2,6 +2,7 @@
 # sources: mcu_pb.proto
 # plugin: python-betterproto
 from dataclasses import dataclass
+from typing import List
 
 import betterproto
 
@@ -14,6 +15,17 @@ class VentilationMode(betterproto.Enum):
     psv = 4
     niv = 5
     hfnc = 6
+
+
+class LogEventCode(betterproto.Enum):
+    fio2_too_low = 0
+    fio2_too_high = 1
+    spo2_too_low = 2
+    spo2_too_high = 3
+    rr_too_low = 4
+    rr_too_high = 5
+    battery_low = 6
+    screen_locked = 7
 
 
 @dataclass
@@ -86,6 +98,7 @@ class Parameters(betterproto.Message):
     ie: float = betterproto.float_field(7)
     fio2: float = betterproto.float_field(8)
     flow: float = betterproto.float_field(9)
+    ventilating: bool = betterproto.bool_field(10)
 
 
 @dataclass
@@ -99,6 +112,7 @@ class ParametersRequest(betterproto.Message):
     ie: float = betterproto.float_field(7)
     fio2: float = betterproto.float_field(8)
     flow: float = betterproto.float_field(9)
+    ventilating: bool = betterproto.bool_field(10)
 
 
 @dataclass
@@ -111,3 +125,37 @@ class Ping(betterproto.Message):
 class Announcement(betterproto.Message):
     time: int = betterproto.uint32_field(1)
     announcement: bytes = betterproto.bytes_field(2)
+
+
+@dataclass
+class LogEvent(betterproto.Message):
+    id: int = betterproto.uint32_field(1)
+    time: int = betterproto.uint32_field(2)
+    code: "LogEventCode" = betterproto.enum_field(3)
+    old_value: float = betterproto.float_field(4)
+    new_value: float = betterproto.float_field(5)
+
+
+@dataclass
+class ExpectedLogEvent(betterproto.Message):
+    id: int = betterproto.uint32_field(1)
+
+
+@dataclass
+class NextLogEvents(betterproto.Message):
+    log_events: List["LogEvent"] = betterproto.message_field(1)
+
+
+@dataclass
+class ActiveLogEvents(betterproto.Message):
+    id: List[int] = betterproto.uint32_field(1)
+
+
+@dataclass
+class BatteryPower(betterproto.Message):
+    power_left: int = betterproto.uint32_field(1)
+
+
+@dataclass
+class ScreenStatus(betterproto.Message):
+    lock: bool = betterproto.bool_field(1)

--- a/backend/ventserver/simulation.py
+++ b/backend/ventserver/simulation.py
@@ -232,12 +232,9 @@ class HFNCSimulator(BreathingCircuitSimulator):
         if self._parameters.mode != mcu_pb.VentilationMode.hfnc:
             return
 
-        if self._parameters_request.flow > 0:
+        if 0 <= self._parameters_request.flow <= 80:
             self._parameters.flow = self._parameters_request.flow
-        if (
-                self._parameters_request.fio2 >= 21
-                and self._parameters_request.fio2 <= 100
-        ):
+        if 21 <= self._parameters_request.fio2 <= 100:
             self._parameters.fio2 = self._parameters_request.fio2
         if self._parameters_request.rr > 0:
             self._parameters.rr = self._parameters_request.rr
@@ -367,7 +364,8 @@ async def main() -> None:
     for state in all_states:
         if state is mcu_pb.ParametersRequest:
             all_states[state] = mcu_pb.ParametersRequest(
-                mode=mcu_pb.VentilationMode.hfnc, rr=30, fio2=60, flow=6
+                mode=mcu_pb.VentilationMode.hfnc, ventilating=False,
+                rr=30, fio2=60, flow=6
             )
         else:
             all_states[state] = state()

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
@@ -20,7 +20,26 @@ typedef enum _VentilationMode {
     VentilationMode_hfnc = 6
 } VentilationMode;
 
+typedef enum _LogEventCode {
+    LogEventCode_fio2_too_low = 0,
+    LogEventCode_fio2_too_high = 1,
+    LogEventCode_spo2_too_low = 2,
+    LogEventCode_spo2_too_high = 3,
+    LogEventCode_rr_too_low = 4,
+    LogEventCode_rr_too_high = 5,
+    LogEventCode_battery_low = 6,
+    LogEventCode_screen_locked = 7
+} LogEventCode;
+
 /* Struct definitions */
+typedef struct _ActiveLogEvents {
+    pb_callback_t id;
+} ActiveLogEvents;
+
+typedef struct _NextLogEvents {
+    pb_callback_t log_events;
+} NextLogEvents;
+
 typedef struct _AlarmLimitsRequest {
     uint32_t rr_min;
     uint32_t rr_max;
@@ -62,6 +81,10 @@ typedef struct _Announcement {
     Announcement_announcement_t announcement;
 } Announcement;
 
+typedef struct _BatteryPower {
+    uint32_t power_left;
+} BatteryPower;
+
 typedef struct _CycleMeasurements {
     uint32_t time;
     float vt;
@@ -71,6 +94,18 @@ typedef struct _CycleMeasurements {
     float ip;
     float ve;
 } CycleMeasurements;
+
+typedef struct _ExpectedLogEvent {
+    uint32_t id;
+} ExpectedLogEvent;
+
+typedef struct _LogEvent {
+    uint32_t id;
+    uint32_t time;
+    LogEventCode code;
+    float oldValue;
+    float newValue;
+} LogEvent;
 
 typedef struct _Parameters {
     uint32_t time;
@@ -82,6 +117,7 @@ typedef struct _Parameters {
     float ie;
     float fio2;
     float flow;
+    bool ventilating;
 } Parameters;
 
 typedef struct _ParametersRequest {
@@ -94,12 +130,17 @@ typedef struct _ParametersRequest {
     float ie;
     float fio2;
     float flow;
+    bool ventilating;
 } ParametersRequest;
 
 typedef struct _Ping {
     uint32_t time;
     uint32_t id;
 } Ping;
+
+typedef struct _ScreenStatus {
+    bool lock;
+} ScreenStatus;
 
 typedef struct _SensorMeasurements {
     uint32_t time;
@@ -117,6 +158,10 @@ typedef struct _SensorMeasurements {
 #define _VentilationMode_MAX VentilationMode_hfnc
 #define _VentilationMode_ARRAYSIZE ((VentilationMode)(VentilationMode_hfnc+1))
 
+#define _LogEventCode_MIN LogEventCode_fio2_too_low
+#define _LogEventCode_MAX LogEventCode_screen_locked
+#define _LogEventCode_ARRAYSIZE ((LogEventCode)(LogEventCode_screen_locked+1))
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -127,20 +172,34 @@ extern "C" {
 #define AlarmLimitsRequest_init_default          {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define SensorMeasurements_init_default          {0, 0, 0, 0, 0, 0, 0}
 #define CycleMeasurements_init_default           {0, 0, 0, 0, 0, 0, 0}
-#define Parameters_init_default                  {0, _VentilationMode_MIN, 0, 0, 0, 0, 0, 0, 0}
-#define ParametersRequest_init_default           {0, _VentilationMode_MIN, 0, 0, 0, 0, 0, 0, 0}
+#define Parameters_init_default                  {0, _VentilationMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0}
+#define ParametersRequest_init_default           {0, _VentilationMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0}
 #define Ping_init_default                        {0, 0}
 #define Announcement_init_default                {0, {0, {0}}}
+#define LogEvent_init_default                    {0, 0, _LogEventCode_MIN, 0, 0}
+#define ExpectedLogEvent_init_default            {0}
+#define NextLogEvents_init_default               {{{NULL}, NULL}}
+#define ActiveLogEvents_init_default             {{{NULL}, NULL}}
+#define BatteryPower_init_default                {0}
+#define ScreenStatus_init_default                {0}
 #define Alarms_init_zero                         {0, 0, 0}
 #define AlarmLimitsRequest_init_zero             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define SensorMeasurements_init_zero             {0, 0, 0, 0, 0, 0, 0}
 #define CycleMeasurements_init_zero              {0, 0, 0, 0, 0, 0, 0}
-#define Parameters_init_zero                     {0, _VentilationMode_MIN, 0, 0, 0, 0, 0, 0, 0}
-#define ParametersRequest_init_zero              {0, _VentilationMode_MIN, 0, 0, 0, 0, 0, 0, 0}
+#define Parameters_init_zero                     {0, _VentilationMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0}
+#define ParametersRequest_init_zero              {0, _VentilationMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0}
 #define Ping_init_zero                           {0, 0}
 #define Announcement_init_zero                   {0, {0, {0}}}
+#define LogEvent_init_zero                       {0, 0, _LogEventCode_MIN, 0, 0}
+#define ExpectedLogEvent_init_zero               {0}
+#define NextLogEvents_init_zero                  {{{NULL}, NULL}}
+#define ActiveLogEvents_init_zero                {{{NULL}, NULL}}
+#define BatteryPower_init_zero                   {0}
+#define ScreenStatus_init_zero                   {0}
 
 /* Field tags (for use in manual encoding/decoding) */
+#define ActiveLogEvents_id_tag                   1
+#define NextLogEvents_log_events_tag             1
 #define AlarmLimitsRequest_rr_min_tag            1
 #define AlarmLimitsRequest_rr_max_tag            2
 #define AlarmLimitsRequest_pip_min_tag           3
@@ -172,6 +231,7 @@ extern "C" {
 #define Alarms_alarm_two_tag                     3
 #define Announcement_time_tag                    1
 #define Announcement_announcement_tag            2
+#define BatteryPower_power_left_tag              1
 #define CycleMeasurements_time_tag               1
 #define CycleMeasurements_vt_tag                 2
 #define CycleMeasurements_rr_tag                 3
@@ -179,6 +239,12 @@ extern "C" {
 #define CycleMeasurements_pip_tag                5
 #define CycleMeasurements_ip_tag                 6
 #define CycleMeasurements_ve_tag                 7
+#define ExpectedLogEvent_id_tag                  1
+#define LogEvent_id_tag                          1
+#define LogEvent_time_tag                        2
+#define LogEvent_code_tag                        3
+#define LogEvent_oldValue_tag                    4
+#define LogEvent_newValue_tag                    5
 #define Parameters_time_tag                      1
 #define Parameters_mode_tag                      2
 #define Parameters_pip_tag                       3
@@ -188,6 +254,7 @@ extern "C" {
 #define Parameters_ie_tag                        7
 #define Parameters_fio2_tag                      8
 #define Parameters_flow_tag                      9
+#define Parameters_ventilating_tag               10
 #define ParametersRequest_time_tag               1
 #define ParametersRequest_mode_tag               2
 #define ParametersRequest_pip_tag                3
@@ -197,8 +264,10 @@ extern "C" {
 #define ParametersRequest_ie_tag                 7
 #define ParametersRequest_fio2_tag               8
 #define ParametersRequest_flow_tag               9
+#define ParametersRequest_ventilating_tag        10
 #define Ping_time_tag                            1
 #define Ping_id_tag                              2
+#define ScreenStatus_lock_tag                    1
 #define SensorMeasurements_time_tag              1
 #define SensorMeasurements_cycle_tag             2
 #define SensorMeasurements_paw_tag               3
@@ -276,7 +345,8 @@ X(a, STATIC,   SINGULAR, FLOAT,    vt,                5) \
 X(a, STATIC,   SINGULAR, FLOAT,    rr,                6) \
 X(a, STATIC,   SINGULAR, FLOAT,    ie,                7) \
 X(a, STATIC,   SINGULAR, FLOAT,    fio2,              8) \
-X(a, STATIC,   SINGULAR, FLOAT,    flow,              9)
+X(a, STATIC,   SINGULAR, FLOAT,    flow,              9) \
+X(a, STATIC,   SINGULAR, BOOL,     ventilating,      10)
 #define Parameters_CALLBACK NULL
 #define Parameters_DEFAULT NULL
 
@@ -289,7 +359,8 @@ X(a, STATIC,   SINGULAR, FLOAT,    vt,                5) \
 X(a, STATIC,   SINGULAR, FLOAT,    rr,                6) \
 X(a, STATIC,   SINGULAR, FLOAT,    ie,                7) \
 X(a, STATIC,   SINGULAR, FLOAT,    fio2,              8) \
-X(a, STATIC,   SINGULAR, FLOAT,    flow,              9)
+X(a, STATIC,   SINGULAR, FLOAT,    flow,              9) \
+X(a, STATIC,   SINGULAR, BOOL,     ventilating,      10)
 #define ParametersRequest_CALLBACK NULL
 #define ParametersRequest_DEFAULT NULL
 
@@ -305,6 +376,41 @@ X(a, STATIC,   SINGULAR, BYTES,    announcement,      2)
 #define Announcement_CALLBACK NULL
 #define Announcement_DEFAULT NULL
 
+#define LogEvent_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   id,                1) \
+X(a, STATIC,   SINGULAR, UINT32,   time,              2) \
+X(a, STATIC,   SINGULAR, UENUM,    code,              3) \
+X(a, STATIC,   SINGULAR, FLOAT,    oldValue,          4) \
+X(a, STATIC,   SINGULAR, FLOAT,    newValue,          5)
+#define LogEvent_CALLBACK NULL
+#define LogEvent_DEFAULT NULL
+
+#define ExpectedLogEvent_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   id,                1)
+#define ExpectedLogEvent_CALLBACK NULL
+#define ExpectedLogEvent_DEFAULT NULL
+
+#define NextLogEvents_FIELDLIST(X, a) \
+X(a, CALLBACK, REPEATED, MESSAGE,  log_events,        1)
+#define NextLogEvents_CALLBACK pb_default_field_callback
+#define NextLogEvents_DEFAULT NULL
+#define NextLogEvents_log_events_MSGTYPE LogEvent
+
+#define ActiveLogEvents_FIELDLIST(X, a) \
+X(a, CALLBACK, REPEATED, UINT32,   id,                1)
+#define ActiveLogEvents_CALLBACK pb_default_field_callback
+#define ActiveLogEvents_DEFAULT NULL
+
+#define BatteryPower_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   power_left,        1)
+#define BatteryPower_CALLBACK NULL
+#define BatteryPower_DEFAULT NULL
+
+#define ScreenStatus_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, BOOL,     lock,              1)
+#define ScreenStatus_CALLBACK NULL
+#define ScreenStatus_DEFAULT NULL
+
 extern const pb_msgdesc_t Alarms_msg;
 extern const pb_msgdesc_t AlarmLimitsRequest_msg;
 extern const pb_msgdesc_t SensorMeasurements_msg;
@@ -313,6 +419,12 @@ extern const pb_msgdesc_t Parameters_msg;
 extern const pb_msgdesc_t ParametersRequest_msg;
 extern const pb_msgdesc_t Ping_msg;
 extern const pb_msgdesc_t Announcement_msg;
+extern const pb_msgdesc_t LogEvent_msg;
+extern const pb_msgdesc_t ExpectedLogEvent_msg;
+extern const pb_msgdesc_t NextLogEvents_msg;
+extern const pb_msgdesc_t ActiveLogEvents_msg;
+extern const pb_msgdesc_t BatteryPower_msg;
+extern const pb_msgdesc_t ScreenStatus_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
 #define Alarms_fields &Alarms_msg
@@ -323,16 +435,28 @@ extern const pb_msgdesc_t Announcement_msg;
 #define ParametersRequest_fields &ParametersRequest_msg
 #define Ping_fields &Ping_msg
 #define Announcement_fields &Announcement_msg
+#define LogEvent_fields &LogEvent_msg
+#define ExpectedLogEvent_fields &ExpectedLogEvent_msg
+#define NextLogEvents_fields &NextLogEvents_msg
+#define ActiveLogEvents_fields &ActiveLogEvents_msg
+#define BatteryPower_fields &BatteryPower_msg
+#define ScreenStatus_fields &ScreenStatus_msg
 
 /* Maximum encoded size of messages (where known) */
 #define Alarms_size                              10
 #define AlarmLimitsRequest_size                  167
 #define SensorMeasurements_size                  37
 #define CycleMeasurements_size                   36
-#define Parameters_size                          43
-#define ParametersRequest_size                   43
+#define Parameters_size                          45
+#define ParametersRequest_size                   45
 #define Ping_size                                12
 #define Announcement_size                        72
+#define LogEvent_size                            24
+#define ExpectedLogEvent_size                    6
+/* NextLogEvents_size depends on runtime parameters */
+/* ActiveLogEvents_size depends on runtime parameters */
+#define BatteryPower_size                        6
+#define ScreenStatus_size                        2
 
 #ifdef __cplusplus
 } /* extern "C" */
@@ -371,14 +495,14 @@ struct MessageDescriptor<CycleMeasurements> {
 };
 template <>
 struct MessageDescriptor<Parameters> {
-    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 9;
+    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 10;
     static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {
         return &Parameters_msg;
     }
 };
 template <>
 struct MessageDescriptor<ParametersRequest> {
-    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 9;
+    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 10;
     static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {
         return &ParametersRequest_msg;
     }
@@ -395,6 +519,48 @@ struct MessageDescriptor<Announcement> {
     static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 2;
     static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {
         return &Announcement_msg;
+    }
+};
+template <>
+struct MessageDescriptor<LogEvent> {
+    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 5;
+    static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {
+        return &LogEvent_msg;
+    }
+};
+template <>
+struct MessageDescriptor<ExpectedLogEvent> {
+    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 1;
+    static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {
+        return &ExpectedLogEvent_msg;
+    }
+};
+template <>
+struct MessageDescriptor<NextLogEvents> {
+    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 1;
+    static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {
+        return &NextLogEvents_msg;
+    }
+};
+template <>
+struct MessageDescriptor<ActiveLogEvents> {
+    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 1;
+    static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {
+        return &ActiveLogEvents_msg;
+    }
+};
+template <>
+struct MessageDescriptor<BatteryPower> {
+    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 1;
+    static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {
+        return &BatteryPower_msg;
+    }
+};
+template <>
+struct MessageDescriptor<ScreenStatus> {
+    static PB_INLINE_CONSTEXPR const pb_size_t fields_array_length = 1;
+    static PB_INLINE_CONSTEXPR const pb_msgdesc_t* fields() {
+        return &ScreenStatus_msg;
     }
 };
 }  // namespace nanopb

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/ParametersService.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/ParametersService.h
@@ -35,6 +35,9 @@ class HFNCParameters : public ParametersService {
  public:
   void transform(const ParametersRequest &parameters_request, Parameters &parameters) override;
   [[nodiscard]] bool mode_active(const Parameters &parameters) const override;
+
+ private:
+  static constexpr float max_flow = 80;  // L/min
 };
 
 class ParametersServices {

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Application/mcu_pb.c
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Application/mcu_pb.c
@@ -30,5 +30,24 @@ PB_BIND(Ping, Ping, AUTO)
 PB_BIND(Announcement, Announcement, AUTO)
 
 
+PB_BIND(LogEvent, LogEvent, AUTO)
+
+
+PB_BIND(ExpectedLogEvent, ExpectedLogEvent, AUTO)
+
+
+PB_BIND(NextLogEvents, NextLogEvents, AUTO)
+
+
+PB_BIND(ActiveLogEvents, ActiveLogEvents, AUTO)
+
+
+PB_BIND(BatteryPower, BatteryPower, AUTO)
+
+
+PB_BIND(ScreenStatus, ScreenStatus, AUTO)
+
+
+
 
 

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Controller.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Controller.cpp
@@ -24,14 +24,27 @@ void HFNCController::transform(
 
   // Open-loop setpoints
   float flow_o2_ratio = (parameters.fio2 - fio2_min) / (fio2_max - fio2_min);
-  actuator_setpoints.flow_o2 = flow_o2_ratio * parameters.flow;
-  actuator_setpoints.flow_air = parameters.flow - actuator_setpoints.flow_o2;
+  if (parameters.ventilating) {
+    actuator_setpoints.flow_o2 = flow_o2_ratio * parameters.flow;
+    actuator_setpoints.flow_air = parameters.flow - actuator_setpoints.flow_o2;
+  } else {
+    actuator_setpoints.flow_o2 = 0;
+    actuator_setpoints.flow_air = 0;
+  }
 
   // PI Controller
   valve_air_.transform(
       sensor_vars.flow_air, actuator_setpoints.flow_air, actuator_vars.valve_air_opening);
   valve_o2_.transform(
       sensor_vars.flow_o2, actuator_setpoints.flow_o2, actuator_vars.valve_o2_opening);
+
+  // Override for closed valve
+  if (actuator_setpoints.flow_o2 == 0) {
+    actuator_vars.valve_o2_opening = 0;
+  }
+  if (actuator_setpoints.flow_air == 0) {
+    actuator_vars.valve_air_opening = 0;
+  }
 }
 
 }  // namespace Pufferfish::Driver::BreathingCircuit

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/ParametersService.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/ParametersService.cpp
@@ -26,6 +26,7 @@ void PCACParameters::transform(
     return;
   }
 
+  parameters.ventilating = parameters_request.ventilating;
   if (parameters_request.rr > 0) {
     parameters.rr = parameters_request.rr;
   }
@@ -52,7 +53,8 @@ void HFNCParameters::transform(
     return;
   }
 
-  if (parameters_request.flow >= 0) {
+  parameters.ventilating = parameters_request.ventilating;
+  if (parameters_request.flow >= 0 && parameters_request.flow <= max_flow) {
     parameters.flow = parameters_request.flow;
   }
   transform_fio2(parameters_request.fio2, parameters.fio2);

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Simulator.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Simulator.cpp
@@ -46,7 +46,7 @@ void PCACSimulator::transform(
     return;
   }
 
-  if (parameters.mode != VentilationMode_pc_ac) {
+  if (!parameters.ventilating || parameters.mode != VentilationMode_pc_ac) {
     return;
   }
 
@@ -114,7 +114,7 @@ void HFNCSimulator::transform(
     return;
   }
 
-  if (parameters.mode != VentilationMode_hfnc) {
+  if (!parameters.ventilating || parameters.mode != VentilationMode_hfnc) {
     return;
   }
 

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -476,7 +476,9 @@ int main(void)
 
   // Hardware PWMs
   drive1_ch1.start();
+  drive1_ch1.set_duty_cycle_raw(0);
   drive1_ch2.start();
+  drive1_ch2.set_duty_cycle_raw(0);
 
   // Software PWMs
   blinker.start(time.millis());

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -555,20 +555,21 @@ int main(void)
 
     // Breathing Circuit Control Loop
     hfnc.update(current_time);
+
     // Indicators for debugging
-    /*static constexpr float valve_opening_indicator_threshold = 0.5;
+    static constexpr float valve_opening_indicator_threshold = 0.00001;
     if (hfnc.actuator_vars().valve_air_opening > valve_opening_indicator_threshold) {
-      board_led1.write(true);
-    } else {
       board_led1.write(dimmer.output());
-    }*/
-    if (hfnc.sensor_vars().flow_o2 > 1 || hfnc.sensor_vars().flow_air > 1) {
+    } else {
+      board_led1.write(false);
+    }
+    /*if (hfnc.sensor_vars().flow_o2 > 1 || hfnc.sensor_vars().flow_air > 1) {
       board_led1.write(true);
     } else if (hfnc.sensor_vars().flow_o2 < -1 || hfnc.sensor_vars().flow_air < -1) {
       board_led1.write(dimmer.output());
     } else {
       board_led1.write(false);
-    }
+    }*/
 
     // Backend Communication Protocol
     backend.receive();


### PR DESCRIPTION
This PR:

- Makes the firmware use the `ParametersRequest.ventilating` field to determine whether to run the simulator and control loop.
- Changes PI controller setpoints to 0 when the the `ventilating` field is set to `false`.
- Overrides the PI controller to close the valves when flow rate setpoint is 0 L/min.
- Makes the backend application turn off ventilation at startup, regardless of what the value of `ParametersRequest` loaded from file is. This is only a workaround and is undesirable behavior, we will need to fix this later (in fact we might just eventually want to use the value of `ParametersRequest` from file, since the `ventilation` flag should be set to off with a clean shutdown of the RPi or a clean close of the backend program).