### PR TITLE
Fix firmware bug and remove RR from HFNC

### DIFF
--- a/backend/ventserver/application.py
+++ b/backend/ventserver/application.py
@@ -67,7 +67,7 @@ async def main() -> None:
         if state is mcu_pb.ParametersRequest:
             all_states[state] = mcu_pb.ParametersRequest(
                 mode=mcu_pb.VentilationMode.hfnc, ventilating=False,
-                rr=30, fio2=60, flow=6
+                fio2=60, flow=6
             )
         else:
             all_states[state] = state()
@@ -77,9 +77,7 @@ async def main() -> None:
         mcu_pb.Parameters, mcu_pb.CycleMeasurements,
         mcu_pb.SensorMeasurements, mcu_pb.ParametersRequest
     ]
-    await _trio.load_file_states(
-        states, protocol, filehandler
-    )
+    await _trio.load_file_states(states, protocol, filehandler)
 
     # Turn off ventilation
     parameters_request = all_states[mcu_pb.ParametersRequest]

--- a/backend/ventserver/application.py
+++ b/backend/ventserver/application.py
@@ -64,13 +64,7 @@ async def main() -> None:
     # Initialize state with defaults
     all_states = protocol.receive.backend.all_states
     for state in all_states:
-        if state is mcu_pb.ParametersRequest:
-            all_states[state] = mcu_pb.ParametersRequest(
-                mode=mcu_pb.VentilationMode.hfnc, ventilating=False,
-                fio2=60, flow=6
-            )
-        else:
-            all_states[state] = state()
+        all_states[state] = state()
 
     # Load state from file
     states: List[Type[betterproto.Message]] = [

--- a/backend/ventserver/application.py
+++ b/backend/ventserver/application.py
@@ -1,7 +1,7 @@
 """Trio I/O with sans-I/O protocol, running application."""
 
 import logging
-from typing import Type, List
+from typing import Dict, List, Optional, Type
 import functools
 
 import trio
@@ -19,19 +19,47 @@ from ventserver.protocols import exceptions
 from ventserver.protocols.protobuf import mcu_pb
 
 
-logger = logging.getLogger()
-handler = logging.StreamHandler()
-formatter = logging.Formatter(
-    '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
-)
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
+async def initialize_states_from_file(all_states: Dict[
+        Type[betterproto.Message], Optional[betterproto.Message]
+], protocol: server.Protocol, filehandler: fileio.Handler) -> None:
+    """Initialize states from filesystem and turn off ventilation."""
+
+    # Load state from file
+    states: List[Type[betterproto.Message]] = [
+        mcu_pb.Parameters, mcu_pb.CycleMeasurements,
+        mcu_pb.SensorMeasurements, mcu_pb.ParametersRequest
+    ]
+    await _trio.load_file_states(states, protocol, filehandler)
+
+    # Turn off ventilation
+    parameters_request = all_states[mcu_pb.ParametersRequest]
+    if parameters_request is not None:
+        parameters_request.ventilating = False
+
+
+def filter_multierror(exc: trio.MultiError) -> None:
+    """Filter out trio.MultiErrors from KeyboardInterrupts."""
+    if len(exc.exceptions) != 2:
+        raise exc
+    if (
+            not isinstance(exc.exceptions[0], KeyboardInterrupt) or
+            not isinstance(exc.exceptions[1], trio.EndOfChannel)
+    ):
+        raise exc
 
 
 async def main() -> None:
     """Set up wiring between subsystems and process until completion."""
-    # pylint: disable=duplicate-code
+    # Configure logging
+    logger = logging.getLogger()
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
     # Sans-I/O Protocols
     protocol = server.Protocol()
 
@@ -61,22 +89,11 @@ async def main() -> None:
         server.ReceiveOutputEvent
     ] = channels.TrioChannel()
 
-    # Initialize state with defaults
+    # Initialize states
     all_states = protocol.receive.backend.all_states
     for state in all_states:
         all_states[state] = state()
