### PR TITLE
Fix remaining unused vars errors in the frontend

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -48,8 +48,6 @@ jobs:
 
   build:
     runs-on: ubuntu-18.04
-    # This is temporarily enabled because the build currently fails
-    continue-on-error: true
     strategy:
       matrix:
         node_version: [12]

--- a/frontend/src/modules/dashboard/components/Axes.tsx
+++ b/frontend/src/modules/dashboard/components/Axes.tsx
@@ -4,7 +4,7 @@ import { Grid, GridRows, GridColumns } from '@vx/grid';
 import { Group } from '@vx/group';
 import { AxisLeft, AxisBottom } from '@vx/axis';
 import { Line } from '@vx/shape';
-import { scaleTime, scaleLinear } from '@vx/scale';
+import { scaleLinear } from '@vx/scale';
 
 // responsive utils for axis ticks
 function numTicksForHeight(height: number) {

--- a/frontend/src/modules/dashboard/containers/WaveformInfo.tsx
+++ b/frontend/src/modules/dashboard/containers/WaveformInfo.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Grid, Typography } from '@material-ui/core';


### PR DESCRIPTION
This PR:

- Fixes the remaining linter complaints about unused vars (from module imports)
- Configures Github Actions to require a successful `yarn build` for the frontend checks workflow to pass.