### PR TITLE
Update the active simulator before updating the clock

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Simulator.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Simulator.cpp
@@ -171,8 +171,6 @@ void Simulators::transform(
     const SensorVars &sensor_vars,
     SensorMeasurements &sensor_measurements,
     CycleMeasurements &cycle_measurements) {
-  input_clock(current_time);
-
   switch (parameters.mode) {
     case VentilationMode_pc_ac:
       active_simulator_ = &pc_ac_;
@@ -184,6 +182,8 @@ void Simulators::transform(
       active_simulator_ = nullptr;
       return;
   }
+
+  input_clock(current_time);
 
   active_simulator_->transform(parameters, sensor_vars, sensor_measurements, cycle_measurements);
 }


### PR DESCRIPTION
This PR fixes incorrect behavior in clock updates for the breathing circuit simulator of the frontend. Previously, the `Simulators::transform` method was updating the clock before updating the pointer to the active simulator. However, the clock update method was returning early if there was no active simulator when it was called, which meant that a newly-activated simulator's `transform` method would be called with a stale clock in the first call. Calling the clock update method **after** updating the pointer to the active simulator should fix this problem.