-
-    # Load state from file
-    states: List[Type[betterproto.Message]] = [
-        mcu_pb.Parameters, mcu_pb.CycleMeasurements,
-        mcu_pb.SensorMeasurements, mcu_pb.ParametersRequest
-    ]
-    await _trio.load_file_states(states, protocol, filehandler)
-
-    # Turn off ventilation
-    parameters_request = all_states[mcu_pb.ParametersRequest]
-    if parameters_request is not None:
-        parameters_request.ventilating = False
+    await initialize_states_from_file(all_states, protocol, filehandler)
 
     try:
         async with channel.push_endpoint:
@@ -105,10 +122,12 @@ async def main() -> None:
                 nursery.cancel_scope.cancel()
     except trio.EndOfChannel:
         logger.info('Finished, quitting!')
+    except KeyboardInterrupt:
+        logger.info('Quitting!')
+    except trio.MultiError as exc:
+        filter_multierror(exc)
+        logger.info('Finished, quitting!')
 
 
 if __name__ == '__main__':
-    try:
-        trio.run(main)
-    except KeyboardInterrupt:
-        logger.info('Quitting!')
+    trio.run(main)

--- a/backend/ventserver/integration/_trio.py
+++ b/backend/ventserver/integration/_trio.py
@@ -372,10 +372,10 @@ async def load_file_states(
 ) -> None:
     """Initialize state values from state store or default values."""
     for state in states:
-        try: # Handle fileio errors
+        try:  # Handle fileio errors
             filehandler.set_props(state.__name__, "rb")
             await filehandler.open()
-            async with  filehandler:
+            async with filehandler:
                 message = await filehandler.receive()
                 logger.info("State initialized from file: %s", state.__name__)
                 protocol.receive.input(

--- a/backend/ventserver/simulator.py
+++ b/backend/ventserver/simulator.py
@@ -9,7 +9,7 @@ server to act as a mock in place of the real backend server.
 import logging
 import time
 import functools
-from typing import Mapping, Optional, Type, List
+from typing import Mapping, Optional, Type
 
 import betterproto
 import trio
@@ -25,18 +25,7 @@ from ventserver.protocols import exceptions
 from ventserver.protocols.application import lists
 from ventserver.protocols.protobuf import mcu_pb
 from ventserver.simulation import alarm_limits, alarms, parameters, simulators
-
-
-# Configure logging
-
-logger = logging.getLogger()
-handler = logging.StreamHandler()
-formatter = logging.Formatter(
-    '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
-)
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
+from ventserver import application
 
 
 # Simulators
@@ -78,7 +67,16 @@ async def simulate_states(
 
 async def main() -> None:
     """Set up wiring between subsystems and process until completion."""
-    # pylint: disable=duplicate-code
+    # Configure logging
+    logger = logging.getLogger()
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
     # Sans-I/O Protocols
     protocol = server.Protocol()
 
@@ -105,7 +103,7 @@ async def main() -> None:
         server.ReceiveOutputEvent
     ] = channels.TrioChannel()
 
-    # Initialize States
+    # Initialize states with defaults
     all_states = protocol.receive.backend.all_states
     for state in all_states:
         if state is mcu_pb.ParametersRequest:
@@ -115,18 +113,9 @@ async def main() -> None:
             )
         else:
             all_states[state] = state()
-
-    # Load state from file
-    states: List[Type[betterproto.Message]] = [
-        mcu_pb.Parameters, mcu_pb.CycleMeasurements,
-        mcu_pb.SensorMeasurements, mcu_pb.ParametersRequest
-    ]
-    await _trio.load_file_states(states, protocol, filehandler)
-
-    # Turn off ventilation
-    parameters_request = all_states[mcu_pb.ParametersRequest]
-    if parameters_request is not None:
-        parameters_request.ventilating = False
+    await application.initialize_states_from_file(
+        all_states, protocol, filehandler
+    )
 
     try:
         async with channel.push_endpoint:
