### PR TITLE
Make selectors which round values return NaN, not 0, for missing values

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Simulator.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Simulator.h
@@ -84,7 +84,7 @@ class HFNCSimulator : public Simulator {
       const Parameters &parameters,
       const SensorVars &sensor_vars,
       SensorMeasurements &sensor_measurements,
-      CycleMeasurements &cycle_measurements) override;
+      CycleMeasurements & /*cycle_measurements*/) override;
 
  private:
   static const uint32_t default_cycle_period = 2000;  // ms

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Simulator.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Simulator.cpp
@@ -109,7 +109,9 @@ void HFNCSimulator::transform(
     const Parameters &parameters,
     const SensorVars &sensor_vars,
     SensorMeasurements &sensor_measurements,
-    CycleMeasurements &cycle_measurements) {
+    // cycle_measurements is part of the Simulator interface
+    // NOLINTNEXTLINE(misc-unused-parameters)
+    CycleMeasurements & /*cycle_measurements*/) {
   if (!update_needed()) {
     return;
   }

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -26,7 +26,7 @@ import {
 const roundValue = (value: number) => {
   return value !== undefined && !Number.isNaN(value)
     ? parseInt(value.toFixed(0).replace(/^-0$/, '0'), DECIMAL_RADIX)
-    : 0;
+    : NaN;
 };
 export const getController = ({ controller }: StoreState): ControllerStates => controller;
 


### PR DESCRIPTION
This PR makes it possible to display "--%" instead of "0%" for SpO2 when the SpO2 sensor is not producing data (e.g. because the sensor was taken off the finger). The React components for value display can already do this; this fix makes it possible for the selectors give correct inputs with those components when data is missing.