### PR TITLE
Fix modernize-make-unique/shared IncludeStyle options

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -117,30 +117,6 @@ jobs:
       run: |
         ./clang-tidy-all.sh Clang
 
-  clang-tidy-11:
-    runs-on: ubuntu-20.04
-
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get install gcc-arm-none-eabi cmake
-        sudo apt-get remove -y libllvm10
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository -y -s 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
-        sudo apt-get update
-        sudo apt-get install clang-tidy-11
-
-    - name: Run CMake
-      run: |
-        ./cmake.sh Clang /usr/lib /usr/bin
-
-    - name: Run clang-tidy
-      run: |
-        alias clang-tidy="clang-tidy-11"
-        ./clang-tidy-all.sh Clang
-
   catch2-clang-tidy:
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -138,6 +138,7 @@ jobs:
 
     - name: Run clang-tidy
       run: |
+        alias clang-tidy="clang-tidy-11"
         ./clang-tidy-all.sh Clang
 
   catch2-clang-tidy:

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -117,6 +117,29 @@ jobs:
       run: |
         ./clang-tidy-all.sh Clang
 
+  clang-tidy-11:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install gcc-arm-none-eabi cmake
+        sudo apt-get remove -y libllvm10
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository -y -s 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
+        sudo apt-get update
+        sudo apt-get install clang-tidy-11
+
+    - name: Run CMake
+      run: |
+        ./cmake.sh Clang /usr/lib /usr/bin
+
+    - name: Run clang-tidy
+      run: |
+        ./clang-tidy-all.sh Clang
+
   catch2-clang-tidy:
     runs-on: ubuntu-20.04
 

--- a/firmware/ventilator-controller-stm32/.clang-tidy
+++ b/firmware/ventilator-controller-stm32/.clang-tidy
@@ -255,7 +255,7 @@ CheckOptions:
   - key:             modernize-make-shared.IgnoreMacros
     value:           '1'
   - key:             modernize-make-shared.IncludeStyle
-    value:           '0'
+    value:           llvm
   - key:             modernize-make-shared.MakeSmartPtrFunction
     value:           'std::make_shared'
   - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
@@ -263,7 +263,7 @@ CheckOptions:
   - key:             modernize-make-unique.IgnoreMacros
     value:           '1'
   - key:             modernize-make-unique.IncludeStyle
