### PR TITLE
Refactor the frontend communication protocol implementation

### DIFF
--- a/backend/ventserver/integration/_trio.py
+++ b/backend/ventserver/integration/_trio.py
@@ -256,7 +256,7 @@ async def process_io_persistently(
         nursery: trio.Nursery,
         channel: triochannels.TrioChannel[server.ReceiveOutputEvent],
         push_endpoint: 'trio.MemorySendChannel[server.ReceiveOutputEvent]',
-        reconnect_interval: float = 0.001
+        reconnect_interval: float = 0.01
 ) -> None:
     """Process all traffic on the I/O endpoint and reconnect on broken pipes.
 

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
         "prettier/prettier": "error",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/no-unused-vars": "off",
+        "no-console": ["error", {"allow": ["warn", "error"]}],
         "react/jsx-filename-extension": [
             1,
             { "extensions": [".js", ".jsx", ".ts", ".tsx"] }

--- a/frontend/src/spec/step-definitions/alarm-modal.steps.tsx
+++ b/frontend/src/spec/step-definitions/alarm-modal.steps.tsx
@@ -10,10 +10,6 @@ import { AlarmModal } from '../../modules/controllers';
 import { darkTheme } from '../../styles/customTheme';
 import { updateCommittedState } from '../../store/controller/actions';
 import { ALARM_LIMITS, commitAction } from '../../store/controller/types';
-import controllerSaga, {
-  initConnectionPersistently,
-  updateClock,
-} from '../../store/controller/saga';
 import { INITIALIZED } from '../../store/app/types';
 
 const feature = loadFeature('src/spec/features/alarm-modal.feature');

--- a/frontend/src/spec/step-definitions/saga.steps.tsx
+++ b/frontend/src/spec/step-definitions/saga.steps.tsx
@@ -2,10 +2,8 @@ import { loadFeature, defineFeature } from 'jest-cucumber';
 import { h } from 'preact';
 import * as React from 'react';
 import { delay, takeEvery, takeLatest } from 'redux-saga/effects';
-import controllerSaga, {
-  initConnectionPersistently,
-  updateClock,
-} from '../../store/controller/saga';
+import controllerSaga, { serviceConnectionPersistently } from '../../store/controller/saga';
+import updateClock from '../../store/controller/io/clock';
 import { INITIALIZED } from '../../store/app/types';
 
 const feature = loadFeature('src/spec/features/saga.feature');
@@ -20,12 +18,12 @@ defineFeature(feature, (test) => {
 
     when(/^Saga workers are defined$/, async () => {
       expect(controllerSaga).toBeDefined();
-      expect(initConnectionPersistently).toBeDefined();
+      expect(serviceConnectionPersistently).toBeDefined();
       expect(updateClock).toBeDefined();
     });
 
     then(/^Saga should run workers for socket connection & clock$/, () => {
-      expect(genObject.next().value).toEqual(takeEvery(INITIALIZED, initConnectionPersistently));
+      expect(genObject.next().value).toEqual(takeEvery(INITIALIZED, serviceConnectionPersistently));
       expect(genObject.next().value).toEqual(takeLatest(INITIALIZED, updateClock));
     });
   });

--- a/frontend/src/store/controller/io/clock.ts
+++ b/frontend/src/store/controller/io/clock.ts
@@ -1,0 +1,9 @@
+import { put, delay } from 'redux-saga/effects';
+import { CLOCK_UPDATED } from '../../app/types';
+
+export default function* updateClock(updateInterval = 1000): IterableIterator<unknown> {
+  while (true) {
+    yield delay(updateInterval);
+    yield put({ type: CLOCK_UPDATED });
+  }
+}

--- a/frontend/src/store/controller/io/websocket.ts
+++ b/frontend/src/store/controller/io/websocket.ts
@@ -1,0 +1,64 @@
+import { eventChannel, EventChannel } from 'redux-saga';
+import { call, take, delay, apply, CallEffect, TakeEffect } from 'redux-saga/effects';
+
+export const createConnectionChannel = (host = 'localhost', port = 8000): EventChannel<unknown> => {
+  return eventChannel((emit) => {
+    const sock = new WebSocket(`ws://${host}:${port}/`);
+    sock.onerror = (err) => emit({ err, sock: null });
+    sock.onopen = (event) => emit({ err: null, sock });
+    sock.onclose = (event) => emit({ err: 'Closing!', sock });
+    return () => {
+      // console.log('Closing WebSocket...');
+      sock.close();
+    };
+  });
+};
+
+export const createReceiveChannel = (sock: WebSocket): EventChannel<unknown> => {
+  const sockCopy = sock;
+  return eventChannel((emit) => {
+    sockCopy.onmessage = (message) => emit(message.data);
+    return () => {
+      sockCopy.close();
+    };
+  });
+};
+
+export function* sendBuffer(
+  sock: WebSocket,
+  buffer: Uint8Array | undefined,
+): Generator<CallEffect<void>, void, unknown> {
+  if (buffer === undefined) {
+    return;
+  }
+
+  yield apply(sock, sock.send, [buffer]);
+}
+
+export interface Connection {
+  sock: WebSocket;
+  connectionChannel: EventChannel<unknown>;
+}
+
+export function* setupConnection(
+  retryInterval = 10,
+): Generator<
+  CallEffect<true | EventChannel<unknown>> | TakeEffect | CallEffect<true>,
+  // The Generator type is templated and so complicated that we can't specify its type.
+  // eslint-disable @typescript-eslint/no-explicit-any
+  any,
+  // The Generator type is templated and so complicated that we can't specify its type.
+  // eslint-disable @typescript-eslint/no-explicit-any
+  any
+> {
+  while (true) {
+    const connectionChannel = yield call(createConnectionChannel);
+    const connection = yield take(connectionChannel);
+    if (connection.err == null) {
+      return { sock: connection.sock, connectionChannel };
+    }
+    // console.warn('WebSocket connection error', connection.err)
+    yield delay(retryInterval);
+  }
+  // console.log('Connected to WebSocket!');
+}

--- a/frontend/src/store/controller/io/websocket.ts
+++ b/frontend/src/store/controller/io/websocket.ts
@@ -32,6 +32,12 @@ export const createReceiveChannel = (sock: WebSocket): EventChannel<Response> =>
   });
 };
 
+export function* receiveBuffer(
+  response: Response,
+): Generator<Promise<ArrayBuffer>, Uint8Array, Iterable<number>> {
+  return new Uint8Array(yield response.arrayBuffer());
+}
+
 export function* sendBuffer(
   sock: WebSocket,
   buffer: Uint8Array | undefined,

--- a/frontend/src/store/controller/protocols/backend.ts
+++ b/frontend/src/store/controller/protocols/backend.ts
@@ -1,0 +1,28 @@
+import { PBMessageType } from '../types';
+import { MessageSelectors } from '../selectors';
+import { MessageSerializer, MessageSerializers } from './messages';
+
+export interface StateProcessor {
+  // This "any" is needed because MessageSelectors has a value type of "any".
+  // Refer to the "Dynamic Dispatch" section of ./selectors to justify the use
+  // of any in MessageSelectors.
+  // eslint-disable @typescript-eslint/no-explicit-any
+  selector: any;
+  serializer: MessageSerializer;
+}
+
+export const getStateProcessor = (pbMessageType: PBMessageType): StateProcessor | undefined => {
+  const selector = MessageSelectors.get(pbMessageType);
+  if (selector === undefined) {
+    // TODO: raise an exception instead?
+    return undefined;
+  }
+
+  const serializer = MessageSerializers.get(pbMessageType);
+  if (serializer === undefined) {
+    // TODO: raise an exception instead?
+    return undefined;
+  }
+
+  return { selector, serializer };
+};

--- a/frontend/src/store/controller/protocols/backend.ts
+++ b/frontend/src/store/controller/protocols/backend.ts
@@ -1,27 +1,47 @@
 import { PBMessageType } from '../types';
-import { MessageSelectors } from '../selectors';
-import { MessageSerializer, MessageSerializers } from './messages';
+import { getParametersRequest, getAlarmLimitsRequest, getExpectedLogEvent } from '../selectors';
+import { MessageSerializer, serializeMessage } from './messages';
+import { Schedule } from './states';
+import { ParametersRequest, AlarmLimitsRequest, ExpectedLogEvent } from '../proto/mcu_pb';
+
+export const initialSendSchedule: Schedule = [
+  { time: 50, pbMessageType: ParametersRequest },
+  { time: 50, pbMessageType: AlarmLimitsRequest },
+  { time: 50, pbMessageType: ExpectedLogEvent },
+];
+
+export const MessageSerializers = new Map<PBMessageType, MessageSerializer>([
+  [AlarmLimitsRequest, serializeMessage<AlarmLimitsRequest>(AlarmLimitsRequest)],
+  [ParametersRequest, serializeMessage<ParametersRequest>(ParametersRequest)],
+  [ExpectedLogEvent, serializeMessage<ExpectedLogEvent>(ExpectedLogEvent)],
+]);
+
+// The OutputSelector type is templated and so complicated that it's not clear
+// whether we can specify its type in a Map, but for now we'll just delegate the
+// responsibility of using types correctly to the calling code.
+// eslint-disable @typescript-eslint/no-explicit-any
+export const MessageSelectors = new Map<PBMessageType, any>([
+  [AlarmLimitsRequest, getAlarmLimitsRequest],
+  [ParametersRequest, getParametersRequest],
+  [ExpectedLogEvent, getExpectedLogEvent],
+]);
 
 export interface StateProcessor {
   // This "any" is needed because MessageSelectors has a value type of "any".
-  // Refer to the "Dynamic Dispatch" section of ./selectors to justify the use
-  // of any in MessageSelectors.
   // eslint-disable @typescript-eslint/no-explicit-any
   selector: any;
   serializer: MessageSerializer;
 }
 
-export const getStateProcessor = (pbMessageType: PBMessageType): StateProcessor | undefined => {
+export const getStateProcessor = (pbMessageType: PBMessageType): StateProcessor => {
   const selector = MessageSelectors.get(pbMessageType);
   if (selector === undefined) {
-    // TODO: raise an exception instead?
-    return undefined;
+    throw new Error(`Backend: missing selector for ${pbMessageType}`);
   }
 
   const serializer = MessageSerializers.get(pbMessageType);
   if (serializer === undefined) {
-    // TODO: raise an exception instead?
-    return undefined;
+    throw new Error(`Backend: missing message serializer for ${pbMessageType}`);
   }
 
   return { selector, serializer };

--- a/frontend/src/store/controller/protocols/messages.ts
+++ b/frontend/src/store/controller/protocols/messages.ts
@@ -1,0 +1,51 @@
+import { BufferReader } from 'protobufjs/minimal';
+import { MessageClass, MessageTypes, PBMessage, PBMessageType } from '../types';
+import { ParametersRequest, AlarmLimitsRequest } from '../proto/mcu_pb';
+import { updateState } from '../actions';
+
+export interface MessageParseResults {
+  messageType: number;
+  pbMessage: PBMessage;
+}
+
+export const deserializeMessage = (body: Uint8Array): MessageParseResults | undefined => {
+  const messageType = body[0];
+  const messageBody = body.slice(1);
+  const messageBodyReader = new BufferReader(messageBody);
+  const messageClass = MessageClass.get(messageType);
+  if (messageClass === undefined) {
+    // TODO: raise an exception instead?
+    return undefined;
+  }
+
+  const pbMessage = messageClass.decode(messageBodyReader);
+  return { messageType, pbMessage };
+};
+
+export const serializeMessage = <T extends PBMessage>(pbMessageType: PBMessageType) => (
+  pbMessage: PBMessage,
+): Uint8Array | undefined => {
+  const messageType = MessageTypes.get(pbMessageType);
+  if (messageType === undefined) {
+    // TODO: raise an exception instead?
+    return undefined;
+  }
+
+  // It's not clear whether there is any reasonable way to make the types work
+  // here. A fundamentally different design might make it possible to have
+  // specified types for pbMessageType, but for now we'll just delegate the
+  // responsibility of using types correctly to the calling code.
+  // eslint-disable @typescript-eslint/no-explicit-any
+  const messageBody = (pbMessageType as any).encode(pbMessage as T).finish();
+  const buffer = new Uint8Array(1 + messageBody.length);
+  buffer.set([messageType], 0);
+  buffer.set(messageBody, 1);
+  return buffer;
+};
+
+// Dynamic dispatch
+export type MessageSerializer = (pbMessage: PBMessage) => Uint8Array | undefined;
+export const MessageSerializers = new Map<PBMessageType, MessageSerializer>([
+  [AlarmLimitsRequest, serializeMessage<AlarmLimitsRequest>(AlarmLimitsRequest)],
+  [ParametersRequest, serializeMessage<ParametersRequest>(ParametersRequest)],
+]);

--- a/frontend/src/store/controller/protocols/states.ts
+++ b/frontend/src/store/controller/protocols/states.ts
@@ -1,0 +1,20 @@
+import { PBMessageType } from '../types';
+
+// Send state update scheduling
+
+export interface ScheduleEntry {
+  time: number;
+  pbMessageType: PBMessageType;
+}
+
+export type Schedule = Array<ScheduleEntry>;
+
+// Note: this function mutates the input array
+export const advanceSchedule = (schedule: Schedule): ScheduleEntry => {
+  const entry = schedule.shift();
+  if (entry === undefined) {
+    throw new Error('State Synchronization: invalid schedule');
+  }
+  schedule.push(entry);
+  return entry;
+};

--- a/frontend/src/store/controller/reducers.ts
+++ b/frontend/src/store/controller/reducers.ts
@@ -13,7 +13,7 @@ import { waveformHistoryReducer, pvHistoryReducer } from './reducers/derived';
 import {
   alarmLimitsReducer,
   alarmLimitsRequestStandbyReducer,
-  expectedLoggedEventReducer,
+  expectedLogEventReducer,
   frontendDisplaySettingReducer,
   parametersRequestReducer,
   parametersRequestStanbyReducer,
@@ -29,7 +29,7 @@ export const controllerReducer = combineReducers({
   parametersRequestStandby: parametersRequestStanbyReducer,
   systemSettingRequest: systemSettingRequestReducer,
   frontendDisplaySetting: frontendDisplaySettingReducer,
-  expectedLoggedEvent: expectedLoggedEventReducer,
+  expectedLogEvent: expectedLogEventReducer,
   nextLogEvents: nextLogEventsReducer,
   batteryPower: messageReducer<BatteryPower>(MessageType.BatteryPower, BatteryPower),
   screenStatus: messageReducer<ScreenStatus>(MessageType.ScreenStatus, ScreenStatus),

--- a/frontend/src/store/controller/reducers/components.ts
+++ b/frontend/src/store/controller/reducers/components.ts
@@ -119,7 +119,7 @@ export const frontendDisplaySettingReducer = (
   return withRequestUpdate<FrontendDisplaySetting>(state, action, FRONTEND_DISPLAY_SETTINGS);
 };
 
-export const expectedLoggedEventReducer = (
+export const expectedLogEventReducer = (
   state: ExpectedLogEvent = ExpectedLogEvent.fromJSON({
     id: 0,
   }) as ExpectedLogEvent,

--- a/frontend/src/store/controller/saga.ts
+++ b/frontend/src/store/controller/saga.ts
@@ -16,11 +16,11 @@ import { updateState } from './actions';
 import { deserializeMessage } from './protocols/messages';
 import { advanceSchedule } from './protocols/states';
 import { getStateProcessor, initialSendSchedule } from './protocols/backend';
-import { createReceiveChannel, sendBuffer, setupConnection, } from './io/websocket';
+import { createReceiveChannel, receiveBuffer, sendBuffer, setupConnection } from './io/websocket';
 import updateClock from './io/clock';
 
 function* deserializeResponse(response: Response) {
-  const buffer = new Uint8Array(yield response.arrayBuffer());
+  const buffer = yield receiveBuffer(response);
   return deserializeMessage(buffer);
 }
 
@@ -54,7 +54,6 @@ function* sendAll(sock: WebSocket) {
     yield sendState(sock, pbMessageType);
     yield delay(time);
   }
-  // console.log('Websocket is no longer open!');
 }
 
 function* serviceConnection() {
@@ -69,7 +68,7 @@ function* serviceConnection() {
 export function* serviceConnectionPersistently(): IterableIterator<unknown> {
   while (true) {
     yield serviceConnection();
-    // console.log('Reestablishing WebSocket connection...');
+    console.warn('Reestablishing WebSocket connection...');
   }
 }
 

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -283,13 +283,3 @@ export const getScreenStatus = createSelector(
   getController,
   (states: ControllerStates): boolean => states.screenStatus.lock,
 );
-
-// Dynamic dispatch
-// The OutputSelector type is templated and so complicated that it's not clear
-// whether we can specify its type in a Map, but for now we'll just delegate the
-// responsibility of using types correctly to the calling code.
-// eslint-disable @typescript-eslint/no-explicit-any
-export const MessageSelectors = new Map<PBMessageType, any>([
-  [AlarmLimitsRequest, getAlarmLimitsRequest],
-  [ParametersRequest, getParametersRequest],
-]);

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -14,6 +14,7 @@ import {
 } from './proto/mcu_pb';
 import { RotaryEncoder, FrontendDisplaySetting, SystemSettingRequest } from './proto/frontend_pb';
 import {
+  PBMessageType,
   ControllerStates,
   WaveformPoint,
   WaveformHistory,
@@ -282,3 +283,13 @@ export const getScreenStatus = createSelector(
   getController,
   (states: ControllerStates): boolean => states.screenStatus.lock,
 );
+
+// Dynamic dispatch
+// The OutputSelector type is templated and so complicated that it's not clear
+// whether we can specify its type in a Map, but for now we'll just delegate the
+// responsibility of using types correctly to the calling code.
+// eslint-disable @typescript-eslint/no-explicit-any
+export const MessageSelectors = new Map<PBMessageType, any>([
+  [AlarmLimitsRequest, getAlarmLimitsRequest],
+  [ParametersRequest, getParametersRequest],
+]);

--- a/frontend/src/store/controller/types.ts
+++ b/frontend/src/store/controller/types.ts
@@ -41,23 +41,21 @@ export interface RotaryEncoderParameter {
 
 export type PBMessage =
   // mcu_pb
-  | AlarmLimits
-  | AlarmLimitsRequest
   | Alarms
   | SensorMeasurements
   | CycleMeasurements
   | Parameters
   | ParametersRequest
-  | LogEvent
+  | AlarmLimits
+  | AlarmLimitsRequest
   | ExpectedLogEvent
   | NextLogEvents
   | ActiveLogEvents
+  // frontend_pb
   | BatteryPower
   | ScreenStatus
-  // frontend_pb
   | SystemSettingRequest
   | FrontendDisplaySetting
-  | RotaryEncoderParameter
   | RotaryEncoder;
 
 export type PBMessageType =
@@ -69,16 +67,18 @@ export type PBMessageType =
   | typeof CycleMeasurements
   | typeof Parameters
   | typeof ParametersRequest
+  | typeof ExpectedLogEvent
   | typeof NextLogEvents
   | typeof ActiveLogEvents
+  // frontend_pb
   | typeof BatteryPower
   | typeof ScreenStatus
-  // frontend_pb
   | typeof SystemSettingRequest
   | typeof FrontendDisplaySetting
   | typeof RotaryEncoder;
 
 export enum MessageType {
+  // mcu_pb
   Alarms = 1,
   SensorMeasurements = 2,
   CycleMeasurements = 3,
@@ -89,6 +89,7 @@ export enum MessageType {
   ExpectedLogEvent = 8,
   NextLogEvents = 9,
   ActiveLogEvents = 10,
+  // frontend_pb
   BatteryPower = 64,
   ScreenStatus = 65,
   RotaryEncoder = 128,
@@ -156,30 +157,42 @@ export interface ControllerStates {
 }
 
 export const MessageClass = new Map<MessageType, PBMessageType>([
+  // mcu_pb
   [MessageType.Alarms, Alarms],
-  [MessageType.AlarmLimitsRequest, AlarmLimitsRequest],
-  [MessageType.SystemSettingRequest, SystemSettingRequest],
-  [MessageType.FrontendDisplaySetting, FrontendDisplaySetting],
   [MessageType.SensorMeasurements, SensorMeasurements],
   [MessageType.CycleMeasurements, CycleMeasurements],
   [MessageType.Parameters, Parameters],
   [MessageType.ParametersRequest, ParametersRequest],
+  [MessageType.AlarmLimits, AlarmLimits],
+  [MessageType.AlarmLimitsRequest, AlarmLimitsRequest],
+  [MessageType.ExpectedLogEvent, ExpectedLogEvent],
   [MessageType.NextLogEvents, NextLogEvents],
   [MessageType.ActiveLogEvents, ActiveLogEvents],
+  // frontend_pb
+  [MessageType.BatteryPower, BatteryPower],
+  [MessageType.ScreenStatus, ScreenStatus],
+  [MessageType.SystemSettingRequest, SystemSettingRequest],
+  [MessageType.FrontendDisplaySetting, FrontendDisplaySetting],
   [MessageType.RotaryEncoder, RotaryEncoder],
 ]);
 
 export const MessageTypes = new Map<PBMessageType, MessageType>([
+  // mcu_pb
   [Alarms, MessageType.Alarms],
-  [AlarmLimitsRequest, MessageType.AlarmLimitsRequest],
-  [SystemSettingRequest, MessageType.SystemSettingRequest],
-  [FrontendDisplaySetting, MessageType.FrontendDisplaySetting],
   [SensorMeasurements, MessageType.SensorMeasurements],
   [CycleMeasurements, MessageType.CycleMeasurements],
   [Parameters, MessageType.Parameters],
   [ParametersRequest, MessageType.ParametersRequest],
+  [AlarmLimits, MessageType.AlarmLimits],
+  [AlarmLimitsRequest, MessageType.AlarmLimitsRequest],
+  [ExpectedLogEvent, MessageType.ExpectedLogEvent],
   [NextLogEvents, MessageType.NextLogEvents],
   [ActiveLogEvents, MessageType.ActiveLogEvents],
+  // frontend_pb
+  [BatteryPower, MessageType.BatteryPower],
+  [ScreenStatus, MessageType.ScreenStatus],
+  [SystemSettingRequest, MessageType.SystemSettingRequest],
+  [FrontendDisplaySetting, MessageType.FrontendDisplaySetting],
   [RotaryEncoder, MessageType.RotaryEncoder],
 ]);
 


### PR DESCRIPTION
This PR addresses #235 by:

- Moving the message serialization/deserialization implementation into a separate file
- Adding a prototype implementation of the state synchronization protocol, in a separate file
- Moving websocket connection and send/receive logic into a separate file

This PR does not:
- Decompose the list synchronization protocol implementation into a separate file (let's do this in a separate PR)