### PR TITLE
Add measurement smoothing and debouncing with timeout hysteresis

### DIFF
--- a/frontend/src/modules/dashboard/views/HFNCMainView.tsx
+++ b/frontend/src/modules/dashboard/views/HFNCMainView.tsx
@@ -6,9 +6,9 @@ import {
   getParametersFiO2,
   getParametersFlow,
   getROXIndex,
-  getSensorMeasurementsFiO2Value,
-  getSensorMeasurementsFlow,
-  getSensorMeasurementsSpO2,
+  getSmoothedFiO2Value,
+  getSmoothedFlow,
+  getSmoothedSpO2,
 } from '../../../store/controller/selectors';
 import { a11yProps, TabPanel } from '../../controllers/TabPanel';
 import { BMIN, LMIN, PERCENT } from '../../info/units';
@@ -136,7 +136,7 @@ const HFNCMainView = (): JSX.Element => {
           <Grid container item justify="center" alignItems="stretch">
             <ValueInfo
               mainContainer={{
-                selector: getSensorMeasurementsSpO2,
+                selector: getSmoothedSpO2,
                 label: 'SpO2',
                 stateKey: 'spo2',
                 units: PERCENT,
@@ -247,7 +247,7 @@ const HFNCMainView = (): JSX.Element => {
             >
               <Grid item xs className={classes.rightBorder}>
                 <ControlInfo
-                  selector={getSensorMeasurementsFiO2Value}
+                  selector={getSmoothedFiO2Value}
                   label="FiO2"
                   stateKey="fio2"
                   units={PERCENT}
@@ -257,7 +257,7 @@ const HFNCMainView = (): JSX.Element => {
               </Grid>
               <Grid item xs className={classes.rightBorder}>
                 <ControlInfo
-                  selector={getSensorMeasurementsFlow}
+                  selector={getSmoothedFlow}
                   label="Flow Rate"
                   stateKey="flow"
                   units={LMIN}

--- a/frontend/src/store/controller/reducers.ts
+++ b/frontend/src/store/controller/reducers.ts
@@ -23,6 +23,7 @@ import {
   activeLogEventsReducer,
   pvHistoryReducer,
   waveformHistoryReducer,
+  sensorMeasurementSmoothingReducer,
 } from './reducers/derived';
 import { MessageType } from './types';
 
@@ -56,6 +57,29 @@ export const controllerReducer = combineReducers({
   rotaryEncoder: rotaryEncoderReducer,
 
   // Derived states
+  smoothedMeasurements: combineReducers({
+    spo2: sensorMeasurementSmoothingReducer(
+      0.5,
+      1.0,
+      200,
+      500,
+      (sensorMeasurements) => sensorMeasurements.spo2,
+    ),
+    fio2: sensorMeasurementSmoothingReducer(
+      0.5,
+      0.1,
+      500,
+      200,
+      (sensorMeasurements) => sensorMeasurements.fio2,
+    ),
+    flow: sensorMeasurementSmoothingReducer(
+      0.5,
+      0.5,
+      500,
+      200,
+      (sensorMeasurements) => sensorMeasurements.flow,
+    ),
+  }),
   waveformHistoryPaw: waveformHistoryReducer<SensorMeasurements>(
     MessageType.SensorMeasurements,
     (sensorMeasurements: SensorMeasurements) => sensorMeasurements.time,

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -66,6 +66,17 @@ export const getSensorMeasurementsSpO2 = createSelector(
   (sensorMeasurements: SensorMeasurements): number => roundValue(sensorMeasurements.spo2),
 );
 
+// SensorMeasurementsSmoothed
+export const getSmoothedFlow = createSelector(getController, (states: ControllerStates): number =>
+  roundValue(states.smoothedMeasurements.flow.smoothed),
+);
+export const getSmoothedFiO2 = createSelector(getController, (states: ControllerStates): number =>
+  roundValue(states.smoothedMeasurements.fio2.smoothed),
+);
+export const getSmoothedSpO2 = createSelector(getController, (states: ControllerStates): number =>
+  roundValue(states.smoothedMeasurements.spo2.smoothed),
+);
+
 // CycleMeasurements
 export const getCycleMeasurements = createSelector(
   getController,
@@ -144,12 +155,11 @@ export const getParametersRequestMode = createSelector(
 );
 
 // Derived FiO2 Sensor Measurements
-export const getSensorMeasurementsFiO2Value = createSelector(
-  getSensorMeasurements,
+export const getSmoothedFiO2Value = createSelector(
+  getSmoothedFiO2,
   getParametersFlow,
-  (sensorMeasurements: SensorMeasurements, getParametersFlow: number): number | undefined => {
-    const fio2Value = sensorMeasurements.fio2;
-    return getParametersFlow > 0 ? roundValue(fio2Value) : undefined;
+  (fio2: number, getParametersFlow: number): number | undefined => {
+    return getParametersFlow > 0 ? roundValue(fio2) : undefined;
   },
 );
 

--- a/frontend/src/store/controller/types.ts
+++ b/frontend/src/store/controller/types.ts
@@ -139,6 +139,16 @@ export interface PVHistory {
   cycle: number;
 }
 
+export interface SmoothingData {
+  raw: number;
+  average: number;
+  converged: number;
+  smoothed: number;
+  time?: number;
+  convergenceStartTime?: number;
+  changeStartTime?: number;
+}
+
 export interface ControllerStates {
   // Message states from mcu_pb
   alarms: Alarms;
@@ -165,6 +175,11 @@ export interface ControllerStates {
   rotaryEncoder: RotaryEncoderParameter;
 
   // Derived states
+  smoothedMeasurements: {
+    spo2: SmoothingData;
+    fio2: SmoothingData;
+    flow: SmoothingData;
+  };
   waveformHistoryPaw: WaveformHistory;
   waveformHistoryFlow: WaveformHistory;
   waveformHistoryVolume: WaveformHistory;


### PR DESCRIPTION
This PR resolves #264 by adding a custom signal smoothing algorithm as a parameterized reusable reducer in the frontend. It involves two stages: first, the raw signal (e.g. SpO2) is slightly smoothed by an exponentially weighted moving average with a weak filtering coefficient; then, the updated average is compared against the previous average to check whether it has been "close enough" (under a threshold) for at least a minimum amount of time. If so, then it is considered to have converged, and the smoothed value will be locked at the value upon convergence, until the moving average is "far enough" (beyond a threshold) from the smoothed value for at least a minimum amount of time, in which case then the smoothed value will start following the moving average as it is considered to have started transitioning to a different level.

The second stage of this algorithm, which is kind of like "button debouncing" but for continuous variables, is necessary for us to avoid allowing a value to flicker quickly between (for example) 3.49 and 3.51, which causes a rounded integer to flicker between 3 and 4. The updated algorithm instead just locks it in at (for example) 3.49 or 3.51, depending on which value it had when it first passed the convergence check.

Timeout hysteresis is introduced by using different timeout thresholds for the convergence check vs. for the transitioning check. This allows us to treat a measurement as converging quickly and wait longer before deciding that it has started transitioning (which is useful for e.g. SpO2); or to wait longer before deciding a measurement has converged and respond sooner to value transitions (which is useful for e.g. FiO2 and flow rate).

For records-keeping:

1. This project is licensed under Apache License v2.0 for any software, and Solderpad Hardware License v2.1 for any hardware - do you agree that your contributions to this project will be under these licenses, too? **Yes**
2. Were any of these contributions also part of work you did for an employer or a client? **No**
3. Does this work include, or is it based on, any third-party work which you did not create? **No**