### PR TITLE
Trigger repo-wide checks when needed

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,6 +4,12 @@ on:
   push:
     paths:
       - 'backend/**'
+  pull_request:
+    types: [ready_for_review, review_requested]
+  pull_request_review:
+    types: [submitted]
+  milestone:
+    types: [opened, deleted]
   workflow_dispatch:
     inputs:
       git-ref:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'backend/**'
+      - '.github/workflows/backend.yml'
   pull_request:
     types: [ready_for_review, review_requested]
   pull_request_review:

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -4,6 +4,12 @@ on:
   push:
     paths:
       - 'firmware/**'
+  pull_request:
+    types: [ready_for_review, review_requested]
+  pull_request_review:
+    types: [submitted]
+  milestone:
+    types: [opened, deleted]
   workflow_dispatch:
     inputs:
       git-ref:

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'firmware/**'
+      - '.github/workflows/firmware.yml'
   pull_request:
     types: [ready_for_review, review_requested]
   pull_request_review:

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -74,6 +74,12 @@ jobs:
         cd cmake-build-`echo ${{ matrix.build-type }} | awk '{print tolower($0)}'`
         make -j2
 
+    - name: Archive binary
+      uses: actions/upload-artifact@v2
+      with:
+        name: firmware-binary
+        path: firmware/ventilator-controller-stm32/cmake-build-debug/*
+
   scan-build:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'frontend/**'
+      - '.github/workflows/frontend.yml'
   pull_request:
     types: [ready_for_review, review_requested]
   pull_request_review:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,6 +4,12 @@ on:
   push:
     paths:
       - 'frontend/**'
+  pull_request:
+    types: [ready_for_review, review_requested]
+  pull_request_review:
+    types: [submitted]
+  milestone:
+    types: [opened, deleted]
   workflow_dispatch:
     inputs:
       git-ref:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,7 +22,7 @@ defaults:
     working-directory: frontend
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -45,6 +45,26 @@ jobs:
 
     - name: Unit Tests
       run: yarn test
+
+  build:
+    runs-on: ubuntu-18.04
+    # This is temporarily enabled because the build currently fails
+    continue-on-error: true
+    strategy:
+      matrix:
+        node_version: [12]
+
+    steps:
+    - uses: actions/checkout@v1
+      name: Checkout repository
+
+    - name: Use Node.js ${{ matrix.node_version }}
+      uses: actions/setup-node@v1
+      with:
+        version: ${{ matrix.node_version }}
+
+    - name: Install dependencies
+      run: yarn install
 
     - name: Build
       run: yarn build

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -45,3 +45,12 @@ jobs:
 
     - name: Unit Tests
       run: yarn test
+
+    - name: Build
+      run: yarn build
+
+    - name: Archive build
+      uses: actions/upload-artifact@v2
+      with:
+        name: frontend-build
+        path: frontend/build


### PR DESCRIPTION
This PR:

- Makes Github Actions run checks for all domains on PR review-related events, so that we can catch potential check failures related to merging from develop
- Makes Github Actions run checks for a domain whenever its workflow configs are changed, so that we don't have to edit another file to re-run the checks (or to do force-pushes) when we only want to change the configs in a commit.
- Uploads the results of firmware builds as a build artifact.
- Adds a `yarn build` step to the frontend checks and uploads the result as a build artifact.