@@ -160,10 +149,12 @@ async def main() -> None:
                 nursery.cancel_scope.cancel()
     except trio.EndOfChannel:
         logger.info('Finished, quitting!')
+    except KeyboardInterrupt:
+        logger.info('Quitting!')
+    except trio.MultiError as exc:
+        application.filter_multierror(exc)
+        logger.info('Finished, quitting!')
 
 
 if __name__ == '__main__':
-    try:
-        trio.run(main)
-    except KeyboardInterrupt:
-        logger.info('Quitting!')
+    trio.run(main)

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
@@ -25,6 +25,7 @@ namespace Pufferfish::Driver::Serial::Backend {
 static const auto message_descriptors = Util::make_array<Util::ProtobufDescriptor>(
     // array index should match the type code value
     Util::get_protobuf_descriptor<Util::UnrecognizedMessage>(),  // 0
+    Util::get_protobuf_descriptor<Util::UnrecognizedMessage>(),  // 1
     Util::get_protobuf_descriptor<SensorMeasurements>(),         // 2
     Util::get_protobuf_descriptor<CycleMeasurements>(),          // 3
     Util::get_protobuf_descriptor<Parameters>(),                 // 4

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/States.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/States.tpp
@@ -26,9 +26,10 @@ StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::input(
     const StateSegment &input) {
   if (all_states_.should_input(input.tag)) {
     all_states_.input(input);
+    return InputStatus::ok;
   }
 
-  return InputStatus::ok;
+  return InputStatus::invalid_type;
 }
 
 template <typename States, typename StateSegment, typename MessageTypes, size_t schedule_size>

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Simulator.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Simulator.cpp
@@ -120,11 +120,6 @@ void HFNCSimulator::transform(
 
   // Timing
   sensor_measurements.time = current_time();
-  uint32_t cycle_period = minute_duration / parameters.rr;
-  if (!Util::within_timeout(cycle_start_time_, cycle_period, current_time())) {
-    init_cycle();
-    transform_rr(parameters.rr, cycle_measurements.rr);
-  }
   transform_flow(parameters.flow, sensor_measurements.flow);
   if (sensor_vars.po2 != 0) {
     // simulate FiO2 from pO2 if pO2 is available
@@ -143,10 +138,6 @@ void HFNCSimulator::transform(
 
 void HFNCSimulator::init_cycle() {
   cycle_start_time_ = current_time();
-}
-
-void HFNCSimulator::transform_rr(float params_rr, float &cycle_meas_rr) {
-  cycle_meas_rr = params_rr;
 }
 
 void HFNCSimulator::transform_flow(float params_flow, float &sens_meas_flow) {


### PR DESCRIPTION
This PR fixes a bug introduced by #266, which updated the set of allowed messages between the firmware and the Python backend. Specifically, it removed any message of type 1, but it did not correctly update the array of nanopb protobuf message descriptors: it just deleted the message descriptor in position 1 instead of replacing it with a placeholder. This meant that when the firmware tried to use message descriptor 7, it tried to index past the end of the array and caused a segfault which made the firmware completely stop.

This PR also removes respiratory rate from the HFNC simulations, as respiratory rate is not part of HFNC mode. Note to @Sudhir-dev: can you replace the RR box with HR (for heart rate, in units of BPM) in the frontend? In a future PR I will add a `hr` field to `SensorMeasurements` and update the firmware to use the heart rate measurement reported by our SpO2 sensor, as well as add heart rate into our simulators.

This PR also unifies some code between the backend's `application` and `simulator` top-level modules to resolve pylint duplicate-code complaints.

For records-keeping:

1. This project is licensed under Apache License v2.0 for any software, and Solderpad Hardware License v2.1 for any hardware - do you agree that your contributions to this project will be under these licenses, too? **Yes**
2. Were any of these contributions also part of work you did for an employer or a client? **No**
3. Does this work include, or is it based on, any third-party work which you did not create? **No**