-    value:           '0'
+    value:           llvm
   - key:             modernize-make-unique.MakeSmartPtrFunction
     value:           'std::make_unique'
   - key:             modernize-make-unique.MakeSmartPtrFunctionHeader

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/FDO2/Commands.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/FDO2/Commands.cpp
@@ -72,6 +72,8 @@ template <>
 ParseStatus parse<Vers>(const ChunkBuffer &input_buffer, Vers &response) {
   const char *end = input_buffer.buffer() + input_buffer.size() - 1;
   const char *parse_start = input_buffer.buffer() + Headers::length;
+  // clang-tidy 12 generates a false positive that this declares a variable of type va_list
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
   char *parse_end = nullptr;
   if (*parse_start != arg_delimiter) {
     return ParseStatus::invalid_arg_delimiter;
@@ -135,6 +137,8 @@ template <>
 ParseStatus parse<Mraw>(const ChunkBuffer &input_buffer, Mraw &response) {
   const char *end = input_buffer.buffer() + input_buffer.size() - 1;
   const char *parse_start = input_buffer.buffer() + Headers::length;
+  // clang-tidy 12 generates a false positive that this declares a variable of type va_list
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
   char *parse_end = nullptr;
   if (*parse_start != arg_delimiter) {
     return ParseStatus::invalid_arg_delimiter;
@@ -255,6 +259,8 @@ template <>
 ParseStatus parse<Bcst>(const ChunkBuffer &input_buffer, Bcst &response) {
   const char *end = input_buffer.buffer() + input_buffer.size() - 1;
   const char *parse_start = input_buffer.buffer() + Headers::length;
+  // clang-tidy 12 generates a false positive that this declares a variable of type va_list
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
   char *parse_end = nullptr;
   if (*parse_start != arg_delimiter) {
     return ParseStatus::invalid_arg_delimiter;
@@ -281,6 +287,8 @@ template <>
 ParseStatus parse<Erro>(const ChunkBuffer &input_buffer, Erro &response) {
   const char *end = input_buffer.buffer() + input_buffer.size() - 1;
   const char *parse_start = input_buffer.buffer() + Headers::length;
+  // clang-tidy 12 generates a false positive that this declares a variable of type va_list
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
   char *parse_end = nullptr;
   if (*parse_start != arg_delimiter) {
     return ParseStatus::invalid_arg_delimiter;

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -302,7 +302,7 @@ int main(void)
 
   // Driver for Interface Board Buttons
   PF::Driver::Button::Debouncer switch_debounce;
-  PF::Driver::Button::EdgeDetector switch_transition;
+  // PF::Driver::Button::EdgeDetector switch_transition;
   PF::Driver::Button::Button button_membrane(button_alarm_en, switch_debounce, time);
 
   // Driver for Solenoid Valves
@@ -424,7 +424,7 @@ int main(void)
   PF::Driver::Serial::Nonin::Sensor nonin_oem(nonin_oem_dev);
 
   // Application State
-  PF::Application::States all_states;
+  PF::Application::States all_states{};
 
   // Driver for Breathing Circuit
   PF::Driver::BreathingCircuit::ParametersServices parameters_service;
@@ -452,10 +452,11 @@ int main(void)
   // Initializables
   auto initializables = PF::Util::make_array<std::reference_wrapper<PF::Driver::Initializable>>(
       sfm3019_air, sfm3019_o2, fdo2, nonin_oem);
-  std::array<PF::InitializableState, initializables.size()> initialization_states;
+  std::array<PF::InitializableState, initializables.size()> initialization_states{};
+  initialization_states.fill(PF::InitializableState::setup);
 
-  int interface_test_state = 0;
-  int interface_test_millis = time.millis();
+  // int interface_test_state = 0;
+  // int interface_test_millis = time.millis();
 
   /* USER CODE END 2 */
 

--- a/firmware/ventilator-controller-stm32/README.md
+++ b/firmware/ventilator-controller-stm32/README.md
@@ -22,7 +22,10 @@ Then you'll need to rename those files back in order to recompile the project:
 
 ## Auto-Formatting
 
-To automatically format all code using clang-format, first install `clang-format`.
+To automatically format all code using clang-format, first install `clang-format`
+at version 10 (which should be the default on Ubuntu 20.04). On macOS with Homebrew
+set up, it will be easiest to install LLVM using Homebrew;, you may not be able to
+install llvm at version 10, in which case you should install it at verson 11 instead.
 
 Then, from this directory, run the `clang-format-all.sh` script with the usual
 options for clang-format (though note that this script will use the configuration
@@ -74,12 +77,16 @@ Clang-based tools), first install `cmake`.
 
 Then find the path where the GCC arm-none-eabi toolchain is available (if you have
 not already installed it into somewhere accessible from the shell), and add it to
-your shell's path. For example, you might have this toolchain provided by the
+your shell's path. For example, on Ubuntu 20.04 you might have this toolchain provided by the
 STM32Cube IDE at
 `/opt/st/stm32cubeide_1.3.0/plugins/com.st.stm32cube.ide.mcu.externaltools.gnu-tools-for-stm32.7-2018-q2-update.linux64_1.0.0.201904181610/tools/bin/`
 in which case you can save it into the `TOOLCHAIN_PATH` variable:
 ```
 TOOLCHAIN_PATH="/opt/st/stm32cubeide_1.3.0/plugins/com.st.stm32cube.ide.mcu.externaltools.gnu-tools-for-stm32.7-2018-q2-update.linux64_1.0.0.201904181610/tools"
+```
+while on macOS you might need to use a different value:
+```
+TOOLCHAIN_PATH="/Applications/STM32CubeIDE.app/Contents/Eclipse/plugins/com.st.stm32cube.ide.mcu.externaltools.gnu-tools-for-stm32.7-2018-q2-update.macos64_1.4.0.202007081208/tools"
 ```
 
 To build the project in debug mode with four build threads (and to generate a
@@ -123,7 +130,9 @@ scan-build make -j4
 ```
 
 Note that on Ubuntu 20.04, you may need to install `clang-tools-10` instead of
-`clang-tools`.
+`clang-tools`. On macOS with a Homebrew installation of LLVM, you may not be able
+to install llvm at version 10, in which case you should install it at
+verson 11 instead.
 
 ### Clang-tidy
 
@@ -138,7 +147,9 @@ use CMake to generate a compile commands database for the Clang build type
 Note that this script will delete and rebuild the `cmake-build-debug` directory
 if it already exists, and then it will run clang-tidy to report all warnings.
 Note that on Ubuntu 20.04, you may need to install `clang-tidy-10` instead of
-`clang-tidy`.
+`clang-tidy`. On macOS with a Homebrew installation of LLVM, you may not be able
+to install llvm at version 10, in which case you should install it at
+verson 11 instead.
 
 You can also pass the `clang-tidy-all.sh` script the normal arguments for clang-tidy,
 though you should not use `--` in the arguments (this causes clang-tidy to ignore


### PR DESCRIPTION
This PR:
- Fixes the [`modernize-make-shared.IncludeStyle`](https://releases.llvm.org/10.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-make-shared.html) and [`modernize-make-unique.IncludeStyle`](https://releases.llvm.org/10.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize-make-unique.html) options by changing them from `'0'` (which is not a valid value) to `llvm` (which is the default value). For some reason, clang-tidy 10 did not complain about this problem, but clang-tidy 11 does.
- Makes the `.clang-tidy` configuration compatible with clang-tidy 11
- Suppresses a few false positives from clang-tidy 11
- Reorganizes the declaration of variables in the firmware's `main.cpp` by moving the declaration of non-const global variables into the body of the `main` function wherever possible.