### PR TITLE
Frontend is killed when the modal is operated or frontend is idle.

### DIFF
--- a/backend/ventserver/protocols/server.py
+++ b/backend/ventserver/protocols/server.py
@@ -118,6 +118,7 @@ class FrontendKillProps():
     fe_connected: bool = attr.ib(default=False)
     fe_connection_time: float = attr.ib(default=0)
     last_fe_kill: float = attr.ib(factory=_time.time)
+    fe_delayed_duration: int = attr.ib(default=5)
 
 
 # Filters
@@ -192,7 +193,8 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, ReceiveOutputEvent]):
         # Kill frontend process if it stops responding.
         # The frontend service will automatically restart the frontend process.
         delayed = False
-        if int(self.current_time - self._kill_props.last_fe_event) > 1:
+        if int(self.current_time - self._kill_props.last_fe_event) >\
+            self._kill_props.fe_delayed_duration:
             if int(self.current_time - self._kill_props.last_fe_kill) > 2:
                 connection_duration = int(
                     self.current_time - self._kill_props.fe_connection_time


### PR DESCRIPTION
Increased duration for which the backend will wait for last frontend message. This PR needs to be tested before merging.