### PR TITLE
Implement unit tests for Protocols/CRCElements

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -92,6 +92,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install gcc-arm-none-eabi cmake
+        sudo apt-get install -y lcov
         sudo apt-get remove -y libllvm10
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository -y -s 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
@@ -139,6 +140,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install gcc-arm-none-eabi cmake
+        sudo apt-get install -y lcov
         sudo apt-get remove -y libllvm10
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository -y -s 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
@@ -163,6 +165,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install cmake
+        sudo apt-get install -y lcov
 
     - name: Run CMake
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Misc
 .DS_Store
 extra_/
+.vscode/
 
 # Vim swapfiles
 *.swp

--- a/firmware/ventilator-controller-stm32/CMakeLists.txt
+++ b/firmware/ventilator-controller-stm32/CMakeLists.txt
@@ -38,15 +38,45 @@ include_directories(
 )
 
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "TestCatch2")
+    set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/)
+    include(CodeCoverage)
+    append_coverage_compiler_flags()
+
+    # disable all optimization
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -O0")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fno-inline -fno-inline-small-functions -fno-default-inline")
+
+    # Some ARM header files give conversion errors from 32-bit to 64-bit
+    # TODO: Need t figure out how to enable this for a small section of code
+    # instead of for the whole project
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fpermissive")
+
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DSTM32H743xx=1")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DSTM32H743xx=1")
+
+    setup_target_for_coverage_lcov(
+        NAME ${CMAKE_BUILD_TYPE}_coverage
+        EXECUTABLE ${CMAKE_BUILD_TYPE}
+        EXCLUDE "/usr/include/*" "Core/Inc/catch2/*" "Core/Test/*" "Core/Src/nanopb/*"
+    )
+
     file(
         GLOB_RECURSE LIBRARY_SOURCES
         "Core/Src/Pufferfish/Driver/Indicators/PulseGenerator.cpp"
         "Core/Src/Pufferfish/Driver/Serial/*.cpp"
+        "Core/Src/Pufferfish/HAL/CRC.cpp"
+        "Core/Src/Pufferfish/Application/mcu_pb.c"
+        "Core/Src/nanopb/pb_encode.c"
+        "Core/Src/nanopb/pb_decode.c"
+        "Core/Src/nanopb/pb_common.c"
+        "Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_crc.c"
+        "Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_crc_ex.c"
     )
     add_library(Pufferfish ${LIBRARY_SOURCES})
     file(GLOB_RECURSE EXECUTABLE_SOURCES "Core/Test/*.*")
     add_executable(${CMAKE_BUILD_TYPE} ${EXECUTABLE_SOURCES})
-    target_link_libraries(${CMAKE_BUILD_TYPE} Pufferfish)
+    target_link_libraries(${CMAKE_BUILD_TYPE} Pufferfish gcov)
 else ()
     add_definitions(-DUSE_HAL_DRIVER -DSTM32H743xx -DDEBUG)
 

--- a/firmware/ventilator-controller-stm32/CMakeLists.txt
+++ b/firmware/ventilator-controller-stm32/CMakeLists.txt
@@ -64,9 +64,11 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "TestCatch2")
     file(
         GLOB_RECURSE LIBRARY_SOURCES
         "Core/Src/Pufferfish/Driver/Indicators/PulseGenerator.cpp"
-        "Core/Src/Pufferfish/Driver/Serial/*.cpp"
+        "Core/Src/Pufferfish/Driver/Serial/*.*"
+        "Core/Src/Pufferfish/Application/*.*"
+        "Core/Src/Pufferfish/Util/*.*"
         "Core/Src/Pufferfish/HAL/CRC.cpp"
-        "Core/Src/Pufferfish/Application/mcu_pb.c"
+        "Core/Src/Pufferfish/HAL/Mock/MockTime.cpp"
         "Core/Src/nanopb/pb_encode.c"
         "Core/Src/nanopb/pb_decode.c"
         "Core/Src/nanopb/pb_common.c"

--- a/firmware/ventilator-controller-stm32/CMakeLists.txt
+++ b/firmware/ventilator-controller-stm32/CMakeLists.txt
@@ -47,14 +47,6 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "TestCatch2")
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -O0")
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fno-inline -fno-inline-small-functions -fno-default-inline")
 
-    # Some ARM header files give conversion errors from 32-bit to 64-bit
-    # TODO: Need t figure out how to enable this for a small section of code
-    # instead of for the whole project
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fpermissive")
-
-    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DSTM32H743xx=1")
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DSTM32H743xx=1")
-
     setup_target_for_coverage_lcov(
         NAME ${CMAKE_BUILD_TYPE}_coverage
         EXECUTABLE ${CMAKE_BUILD_TYPE}
@@ -68,16 +60,16 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "TestCatch2")
         "Core/Src/Pufferfish/Application/*.*"
         "Core/Src/Pufferfish/Util/*.*"
         "Core/Src/Pufferfish/HAL/CRC.cpp"
-        "Core/Src/Pufferfish/HAL/Mock/MockTime.cpp"
-        "Core/Src/nanopb/pb_encode.c"
-        "Core/Src/nanopb/pb_decode.c"
-        "Core/Src/nanopb/pb_common.c"
-        "Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_crc.c"
-        "Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_crc_ex.c"
+        "Core/Src/Pufferfish/HAL/Mock/*.cpp"
+        "Core/Src/nanopb/*.c"
     )
     add_library(Pufferfish ${LIBRARY_SOURCES})
+
     file(GLOB_RECURSE EXECUTABLE_SOURCES "Core/Test/*.*")
+
     add_executable(${CMAKE_BUILD_TYPE} ${EXECUTABLE_SOURCES})
+    include_directories("Core/Inc")
+    include_directories("Core/Test/Inc")
     target_link_libraries(${CMAKE_BUILD_TYPE} Pufferfish gcov)
 else ()
     add_definitions(-DUSE_HAL_DRIVER -DSTM32H743xx -DDEBUG)

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
@@ -26,7 +26,7 @@ BackendReceiver::InputStatus BackendReceiver::input(uint8_t new_byte) {
 }
 
 BackendReceiver::OutputStatus BackendReceiver::output(BackendMessage &output_message) {
-  FrameProps::ChunkBuffer temp_buffer1;
+  FrameProps::PayloadBuffer temp_buffer1;
   BackendCRCReceiver::Props::PayloadBuffer temp_buffer2;
   BackendDatagramReceiver::Props::PayloadBuffer temp_buffer3;
 
@@ -84,7 +84,7 @@ BackendSender::Status BackendSender::transform(
     const BackendMessage &input_message, FrameProps::ChunkBuffer &output_buffer) {
   BackendDatagramSender::Props::PayloadBuffer temp_buffer1;
   BackendCRCSender::Props::PayloadBuffer temp_buffer2;
-  FrameProps::ChunkBuffer temp_buffer3;
+  FrameProps::PayloadBuffer temp_buffer3;
 
   // Message
   switch (message_.transform(input_message, temp_buffer1)) {

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.h
@@ -58,14 +58,14 @@ class CRCElement {
   IndexStatus write_protected(Util::ByteVector<output_size> &output_buffer) const;
 };
 
-// In this CRCElement, the payload can only be set through the constructor, so
-// a const payload can be given in the constructor. However, the parse method
-// is not available, as it would modify the payload given in the constructor.
+// In this CRCElement, the payload can be modified through the parse method, so
+// a const payload cannot be given in the constructor.
 template <size_t body_max_size>
 using ParsedCRCElement = CRCElement<typename CRCElementProps<body_max_size>::PayloadBuffer>;
 
-// In this CRCElement, the payload can be modified through the parse method, so
-// a const payload cannot be given in the constructor.
+// In this CRCElement, the payload can only be set through the constructor, so
+// a const payload can be given in the constructor. However, the parse method
+// is not available, as it would modify the payload given in the constructor.
 template <size_t body_max_size>
 using ConstructedCRCElement =
     CRCElement<const typename CRCElementProps<body_max_size>::PayloadBuffer>;
@@ -82,7 +82,7 @@ class CRCElementReceiver {
   template <size_t input_size>
   Status transform(
       const Util::ByteVector<input_size> &input_buffer,
-      ParsedCRCElement<body_max_size> &output_datagram);
+      ParsedCRCElement<body_max_size> &output_crcelement);
 
  private:
   HAL::CRC32 &crc32c_;

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
@@ -77,6 +77,10 @@ template <size_t input_size>
 typename CRCElementReceiver<body_max_size>::Status CRCElementReceiver<body_max_size>::transform(
     const Util::ByteVector<input_size> &input_buffer,
     ParsedCRCElement<body_max_size> &output_crcelement) {
+  if (input_buffer.size() > body_max_size) {
+    return Status::invalid_parse;
+  }
+
   if (output_crcelement.parse(input_buffer) != IndexStatus::ok) {
     return Status::invalid_parse;
   }

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
@@ -50,7 +50,8 @@ IndexStatus CRCElement<PayloadBuffer>::parse(const Util::ByteVector<input_size> 
       !std::is_const<PayloadBuffer>::value,
       "Parse method unavailable for CRCElements with const PayloadBuffer type");
 
-  if (input_buffer.size() < CRCElementHeaderProps::header_size) {
+  if (input_buffer.size() < CRCElementHeaderProps::header_size ||
+      input_buffer.size() > (payload_.max_size() + CRCElementHeaderProps::header_size)) {
     return IndexStatus::out_of_bounds;
   }
   Util::read_ntoh(input_buffer.buffer(), crc_);
@@ -77,10 +78,6 @@ template <size_t input_size>
 typename CRCElementReceiver<body_max_size>::Status CRCElementReceiver<body_max_size>::transform(
     const Util::ByteVector<input_size> &input_buffer,
     ParsedCRCElement<body_max_size> &output_crcelement) {
-  if (input_buffer.size() > body_max_size) {
-    return Status::invalid_parse;
-  }
-
   if (output_crcelement.parse(input_buffer) != IndexStatus::ok) {
     return Status::invalid_parse;
   }

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
@@ -49,9 +49,12 @@ IndexStatus CRCElement<PayloadBuffer>::parse(const Util::ByteVector<input_size> 
   static_assert(
       !std::is_const<PayloadBuffer>::value,
       "Parse method unavailable for CRCElements with const PayloadBuffer type");
+  static_assert(
+      Util::ByteVector<input_size>::max_size() <=
+          (PayloadBuffer::max_size() + CRCElementHeaderProps::header_size),
+      "Parse method unavailable as the input buffer size is too large");
 
-  if (input_buffer.size() < CRCElementHeaderProps::header_size ||
-      input_buffer.size() > (payload_.max_size() + CRCElementHeaderProps::header_size)) {
+  if (input_buffer.size() < CRCElementHeaderProps::header_size) {
     return IndexStatus::out_of_bounds;
   }
   Util::read_ntoh(input_buffer.buffer(), crc_);

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
@@ -76,13 +76,13 @@ template <size_t body_max_size>
 template <size_t input_size>
 typename CRCElementReceiver<body_max_size>::Status CRCElementReceiver<body_max_size>::transform(
     const Util::ByteVector<input_size> &input_buffer,
-    ParsedCRCElement<body_max_size> &output_datagram) {
-  if (output_datagram.parse(input_buffer) != IndexStatus::ok) {
+    ParsedCRCElement<body_max_size> &output_crcelement) {
+  if (output_crcelement.parse(input_buffer) != IndexStatus::ok) {
     return Status::invalid_parse;
   }
 
   if (ParsedCRCElement<body_max_size>::compute_body_crc(input_buffer, crc32c_) !=
-      output_datagram.crc()) {
+      output_crcelement.crc()) {
     return Status::invalid_crc;
   }
 
@@ -96,8 +96,8 @@ template <size_t output_size>
 typename CRCElementSender<body_max_size>::Status CRCElementSender<body_max_size>::transform(
     const typename Props::PayloadBuffer &input_payload,
     Util::ByteVector<output_size> &output_buffer) {
-  ConstructedCRCElement<body_max_size> datagram(input_payload);
-  if (datagram.write(output_buffer, crc32c_) != IndexStatus::ok) {
+  ConstructedCRCElement<body_max_size> crcelement(input_payload);
+  if (crcelement.write(output_buffer, crc32c_) != IndexStatus::ok) {
     return Status::invalid_length;
   }
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Vector.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Vector.h
@@ -29,7 +29,7 @@ class Vector {
   Vector() = default;
 
   [[nodiscard]] size_t size() const;
-  [[nodiscard]] constexpr size_t max_size() const { return array_size; }
+  [[nodiscard]] static constexpr size_t max_size() { return array_size; }
   [[nodiscard]] bool empty() const;
   [[nodiscard]] bool full() const;
   [[nodiscard]] size_t available() const;

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/Backend/Frames.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/Backend/Frames.cpp
@@ -15,8 +15,8 @@ FrameProps::InputStatus FrameReceiver::input(uint8_t new_byte) {
   return chunk_splitter_.input(new_byte);
 }
 
-FrameProps::OutputStatus FrameReceiver::output(FrameProps::ChunkBuffer &output_buffer) {
-  FrameProps::ChunkBuffer temp_buffer;
+FrameProps::OutputStatus FrameReceiver::output(FrameProps::PayloadBuffer &output_buffer) {
+  FrameProps::EncodedBuffer temp_buffer;
 
   // Chunk
   FrameProps::OutputStatus status = chunk_splitter_.output(temp_buffer);
@@ -36,7 +36,7 @@ FrameProps::OutputStatus FrameReceiver::output(FrameProps::ChunkBuffer &output_b
 // FrameSender
 
 FrameProps::OutputStatus FrameSender::transform(
-    const FrameProps::ChunkBuffer &input_buffer, FrameProps::ChunkBuffer &output_buffer) const {
+    const FrameProps::PayloadBuffer &input_buffer, FrameProps::ChunkBuffer &output_buffer) const {
   // COBS
   FrameProps::OutputStatus status = cobs_encoder.transform(input_buffer, output_buffer);
   if (status != FrameProps::OutputStatus::ok) {

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/FDO2/Commands.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/FDO2/Commands.cpp
@@ -324,7 +324,7 @@ void write<Bcst>(const Bcst &request, ChunkBuffer &output_buffer) {
   std::ostringstream stream;
   stream.rdbuf()->pubsetbuf(
       output_buffer.buffer() + output_buffer.size(),
-      output_buffer.max_size() - output_buffer.size());
+      ChunkBuffer::max_size() - output_buffer.size());
   stream << request.interval;
   if (output_buffer.resize(output_buffer.size() + stream.tellp()) != IndexStatus::ok) {
     // TODO(lietk12): return error

--- a/firmware/ventilator-controller-stm32/Core/Test/Inc/Pufferfish/Test/Util.h
+++ b/firmware/ventilator-controller-stm32/Core/Test/Inc/Pufferfish/Test/Util.h
@@ -1,0 +1,100 @@
+/*
+ * Util.h
+ *
+ *  Created on: Nov 17, 2020
+ *      Author: Renji Panicker
+ *
+ *  A set of helper functins for writing and debugging test cases
+ */
+
+#pragma once
+
+#include <string>
+
+#include "Pufferfish/Util/Vector.h"
+
+namespace Pufferfish::Util {
+
+template <size_t payload_size>
+inline bool operator==(
+    const Pufferfish::Util::ByteVector<payload_size>& lhs, const std::string& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if ((uint8_t)lhs[i] != (uint8_t)rhs.at(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <size_t payload_size>
+inline bool operator!=(
+    const Pufferfish::Util::ByteVector<payload_size>& lhs, const std::string& rhs) {
+  return !(lhs == rhs);
+}
+
+template <size_t payload_size>
+inline bool operator==(
+    const Pufferfish::Util::ByteVector<payload_size>& lhs,
+    const Pufferfish::Util::ByteVector<payload_size>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if ((uint8_t)lhs[i] != (uint8_t)rhs[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <size_t payload_size>
+inline bool operator!=(
+    const Pufferfish::Util::ByteVector<payload_size>& lhs,
+    const Pufferfish::Util::ByteVector<payload_size>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <size_t payload_size>
+inline bool convertStringToByteVector(
+    const std::string& input_string, Pufferfish::Util::ByteVector<payload_size>& output_buffer) {
+  if (input_string.size() >= payload_size) {
+    return false;
+  }
+  for (auto& ch : input_string) {
+    output_buffer.push_back(ch);
+  }
+  return true;
+}
+
+template <size_t payload_size>
+inline std::string convertByteVectorToHexString(
+    const Pufferfish::Util::ByteVector<payload_size>& input_buffer) {
+  std::string output_string;
+  for (size_t i = 0; i < input_buffer.size(); ++i) {
+    auto& ch = input_buffer[i];
+    output_string += "\\x";
+    int c1 = ((ch & 0xf0) >> 4);
+    if ((c1 >= 0) && (c1 <= 9)) {
+      output_string += (c1 + '0');
+    } else if ((c1 >= 10) && (c1 <= 15)) {
+      output_string += ((c1 - 10) + 'A');
+    } else {
+      output_string += ('?');
+    }
+
+    c1 = (ch & 0x0f);
+    if ((c1 >= 0) && (c1 <= 9)) {
+      output_string += (c1 + '0');
+    } else if ((c1 >= 10) && (c1 <= 15)) {
+      output_string += ((c1 - 10) + 'A');
+    } else {
+      output_string += ('?');
+    }
+  }
+  return output_string;
+}
+
+}  // namespace Pufferfish::Util

--- a/firmware/ventilator-controller-stm32/Core/Test/Inc/Pufferfish/Test/Util.h
+++ b/firmware/ventilator-controller-stm32/Core/Test/Inc/Pufferfish/Test/Util.h
@@ -4,7 +4,7 @@
  *  Created on: Nov 17, 2020
  *      Author: Renji Panicker
  *
- *  A set of helper functins for writing and debugging test cases
+ *  A set of helper functions for writing and debugging test cases
  */
 
 #pragma once
@@ -15,86 +15,36 @@
 
 namespace Pufferfish::Util {
 
+// operator to match ByteVector and HexString
 template <size_t payload_size>
-inline bool operator==(
-    const Pufferfish::Util::ByteVector<payload_size>& lhs, const std::string& rhs) {
-  if (lhs.size() != rhs.size()) {
-    return false;
-  }
-  for (size_t i = 0; i < lhs.size(); ++i) {
-    if (static_cast<uint8_t>(lhs[i]) != static_cast<uint8_t>(rhs.at(i))) {
-      return false;
-    }
-  }
-  return true;
-}
+bool operator==(const Pufferfish::Util::ByteVector<payload_size>& lhs, const std::string& rhs);
 
+// operator to match ByteVector and HexString
 template <size_t payload_size>
-inline bool operator!=(
-    const Pufferfish::Util::ByteVector<payload_size>& lhs, const std::string& rhs) {
-  return !(lhs == rhs);
-}
+bool operator!=(const Pufferfish::Util::ByteVector<payload_size>& lhs, const std::string& rhs);
 
+// operator to match two ByteVector's
 template <size_t payload_size>
-inline bool operator==(
+bool operator==(
     const Pufferfish::Util::ByteVector<payload_size>& lhs,
-    const Pufferfish::Util::ByteVector<payload_size>& rhs) {
-  if (lhs.size() != rhs.size()) {
-    return false;
-  }
-  for (size_t i = 0; i < lhs.size(); ++i) {
-    if (static_cast<uint8_t>(lhs[i]) != static_cast<uint8_t>(rhs[i])) {
-      return false;
-    }
-  }
-  return true;
-}
+    const Pufferfish::Util::ByteVector<payload_size>& rhs);
 
+// operator to match two ByteVector's
 template <size_t payload_size>
-inline bool operator!=(
+bool operator!=(
     const Pufferfish::Util::ByteVector<payload_size>& lhs,
-    const Pufferfish::Util::ByteVector<payload_size>& rhs) {
-  return !(lhs == rhs);
-}
+    const Pufferfish::Util::ByteVector<payload_size>& rhs);
 
+// converts HexString to ByteVector
 template <size_t payload_size>
-inline bool convert_string_to_byte_vector(
-    const std::string& input_string, Pufferfish::Util::ByteVector<payload_size>& output_buffer) {
-  if (input_string.size() >= payload_size) {
-    return false;
-  }
-  for (const auto& ch : input_string) {
-    output_buffer.push_back(ch);
-  }
-  return true;
-}
+bool convert_string_to_byte_vector(
+    const std::string& input_string, Pufferfish::Util::ByteVector<payload_size>& output_buffer);
 
+// converts ByteVector to HexString
 template <size_t payload_size>
-inline std::string convert_byte_vector_to_hex_string(
-    const Pufferfish::Util::ByteVector<payload_size>& input_buffer) {
-  std::string output_string;
-  for (size_t i = 0; i < input_buffer.size(); ++i) {
-    auto& ch = input_buffer[i];
-    output_string += "\\x";
-    int c1 = ((ch & 0xf0) >> 4);
-    if ((c1 >= 0) && (c1 <= 9)) {
-      output_string += std::to_string(c1);
-    } else if ((c1 >= 10) && (c1 <= 15)) {
-      output_string += static_cast<char>(c1 - 10 + 'A');
-    } else {
-      output_string += ('?');
-    }
-
-    c1 = (ch & 0x0f);
-    if ((c1 >= 0) && (c1 <= 9)) {
-      output_string += std::to_string(c1);
-    } else if ((c1 >= 10) && (c1 <= 15)) {
-      output_string += static_cast<char>(c1 - 10 + 'A');
-    } else {
-      output_string += ('?');
-    }
-  }
-  return output_string;
-}
+std::string convert_byte_vector_to_hex_string(
+    const Pufferfish::Util::ByteVector<payload_size>& input_buffer);
 
 }  // namespace Pufferfish::Util
+
+#include "Util.tpp"

--- a/firmware/ventilator-controller-stm32/Core/Test/Inc/Pufferfish/Test/Util.h
+++ b/firmware/ventilator-controller-stm32/Core/Test/Inc/Pufferfish/Test/Util.h
@@ -22,7 +22,7 @@ inline bool operator==(
     return false;
   }
   for (size_t i = 0; i < lhs.size(); ++i) {
-    if ((uint8_t)lhs[i] != (uint8_t)rhs.at(i)) {
+    if (static_cast<uint8_t>(lhs[i]) != static_cast<uint8_t>(rhs.at(i))) {
       return false;
     }
   }
@@ -43,7 +43,7 @@ inline bool operator==(
     return false;
   }
   for (size_t i = 0; i < lhs.size(); ++i) {
-    if ((uint8_t)lhs[i] != (uint8_t)rhs[i]) {
+    if (static_cast<uint8_t>(lhs[i]) != static_cast<uint8_t>(rhs[i])) {
       return false;
     }
   }
@@ -58,19 +58,19 @@ inline bool operator!=(
 }
 
 template <size_t payload_size>
-inline bool convertStringToByteVector(
+inline bool convert_string_to_byte_vector(
     const std::string& input_string, Pufferfish::Util::ByteVector<payload_size>& output_buffer) {
   if (input_string.size() >= payload_size) {
     return false;
   }
-  for (auto& ch : input_string) {
+  for (const auto& ch : input_string) {
     output_buffer.push_back(ch);
   }
   return true;
 }
 
 template <size_t payload_size>
-inline std::string convertByteVectorToHexString(
+inline std::string convert_byte_vector_to_hex_string(
     const Pufferfish::Util::ByteVector<payload_size>& input_buffer) {
   std::string output_string;
   for (size_t i = 0; i < input_buffer.size(); ++i) {
@@ -78,18 +78,18 @@ inline std::string convertByteVectorToHexString(
     output_string += "\\x";
     int c1 = ((ch & 0xf0) >> 4);
     if ((c1 >= 0) && (c1 <= 9)) {
-      output_string += (c1 + '0');
+      output_string += std::to_string(c1);
     } else if ((c1 >= 10) && (c1 <= 15)) {
-      output_string += ((c1 - 10) + 'A');
+      output_string += static_cast<char>(c1 - 10 + 'A');
     } else {
       output_string += ('?');
     }
 
     c1 = (ch & 0x0f);
     if ((c1 >= 0) && (c1 <= 9)) {
-      output_string += (c1 + '0');
+      output_string += std::to_string(c1);
     } else if ((c1 >= 10) && (c1 <= 15)) {
-      output_string += ((c1 - 10) + 'A');
+      output_string += static_cast<char>(c1 - 10 + 'A');
     } else {
       output_string += ('?');
     }

--- a/firmware/ventilator-controller-stm32/Core/Test/Inc/Pufferfish/Test/Util.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Inc/Pufferfish/Test/Util.tpp
@@ -1,0 +1,93 @@
+/*
+ * Util.cpp
+ *
+ *  Created on: 27 feb, 2020
+ *      Author: Renji panicker
+ *
+ *  A set of helper functions for writing and debugging test cases
+ */
+#include "Util.h"
+
+namespace Pufferfish::Util {
+
+template <size_t payload_size>
+bool operator==(const Pufferfish::Util::ByteVector<payload_size>& lhs, const std::string& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (static_cast<uint8_t>(lhs[i]) != static_cast<uint8_t>(rhs.at(i))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <size_t payload_size>
+bool operator!=(const Pufferfish::Util::ByteVector<payload_size>& lhs, const std::string& rhs) {
+  return !(lhs == rhs);
+}
+
+template <size_t payload_size>
+bool operator==(
+    const Pufferfish::Util::ByteVector<payload_size>& lhs,
+    const Pufferfish::Util::ByteVector<payload_size>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (static_cast<uint8_t>(lhs[i]) != static_cast<uint8_t>(rhs[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <size_t payload_size>
+bool operator!=(
+    const Pufferfish::Util::ByteVector<payload_size>& lhs,
+    const Pufferfish::Util::ByteVector<payload_size>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <size_t payload_size>
+bool convert_string_to_byte_vector(
+    const std::string& input_string, Pufferfish::Util::ByteVector<payload_size>& output_buffer) {
+  if (input_string.size() >= payload_size) {
+    return false;
+  }
+  for (const auto& ch : input_string) {
+    output_buffer.push_back(ch);
+  }
+  return true;
+}
+
+template <size_t payload_size>
+std::string convert_byte_vector_to_hex_string(
+    const Pufferfish::Util::ByteVector<payload_size>& input_buffer) {
+  std::string output_string;
+  for (size_t i = 0; i < input_buffer.size(); ++i) {
+    auto& ch = input_buffer[i];
+    output_string += "\\x";
+    int c1 = ((ch & 0xf0) >> 4);
+    if ((c1 >= 0) && (c1 <= 9)) {
+      output_string += std::to_string(c1);
+    } else if ((c1 >= 10) && (c1 <= 15)) {
+      output_string += static_cast<char>(c1 - 10 + 'A');
+    } else {
+      output_string += ('?');
+    }
+
+    c1 = (ch & 0x0f);
+    if ((c1 >= 0) && (c1 <= 9)) {
+      output_string += std::to_string(c1);
+    } else if ((c1 >= 10) && (c1 <= 15)) {
+      output_string += static_cast<char>(c1 - 10 + 'A');
+    } else {
+      output_string += ('?');
+    }
+  }
+  return output_string;
+}
+
+}  // namespace Pufferfish::Util

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
@@ -22,103 +22,85 @@ namespace PF = Pufferfish;
 constexpr size_t buffer_size = 254UL;
 using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
 using TestCRCElement = PF::Protocols::CRCElement<TestCRCElementProps::PayloadBuffer>;
+using TestConstructedCRCElement = PF::Protocols::CRCElement<TestCRCElementProps::PayloadBuffer>;
 using TestCRCElementHeaderProps = PF::Protocols::CRCElementHeaderProps;
 
 SCENARIO(
-    "Protocols::CRCElement: The compute_body_crc function correctly computes crc from body",
+    "Protocols::CRCElement: The TestCRCElement::compute_body_crc function correctly computes crc "
+    "from body",
     "[CRCElement]") {
   PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
   GIVEN("A CRC element initialized with an empty payload") {
-    TestCRCElementProps::PayloadBuffer input_payload;
+    WHEN("the crc is computed on an input_buffer with empty payload") {
+      PF::Util::ByteVector<buffer_size> buffer;
+      TestCRCElementProps::PayloadBuffer input_payload;
 
-    TestCRCElement crc_element{input_payload};
-
-    WHEN("the crc is computed from the payload") {
-      // Calculated using the Sunshine Online CRC Calculator
-      uint32_t expected_crc = 0x00000000;
-
-      TestCRCElementProps::PayloadBuffer output_payload;
-      output_payload.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
-      output_payload.copy_from(
+      buffer.copy_from(
           input_payload.buffer(), input_payload.size(), TestCRCElementHeaderProps::payload_offset);
 
-      auto computed_crc = TestCRCElement::compute_body_crc(output_payload, crc32c);
+      auto computed_crc = TestCRCElement::compute_body_crc(buffer, crc32c);
 
-      THEN("the computed crc is equal to the expected crc") {
+      THEN("the computed CRC is '0x00000000") {
+        // Calculated using the Sunshine Online CRC Calculator
+        uint32_t expected_crc = 0x00000000;
         REQUIRE(computed_crc == expected_crc);
       }
     }
-  }
 
-  GIVEN("A CRC Element initialized with the payload '123456789'") {
-    TestCRCElementProps::PayloadBuffer input_payload;
-    auto data = std::string("123456789");
-    for (auto& ch : data) {
-      input_payload.push_back(ch);
-    }
+    WHEN("the crc is computed on an input_buffer with payload '123456789'") {
+      TestCRCElementProps::PayloadBuffer input_payload;
+      auto data = std::string("123456789");
+      for (auto& ch : data) {
+        input_payload.push_back(ch);
+      }
 
-    TestCRCElement crc_element{input_payload};
-
-    WHEN("the crc is computed from the payload") {
-      // Calculated using the Sunshine Online CRC Calculator
-      uint32_t expected_crc = 0xe3069283;
-
-      TestCRCElementProps::PayloadBuffer output_payload;
-      output_payload.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
-      output_payload.copy_from(
+      PF::Util::ByteVector<buffer_size> buffer;
+      buffer.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
+      buffer.copy_from(
           input_payload.buffer(), input_payload.size(), TestCRCElementHeaderProps::payload_offset);
 
-      auto computed_crc = TestCRCElement::compute_body_crc(output_payload, crc32c);
+      auto computed_crc = TestCRCElement::compute_body_crc(buffer, crc32c);
 
-      THEN("the computed crc is equal to the expected crc") {
+      THEN("the computed crc is '0xe3069283'") {
+        // Calculated using the Sunshine Online CRC Calculator
+        uint32_t expected_crc = 0xe3069283;
         REQUIRE(computed_crc == expected_crc);
       }
     }
-  }
 
-  GIVEN("A crc element is initalised with payload 0x00") {
-    TestCRCElementProps::PayloadBuffer input_payload;
-    input_payload.push_back(0x00);
+    WHEN("the CRC is computed on an input_buffer with payload '0x00'") {
+      TestCRCElementProps::PayloadBuffer input_payload;
+      input_payload.push_back(0x00);
 
-    TestCRCElement crc_element{input_payload};
-
-    WHEN("the crc is computed from the payload") {
-      // Calculated using the Sunshine Online CRC Calculator
-      uint32_t expected_crc = 0x527d5351;
-
-      TestCRCElementProps::PayloadBuffer output_payload;
-
-      output_payload.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
-      output_payload.copy_from(
+      PF::Util::ByteVector<buffer_size> buffer;
+      buffer.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
+      buffer.copy_from(
           input_payload.buffer(), input_payload.size(), TestCRCElementHeaderProps::payload_offset);
 
-      auto computed_crc = TestCRCElement::compute_body_crc(output_payload, crc32c);
+      auto computed_crc = TestCRCElement::compute_body_crc(buffer, crc32c);
 
-      THEN("the computed crc is equal to the expected crc") {
+      THEN("the computed crc is '0x527d5351'") {
+        // Calculated using the Sunshine Online CRC Calculator
+        uint32_t expected_crc = 0x527d5351;
         REQUIRE(computed_crc == expected_crc);
       }
     }
-  }
 
-  GIVEN("A crc element is initalised with payload 0x01") {
-    TestCRCElementProps::PayloadBuffer input_payload;
-    input_payload.push_back(0x01);
+    WHEN("the crc is computed on an input_buffer with payload '0x01'") {
+      TestCRCElementProps::PayloadBuffer input_payload;
+      input_payload.push_back(0x01);
 
-    TestCRCElement crc_element{input_payload};
+      PF::Util::ByteVector<buffer_size> buffer;
 
-    WHEN("the crc is computed from the payload") {
-      // Calculated using the Sunshine Online CRC Calculator
-      uint32_t expected_crc = 0xa016d052;
-
-      TestCRCElementProps::PayloadBuffer output_payload;
-
-      output_payload.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
-      output_payload.copy_from(
+      buffer.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
+      buffer.copy_from(
           input_payload.buffer(), input_payload.size(), TestCRCElementHeaderProps::payload_offset);
 
-      auto computed_crc = TestCRCElement::compute_body_crc(output_payload, crc32c);
+      auto computed_crc = TestCRCElement::compute_body_crc(buffer, crc32c);
 
-      THEN("the computed crc is equal to the expected crc") {
+      THEN("the computed crc is '0xa016d052") {
+        // Calculated using the Sunshine Online CRC Calculator
+        uint32_t expected_crc = 0xa016d052;
         REQUIRE(computed_crc == expected_crc);
       }
     }
@@ -137,10 +119,13 @@ SCENARIO(
       input_payload.push_back(bytes);
     }
 
-    TestCRCElement crc_element{input_payload};
+    TestConstructedCRCElement crc_element{input_payload};
     WHEN("The crc and payload are written to the output buffer") {
       TestCRCElementProps::PayloadBuffer output_buffer;
-      auto expected = std::string("\xD7\x91\x15\xF6\x01\x02\x05");
+
+      THEN("the crc accessor method returns 0 before the write method is called") {
+        REQUIRE(crc_element.crc() == 0x00000000);
+      }
 
       auto write_status = crc_element.write(output_buffer, crc32c);
       auto crc_compute = crc32c.compute(input_payload.buffer(), input_payload.size());
@@ -149,23 +134,45 @@ SCENARIO(
         REQUIRE(write_status == PF::IndexStatus::ok);
         REQUIRE(crc_element.crc() == crc_compute);
       }
+      THEN(
+          "The CRC field of the body's header matches the value returned by the crc accessor "
+          "method.") {
+        uint32_t crc_header = 0xd79115f6;
+        REQUIRE(crc_header == crc_element.crc());
+      }
+      THEN("The body's payload section correctly stores the payload as 0x01 0x02 0x05") {
+        REQUIRE(output_buffer.operator[](TestCRCElementHeaderProps::payload_offset) == data[0]);
+        REQUIRE(output_buffer.operator[](TestCRCElementHeaderProps::payload_offset + 1) == data[1]);
+        REQUIRE(output_buffer.operator[](TestCRCElementHeaderProps::payload_offset + 2) == data[2]);
+      }
 
-      THEN("The output buffer is as expected") { REQUIRE(output_buffer == expected); }
+      THEN("The output buffer is as expected") {
+        auto expected = std::string("\xD7\x91\x15\xF6\x01\x02\x05");
+        REQUIRE(output_buffer == expected);
+      }
     }
   }
 
   GIVEN("A crc element is initalised with an empty payload") {
     TestCRCElementProps::PayloadBuffer input_payload;
 
-    TestCRCElement crc_element{input_payload};
-
+    TestConstructedCRCElement crc_element{input_payload};
     WHEN("The crc and payload are written to the output buffer") {
       PF::Util::ByteVector<buffer_size> output_buffer;
 
       auto write_status = crc_element.write(output_buffer, crc32c);
-      auto crc_payload = crc_element.crc();
       THEN("The write status reports ok") { REQUIRE(write_status == PF::IndexStatus::ok); }
-      THEN("The CRC returned by the crc() method is equal to 0") { REQUIRE(crc_payload == 0); }
+      THEN(
+          "The CRC field of the body's header matches the value returned by the crc accessor "
+          "method.") {
+        uint32_t crc_header = 0x00000000;
+        REQUIRE(crc_header == crc_element.crc());
+      }
+      THEN("The body's payload section is empty") {
+        constexpr size_t payload_size = 250UL;
+        PF::Util::ByteVector<payload_size> expected;
+        REQUIRE(crc_element.payload() == expected);
+      }
       THEN("The output buffer is as expected") {
         auto expected_buffer = std::string("\x00\x00\x00\x00", 4);
         REQUIRE(output_buffer == expected_buffer);
@@ -175,43 +182,15 @@ SCENARIO(
 }
 
 SCENARIO(
-    "Protocols::CRCElement: The parse function correctly updates internal crc and payload fields "
-    "from the input buffer",
+    "Protocols::CRCElement: The parse method correctly updates its internal crc value and the "
+    "constructor's payload buffer from the input buffer",
     "[CRCElement]") {
-  GIVEN("A CRC Element initialized with an empty payload buffer with a capacity of 254 bytes") {
-    constexpr size_t buffer_size = 254UL;
-    using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
-    using TestCRCElement = PF::Protocols::CRCElement<TestCRCElementProps::PayloadBuffer>;
-    PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
+  PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
 
+  GIVEN("A CRCElement constructed with an empty payload buffer with a capacity of 254 bytes") {
     TestCRCElementProps::PayloadBuffer payload;
 
     TestCRCElement crc_element{payload};
-
-    WHEN("A body with crc more than 4 bytes and equal to the crc of the payload is parsed") {
-      // Calculated using the Sunshine Online CRC Calculator
-      uint32_t expected_crc = 0x98DBE355;
-
-      auto body = std::string("\x98\xdb\xe3\x55\x01\x05\x01\x02\x03\x04\x05", 11);
-      auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05", 7);
-
-      PF::Util::ByteVector<buffer_size> input_buffer;
-      PF::Util::convert_string_to_byte_vector(body, input_buffer);
-
-      auto parse_status = crc_element.parse(input_buffer);
-      auto crc_check = crc_element.crc();
-      const auto& payload_check = crc_element.payload();
-
-      THEN("the parse method reports ok status") { REQUIRE(parse_status == PF::IndexStatus::ok); }
-
-      THEN("crc returned from the crc() method is equal to the crc in the body/input_buffer") {
-        REQUIRE(crc_check == expected_crc);
-      }
-
-      THEN("payload returned from the payload() method is equal to the payload from the body") {
-        REQUIRE(payload_check == expected_payload);
-      }
-    }
 
     WHEN("A body of less than 4 bytes is parsed") {
       auto body = std::string("\x98\xdb\xe3", 3);
@@ -227,40 +206,155 @@ SCENARIO(
     }
 
     WHEN(
-        "A body with crc and payload is given, where the crc is not equal to the actual crc of the "
-        "payload") {
-      auto body = std::string("\x12\x34\x56\x78\x03\x04\x00\xed\x30\x00", 10);
-      auto expected_payload = std::string("\x03\x04\x00\xed\x30\x00", 6);
-
-      // Calculated using the Sunshine Online CRC Calculator
-      uint32_t expected_crc = 0x6D551F4C;
+        "A body with a complete 4-byte header, and a payload consistent with the CRC field of the "
+        "header, is parsed") {
+      auto body = std::string("\x98\xdb\xe3\x55\x01\x05\x01\x02\x03\x04\x05", 11);
 
       PF::Util::ByteVector<buffer_size> input_buffer;
       PF::Util::convert_string_to_byte_vector(body, input_buffer);
 
       auto parse_status = crc_element.parse(input_buffer);
-      auto crc_check = crc_element.crc();
-
-      auto payload_check = crc_element.payload();
 
       THEN("the parse method reports ok status") { REQUIRE(parse_status == PF::IndexStatus::ok); }
-      THEN("The crc returned from the crc() method is equal to the crc in the body/input_buffer") {
-        uint32_t crc_body = 0x12345678;
-        REQUIRE(crc_check == crc_body);
+      THEN(
+          "the value returned by the crc accessor method is equal to the crc field of the input "
+          "body's header") {
+        // Calculated using the Sunshine Online CRC Calculator
+        uint32_t expected_crc = 0x98DBE355;
+        REQUIRE(crc_element.crc() == expected_crc);
+      }
+      auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05", 7);
+      THEN(
+          "the payload returned from the payload accessor method is equal to the payload from the "
+          "body") {
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+      THEN("the payload given in the CRCElement constructor is independent of the input body") {
+        // change the input_buffer
+        input_buffer.push_back(0x06);
+
+        REQUIRE(crc_element.payload() == expected_payload);
       }
       THEN(
-          "The crc returned from the crc() method is not equal to the actual crc for the given "
-          "payload") {
-        REQUIRE(crc_check != expected_crc);
+          "the payload accessor method returns a reference to the payload buffer given in the "
+          "CRCElement constructor") {
+        // change the payload buffer given to the constructor
+        payload.push_back(0x06);
+
+        // expected buffer returned by the payload accessor method
+        auto expected = std::string("\x01\x05\x01\x02\x03\x04\x05\x06", 8);
+        REQUIRE(crc_element.payload() == expected);
       }
-      THEN("The payload returned from the payload() method is equal to the payload from the body") {
-        REQUIRE(payload_check == expected_payload);
+    }
+
+    WHEN(
+        "A body with a complete 4-byte header, and a payload inconsistent with the CRC field of "
+        "the header, is parsed") {
+      auto body = std::string("\x12\x34\x56\x78\x03\x04\x00\xed\x30\x00", 10);
+
+      PF::Util::ByteVector<buffer_size> input_buffer;
+      PF::Util::convert_string_to_byte_vector(body, input_buffer);
+
+      auto parse_status = crc_element.parse(input_buffer);
+
+      THEN("the parse method reports ok status") { REQUIRE(parse_status == PF::IndexStatus::ok); }
+      THEN(
+          "the value returned by the crc accessor method is equal to the crc field of the input "
+          "body's header") {
+        uint32_t crc_body = 0x12345678;
+        REQUIRE(crc_element.crc() == crc_body);
+      }
+      THEN("the value returned by the crc accessor method is inconsistent with the payload") {
+        // Calculated using the Sunshine Online CRC Calculator
+        uint32_t actual_crc = 0x6D551F4C;
+        REQUIRE(crc_element.crc() != actual_crc);
+      }
+      auto expected_payload = std::string("\x03\x04\x00\xed\x30\x00", 6);
+      THEN(
+          "the payload returned from the payload accessor method is equal to the payload from the "
+          "body") {
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+      THEN("the payload given in the CRCElement constructor is independent of the input body") {
+        // change the input_buffer
+        input_buffer.push_back(0x06);
+
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+      THEN(
+          "the payload accessor method returns a reference to the payload buffer given in the "
+          "CRCElement constructor") {
+        // change the payload buffer given to the constructor
+        payload.push_back(0x06);
+
+        // expected buffer returned by the payload accessor method
+        auto expected = std::string("\x03\x04\x00\xed\x30\x00\x06", 7);
+        REQUIRE(crc_element.payload() == expected);
+      }
+    }
+  }
+
+  GIVEN("A CRC Element initialized with a non-empty payload buffer of capacity 254 bytes") {
+    TestCRCElementProps::PayloadBuffer payload;
+    auto data = std::string("\x12\x13\x14\x15\x16", 5);
+    PF::Util::convert_string_to_byte_vector(data, payload);
+
+    TestCRCElement crc_element{payload};
+
+    WHEN(
+        "A body with a complete 4-byte header, and a payload consistent with the CRC field of the "
+        "header, is parsed") {
+      auto body = std::string("\x2B\x01\xD0\x2C\x01\x06\x11\x22\x33\x44\x55\x66", 12);
+
+      PF::Util::ByteVector<buffer_size> input_buffer;
+      PF::Util::convert_string_to_byte_vector(body, input_buffer);
+
+      THEN("the crc accessor method returns 0 before the parse method is called") {
+        REQUIRE(crc_element.crc() == 0x00000000);
+      }
+      THEN(
+          "the payload returned from the payload accessor method is equal to the payload buffer "
+          "given in the CRCElement constructor") {
+        REQUIRE(crc_element.payload() == data);
+      }
+
+      auto parse_status = crc_element.parse(input_buffer);
+
+      THEN("the parse method reports ok status") { REQUIRE(parse_status == PF::IndexStatus::ok); }
+      THEN(
+          "the value returned by the crc accessor method is equal to the crc field of the input "
+          "body's header") {
+        // Calculated using the Sunshine Online CRC Calculator
+        uint32_t expected_crc = 0x2B01D02C;
+        REQUIRE(crc_element.crc() == expected_crc);
+      }
+      auto expected_payload = std::string("\x01\x06\x11\x22\x33\x44\x55\x66", 8);
+      THEN(
+          "the payload returned from the payload accessor method is equal to the payload from the "
+          "body") {
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+      THEN("the payload given in the CRCElement constructor is independent of the input body") {
+        // change the input_buffer
+        input_buffer.push_back(0x06);
+
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+      THEN(
+          "the payload accessor method returns a reference to the payload buffer given in the "
+          "CRCElement constructor") {
+        // change the payload buffer given to the constructor
+        payload.push_back(0x06);
+
+        // expected buffer returned by the payload accessor method
+        auto expected = std::string("\x01\x06\x11\x22\x33\x44\x55\x66\x06", 9);
+        REQUIRE(crc_element.payload() == expected);
       }
     }
   }
 }
 
-SCENARIO("Protocols::CRCElement: The crc element correctly writes and parses to a buffer") {
+SCENARIO("Protocols::CRCElement: correctly preserves data in roundtrip writing and parsing") {
   GIVEN("A CRC Element initialized with a non empty payload buffer with a capacity of 254 bytes") {
     constexpr size_t buffer_size = 254UL;
     using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
@@ -279,51 +373,96 @@ SCENARIO("Protocols::CRCElement: The crc element correctly writes and parses to 
     WHEN("A body with crc and payload is generated, parsed and generated again") {
       PF::Util::ByteVector<buffer_size> output_buffer;
 
+      THEN("the crc accessor method returns 0 before the first write method is called") {
+        REQUIRE(crc_element.crc() == 0x00000000);
+      }
       auto write_status = crc_element.write(output_buffer, crc32c);
 
-      THEN("The status of write function returns ok") {
+      THEN("The first write method call returns ok status") {
         REQUIRE(write_status == PF::IndexStatus::ok);
       }
-      THEN("The crc from the crc element is equal to expected") {
+      THEN(
+          "After the first write method is called, the crc accessor method returns a value equal "
+          "to the result of directly computing a CRC on the payload") {
+        auto crc_compute = crc32c.compute(payload.buffer(), payload.size());
+        REQUIRE(crc_element.crc() == crc_compute);
+      }
+      THEN(
+          "The CRC field of the body's header matches the value returned by the crc accessor "
+          "method.") {
         // Calculated using the Sunshine Online CRC Calculator
         uint32_t expected_crc = 0x98DBE355;
         REQUIRE(crc_element.crc() == expected_crc);
       }
-      THEN("The payload of the crc element is as expected") {
-        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05");
+      THEN(
+          "The body's payload section correctly stores the payload as '0x01 0x05 0x01 0x02 0x03 "
+          "0x04 0x05'") {
+        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05", 7);
         REQUIRE(crc_element.payload() == expected_payload);
       }
       THEN("The output buffer is as expected") {
-        auto expected_buffer = std::string("\x98\xDB\xE3\x55\x01\x05\x01\x02\x03\x04\x05");
+        auto expected_buffer = std::string("\x98\xDB\xE3\x55\x01\x05\x01\x02\x03\x04\x05", 11);
         REQUIRE(output_buffer == expected_buffer);
       }
 
       auto parse_status = crc_element.parse(output_buffer);
-      THEN("The status of parse function returns ok") {
-        REQUIRE(parse_status == PF::IndexStatus::ok);
-      }
-      THEN("The crc from the CRCElement is equal to the crc in the body") {
+      THEN("The parse method reports ok status") { REQUIRE(parse_status == PF::IndexStatus::ok); }
+      THEN(
+          "the value returned by the crc accessor method is equal to the crc field of the input "
+          "body's header") {
         uint32_t crc_body = 0x98DBE355;
         REQUIRE(crc_element.crc() == crc_body);
       }
-      THEN("payload from the CRCElement is equal to the expected payload from the body") {
-        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05");
+      THEN(
+          "the payload returned from the payload accessor method is equal to the payload from the "
+          "body") {
+        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05", 7);
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+
+      THEN("the payload given in the CRCElement constructor is independent of the input body") {
+        // change the input_buffer
+        output_buffer.push_back(0x06);
+
+        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05", 7);
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+      THEN(
+          "the payload accessor method returns a reference to the payload buffer given in the "
+          "CRCElement constructor") {
+        // change the payload buffer given to the constructor
+        payload.push_back(0x06);
+
+        // expected buffer returned by the payload accessor method
+        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05\x06", 8);
         REQUIRE(crc_element.payload() == expected_payload);
       }
 
       auto write = crc_element.write(output_buffer, crc32c);
-      THEN("The status of write function returns ok") { REQUIRE(write == PF::IndexStatus::ok); }
-      THEN("The crc from the crc element is equal to expected") {
+      THEN("The second write method call returns ok status") {
+        REQUIRE(write == PF::IndexStatus::ok);
+      }
+      THEN(
+          "After the second write method is called, the crc accessor method returns a value equal "
+          "to the result of directly computing a CRC on the payload") {
+        auto crc_compute = crc32c.compute(payload.buffer(), payload.size());
+        REQUIRE(crc_element.crc() == crc_compute);
+      }
+      THEN(
+          "The CRC field of the body's header matches the value returned by the crc accessor "
+          "method.") {
         // Calculated using the Sunshine Online CRC Calculator
         uint32_t expected_crc = 0x98DBE355;
         REQUIRE(crc_element.crc() == expected_crc);
       }
-      THEN("The payload of the crc element is as expected") {
-        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05");
+      THEN(
+          "The body's payload section correctly stores the payload as '0x01 0x05 0x01 0x02 0x03 "
+          "0x04 0x05'") {
+        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05", 7);
         REQUIRE(crc_element.payload() == expected_payload);
       }
       THEN("The output buffer is as expected") {
-        auto expected_buffer = std::string("\x98\xDB\xE3\x55\x01\x05\x01\x02\x03\x04\x05");
+        auto expected_buffer = std::string("\x98\xDB\xE3\x55\x01\x05\x01\x02\x03\x04\x05", 11);
         REQUIRE(output_buffer == expected_buffer);
       }
     }
@@ -331,8 +470,8 @@ SCENARIO("Protocols::CRCElement: The crc element correctly writes and parses to 
 }
 
 SCENARIO(
-    "Protocols::CRCElementReceiver: The crc element receiver correctly parses datagrams into "
-    "payloads",
+    "Protocols::CRCElementReceiver: correctly parses CRCElement bodies and performs consistency "
+    "checking on them",
     "[CRCElementReceiver]") {
   GIVEN("A CRC element receiver of capacity 254 bytes") {
     constexpr size_t buffer_size = 254UL;
@@ -350,30 +489,39 @@ SCENARIO(
     WHEN(
         "A body with crc more than 4 bytes and equal to the crc of the payload is given to the "
         "crc_element receiver") {
-      auto body = std::string("\x98\xdb\xe3\x55\x01\x05\x01\x02\x03\x04\x05", 11);
+      auto body = std::string("\x44\xeb\x77\x5f\x01\x07\x07\x12\x36\x57\x66\x77\x18", 13);
       PF::Util::ByteVector<buffer_size> input_buffer;
       PF::Util::convert_string_to_byte_vector(body, input_buffer);
 
-      uint32_t expected_crc = 0x98dbe355;
-      auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05", 7);
-
       auto transform_status = crc_element_receiver.transform(input_buffer, crc_element);
-      auto payload = crc_element.payload();
 
       THEN("the transform method reports ok status") {
         REQUIRE(transform_status == TestCRCElementReceiver::Status::ok);
       }
-
-      THEN("the crc returned from the crc() method is equal to the crc in the body/input_buffer") {
+      THEN(
+          "the value returned by the crc accessor method is equal to the crc field of the input "
+          "body's header") {
+        uint32_t expected_crc = 0x44EB775F;
         REQUIRE(crc_element.crc() == expected_crc);
       }
+      THEN(
+          "the payload returned from the payload accessor method is equal to the payload from the "
+          "body") {
+        auto expected_payload = std::string("\x01\x07\x07\x12\x36\x57\x66\x77\x18", 9);
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+      THEN("the payload buffer updated in the CRCElement is independent of the input body") {
+        // change input buffer
+        input_buffer.push_back(0x01);
 
-      THEN("the payload returned from the payload() method is equal to the payload from the body") {
-        REQUIRE(payload == expected_payload);
+        auto expected_payload = std::string("\x01\x07\x07\x12\x36\x57\x66\x77\x18", 9);
+        REQUIRE(crc_element.payload() == expected_payload);
       }
     }
 
-    WHEN("body with 0 bytes is given to the crc element receiver") {
+    WHEN(
+        "A body without a complete 4-byte header and empty payload is given to the crc element "
+        "receiver") {
       TestCRCElementProps::PayloadBuffer input_payload;
       TestCRCElement crc_element{input_payload};
 
@@ -387,7 +535,7 @@ SCENARIO(
         REQUIRE(transform_status == TestCRCElementReceiver::Status::invalid_parse);
       }
 
-      THEN("The crc returned from the crc() method is equal to 0") {
+      THEN("the value returned by the crc accessor method is equal to 0x00000000") {
         REQUIRE(crc_element.crc() == expected_crc);
       }
     }
@@ -409,7 +557,7 @@ SCENARIO(
       THEN("the transform status is equal to invalid parse") {
         REQUIRE(status == TestCRCElementReceiver::Status::invalid_parse);
       }
-      THEN("The crc returned from the crc() method is equal to 0") {
+      THEN("the value returned by the crc accessor method is equal to 0") {
         uint32_t expected_crc = 0x00;
         REQUIRE(crc_element.crc() == expected_crc);
       }
@@ -426,7 +574,7 @@ SCENARIO(
       THEN("the transform status is equal to invalid parse") {
         REQUIRE(first == TestCRCElementReceiver::Status::invalid_parse);
       }
-      THEN("The crc returned from the crc() method is equal to 0") {
+      THEN("the value returned by the crc accessor method is equal to 0") {
         uint32_t expected_crc = 0x00;
         REQUIRE(crc_element.crc() == expected_crc);
       }
@@ -443,7 +591,7 @@ SCENARIO(
       THEN("the transform status is equal to invalid parse") {
         REQUIRE(second == TestCRCElementReceiver::Status::invalid_parse);
       }
-      THEN("The crc returned from the crc() method is equal to 0") {
+      THEN("the value returned by the crc accessor method is equal to 0") {
         uint32_t expected_crc = 0x00;
         REQUIRE(crc_element.crc() == expected_crc);
       }
@@ -465,7 +613,8 @@ SCENARIO(
       }
 
       THEN(
-          "the crc returned from the crc() method is equal to the invalid crc given in input "
+          "the value returned by the crc accessor method is equal to the invalid crc given in "
+          "input "
           "body") {
         REQUIRE(crc_element.crc() == expected_crc);
       }
@@ -488,10 +637,6 @@ SCENARIO(
     WHEN("A payload is given along with a sufficiently large output buffer") {
       auto body = std::string("\x13\x03\x05\x06\x23", 5);
 
-      // Calculated using the Sunshine Online CRC Calculator
-      uint32_t expected_crc = 0x81FC3457;
-      auto expected_output = std::string("\x81\xfc\x34\x57\x13\x03\x05\x06\x23", 9);
-
       TestCRCElementProps::PayloadBuffer input_payload;
       PF::Util::convert_string_to_byte_vector(body, input_payload);
 
@@ -503,7 +648,14 @@ SCENARIO(
         REQUIRE(transform_status == TestCRCElementSender::Status::ok);
       }
       THEN("output buffer is as expected, equal to (crc + input_buffer)") {
+        auto expected_output = std::string("\x81\xfc\x34\x57\x13\x03\x05\x06\x23", 9);
         REQUIRE(output_buffer == expected_output);
+      }
+      THEN("The CRC field of the output buffer's header is consistent with the input_payload.") {
+        // Calculated using the Sunshine Online CRC Calculator
+        uint32_t expected_crc = 0x81FC3457;
+        auto crc_compute = crc32c.compute(input_payload.buffer(), input_payload.size());
+        REQUIRE(expected_crc == crc_compute);
       }
     }
   }

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
@@ -324,6 +324,28 @@ SCENARIO(
 
     TestCRCElement crc_element{payload};
 
+    WHEN("A body without a complete 4-byte header is parsed") {
+      auto body = std::string("\x98\xdb\xe3", 3);
+
+      PF::Util::ByteVector<buffer_size> input_buffer;
+      PF::Util::convert_string_to_byte_vector(body, input_buffer);
+
+      auto parse_status = crc_element.parse(input_buffer);
+
+      THEN("the parse method reports out of bounds status") {
+        REQUIRE(parse_status == PF::IndexStatus::out_of_bounds);
+      }
+      THEN("The bytes in the constructor's payload buffer are '0x12 0x13 0x14 0x15 0x16' ") {
+        auto data = PF::Util::make_array<uint8_t>(0x12, 0x13, 0x14, 0x15, 0x16);
+        for (size_t i = 0; i < 5; ++i) {
+          REQUIRE(payload.operator[](i) == data[i]);
+        }
+      }
+      THEN("The payload accesor method returns the constructor's payload buffer") {
+        REQUIRE(crc_element.payload() == data);
+      }
+    }
+
     WHEN(
         "A body with a complete 4-byte header, and a payload consistent with the CRC field of the "
         "header, is parsed") {
@@ -335,9 +357,13 @@ SCENARIO(
       THEN("the crc accessor method returns 0 before the parse method is called") {
         REQUIRE(crc_element.crc() == 0x00000000);
       }
-      THEN(
-          "the payload returned from the payload accessor method is equal to the payload buffer "
-          "given in the CRCElement constructor") {
+      THEN("The bytes in the constructor's payload buffer are '0x12 0x13 0x14 0x15 0x16' ") {
+        auto data = PF::Util::make_array<uint8_t>(0x12, 0x13, 0x14, 0x15, 0x16);
+        for (size_t i = 0; i < 5; ++i) {
+          REQUIRE(payload.operator[](i) == data[i]);
+        }
+      }
+      THEN("The payload accesor method returns the constructor's payload buffer") {
         REQUIRE(crc_element.payload() == data);
       }
 

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
@@ -220,9 +220,17 @@ SCENARIO(
       THEN("the parse method reports out of bounds status") {
         REQUIRE(parse_status == PF::IndexStatus::out_of_bounds);
       }
-      THEN("the constructor's payload buffer remains unchanged") {
+      THEN("the crc accessor method returns 0") { REQUIRE(crc_element.crc() == 0); }
+      THEN(
+          "the payload accessor method returns a reference to the payload buffer given in the "
+          "CRCElement constructor") {
         auto expected = crc_element.payload();
         REQUIRE(expected.empty() == true);
+      }
+      THEN(
+          "the payload given in the CRCElement constructor is independent of the input buffer "
+          "body") {
+        REQUIRE(payload.empty() == true);
       }
     }
 
@@ -251,12 +259,6 @@ SCENARIO(
           "body") {
         REQUIRE(crc_element.payload() == expected_payload);
       }
-      THEN("the payload given in the CRCElement constructor is independent of the input body") {
-        // change the input_buffer
-        input_buffer.push_back(0x06);
-
-        REQUIRE(crc_element.payload() == expected_payload);
-      }
       THEN(
           "the payload accessor method returns a reference to the payload buffer given in the "
           "CRCElement constructor") {
@@ -266,6 +268,12 @@ SCENARIO(
         // expected buffer returned by the payload accessor method
         auto expected = std::string("\x01\x05\x01\x02\x03\x04\x05\x06", 8);
         REQUIRE(crc_element.payload() == expected);
+      }
+      THEN("the payload given in the CRCElement constructor is independent of the input body") {
+        // change the input_buffer
+        input_buffer.push_back(0x06);
+
+        REQUIRE(crc_element.payload() == expected_payload);
       }
     }
 
@@ -298,12 +306,6 @@ SCENARIO(
           "body") {
         REQUIRE(crc_element.payload() == expected_payload);
       }
-      THEN("the payload given in the CRCElement constructor is independent of the input body") {
-        // change the input_buffer
-        input_buffer.push_back(0x06);
-
-        REQUIRE(crc_element.payload() == expected_payload);
-      }
       THEN(
           "the payload accessor method returns a reference to the payload buffer given in the "
           "CRCElement constructor") {
@@ -313,6 +315,12 @@ SCENARIO(
         // expected buffer returned by the payload accessor method
         auto expected = std::string("\x03\x04\x00\xed\x30\x00\x06", 7);
         REQUIRE(crc_element.payload() == expected);
+      }
+      THEN("the payload given in the CRCElement constructor is independent of the input body") {
+        // change the input_buffer
+        input_buffer.push_back(0x06);
+
+        REQUIRE(crc_element.payload() == expected_payload);
       }
     }
   }
@@ -335,13 +343,27 @@ SCENARIO(
       THEN("the parse method reports out of bounds status") {
         REQUIRE(parse_status == PF::IndexStatus::out_of_bounds);
       }
-      THEN("The bytes in the constructor's payload buffer are '0x12 0x13 0x14 0x15 0x16' ") {
+      THEN(
+          "the value returned by the crc accessor method is equal to the crc field of the input "
+          "body's header") {
+        REQUIRE(crc_element.crc() == 0);
+      }
+      THEN("The payload buffer given to it's constructor is '0x12 0x13 0x14 0x15 0x16' ") {
         auto data = PF::Util::make_array<uint8_t>(0x12, 0x13, 0x14, 0x15, 0x16);
         for (size_t i = 0; i < 5; ++i) {
           REQUIRE(payload.operator[](i) == data[i]);
         }
       }
-      THEN("The payload accesor method returns the constructor's payload buffer") {
+      THEN(
+          "the payload accessor method returns a reference to the payload buffer given in the "
+          "CRCElement constructor") {
+        REQUIRE(crc_element.payload() == data);
+      }
+      THEN(
+          "the payload given in the CRCElement constructor is independent of the input buffer "
+          "body") {
+        input_buffer.push_back(0x06);
+
         REQUIRE(crc_element.payload() == data);
       }
     }
@@ -384,12 +406,6 @@ SCENARIO(
           "body") {
         REQUIRE(crc_element.payload() == expected_payload);
       }
-      THEN("the payload given in the CRCElement constructor is independent of the input body") {
-        // change the input_buffer
-        input_buffer.push_back(0x06);
-
-        REQUIRE(crc_element.payload() == expected_payload);
-      }
       THEN(
           "the payload accessor method returns a reference to the payload buffer given in the "
           "CRCElement constructor") {
@@ -399,6 +415,12 @@ SCENARIO(
         // expected buffer returned by the payload accessor method
         auto expected = std::string("\x01\x06\x11\x22\x33\x44\x55\x66\x06", 9);
         REQUIRE(crc_element.payload() == expected);
+      }
+      THEN("the payload given in the CRCElement constructor is independent of the input body") {
+        // change the input_buffer
+        input_buffer.push_back(0x06);
+
+        REQUIRE(crc_element.payload() == expected_payload);
       }
     }
   }
@@ -568,25 +590,28 @@ SCENARIO(
       THEN("the transform method reports ok status") {
         REQUIRE(transform_status == TestCRCElementReceiver::Status::ok);
       }
-      THEN(
-          "After the transform method is called, the value returned by the crc accessor method is "
-          "equal to the crc field of the input "
-          "body's header") {
-        uint32_t expected_crc = 0x44EB775F;
-        REQUIRE(crc_element.crc() == expected_crc);
-      }
-      THEN(
-          "the payload returned from the payload accessor method is equal to the payload from the "
-          "body") {
-        auto expected_payload = std::string("\x01\x07\x07\x12\x36\x57\x66\x77\x18", 9);
-        REQUIRE(crc_element.payload() == expected_payload);
-      }
-      THEN("the payload buffer updated in the CRCElement is independent of the input body") {
-        // change input buffer
-        input_buffer.push_back(0x01);
+      THEN("The ParsedCRCElement output parameter has the following properties") {
+        THEN(
+            "the value returned by it's crc accessor method is "
+            "equal to the crc field of the input "
+            "body's header") {
+          uint32_t expected_crc = 0x44EB775F;
+          REQUIRE(crc_element.crc() == expected_crc);
+        }
+        THEN("the payload given to it's constructor is empty")
+        THEN(
+            "Its payload accessor method returns a reference to the payload given in its "
+            "constructor") {
+          auto expected_payload = std::string("\x01\x07\x07\x12\x36\x57\x66\x77\x18", 9);
+          REQUIRE(crc_element.payload() == expected_payload);
+        }
+        THEN("the payload buffer updated in the CRCElement is independent of the input body") {
+          // change input buffer
+          input_buffer.push_back(0x01);
 
-        auto expected_payload = std::string("\x01\x07\x07\x12\x36\x57\x66\x77\x18", 9);
-        REQUIRE(crc_element.payload() == expected_payload);
+          auto expected_payload = std::string("\x01\x07\x07\x12\x36\x57\x66\x77\x18", 9);
+          REQUIRE(crc_element.payload() == expected_payload);
+        }
       }
     }
 
@@ -599,16 +624,25 @@ SCENARIO(
         REQUIRE(transform_status == TestCRCElementReceiver::Status::invalid_parse);
       }
       THEN(
-          "After the transform method is called, the value returned by the crc accessor method is "
-          "equal to 0x00000000") {
-        uint32_t expected_crc = 0x00000000;
-        REQUIRE(crc_element.crc() == expected_crc);
-      }
-      THEN(
-          "the payload returned from the payload accessor method is equal to the payload from the "
-          "body") {
-        auto expected = crc_element.payload();
-        REQUIRE(expected.empty() == true);
+          "After the transform method is called, The ParsedCRCElement output parameter has the "
+          "following properties : ") {
+        THEN(
+            "the value returned by it's crc accessor method is equal to the crc field of the input "
+            "body's header") {
+          uint32_t expected_crc = 0x00000000;
+          REQUIRE(crc_element.crc() == expected_crc);
+        }
+        THEN(
+            "Its payload accessor method returns a reference to the payload given in its "
+            "constructor") {
+          auto expected = crc_element.payload();
+          REQUIRE(expected.empty() == true);
+        }
+        THEN("The data in its payload is independent of the data in input_buffer") {
+          input_buffer.push_back(0x02);
+          auto expected = crc_element.payload();
+          REQUIRE(expected.empty() == true);
+        }
       }
     }
 
@@ -627,16 +661,25 @@ SCENARIO(
         REQUIRE(status == TestCRCElementReceiver::Status::invalid_parse);
       }
       THEN(
-          "After the transform method is called, the value returned by the crc accessor method is "
-          "equal to 0") {
-        uint32_t expected_crc = 0x00;
-        REQUIRE(crc_element.crc() == expected_crc);
-      }
-      THEN(
-          "the payload returned from the payload accessor method of the output_crcelement is equal "
-          "to the payload from the body") {
-        auto expected = crc_element.payload();
-        REQUIRE(expected.empty() == true);
+          "After the transform method is called, The ParsedCRCElement output parameter has the "
+          "following properties : ") {
+        THEN(
+            "the value returned by it's crc accessor method is equal to the crc field of the input "
+            "body's header") {
+          uint32_t expected_crc = 0x00;
+          REQUIRE(crc_element.crc() == expected_crc);
+        }
+        THEN(
+            "Its payload accessor method returns a reference to the payload given in its "
+            "constructor") {
+          auto expected = crc_element.payload();
+          REQUIRE(expected.empty() == true);
+        }
+        THEN("The data in its payload is independent of the data in input_buffer") {
+          input_buffer.push_back(0x02);
+          auto expected = crc_element.payload();
+          REQUIRE(expected.empty() == true);
+        }
       }
 
       // body of length 2 bytes
@@ -652,16 +695,25 @@ SCENARIO(
         REQUIRE(first == TestCRCElementReceiver::Status::invalid_parse);
       }
       THEN(
-          "After the transform method is called, the value returned by the crc accessor method is "
-          "equal to 0") {
-        uint32_t expected_crc = 0x00;
-        REQUIRE(crc_element.crc() == expected_crc);
-      }
-      THEN(
-          "the payload returned from the payload accessor method of the output_crcelement is equal "
-          "to the payload from the body") {
-        auto expected = crc_element.payload();
-        REQUIRE(expected.empty() == true);
+          "After the transform method is called, The ParsedCRCElement output parameter has the "
+          "following properties : ") {
+        THEN(
+            "the value returned by it's crc accessor method is equal to the crc field of the input "
+            "body's header") {
+          uint32_t expected_crc = 0x00;
+          REQUIRE(crc_element.crc() == expected_crc);
+        }
+        THEN(
+            "Its payload accessor method returns a reference to the payload given in its "
+            "constructor") {
+          auto expected = crc_element.payload();
+          REQUIRE(expected.empty() == true);
+        }
+        THEN("The data in its payload is independent of the data in input_buffer") {
+          input_buffer.push_back(0x02);
+          auto expected = crc_element.payload();
+          REQUIRE(expected.empty() == true);
+        }
       }
 
       // body of length 3 bytes
@@ -677,16 +729,25 @@ SCENARIO(
         REQUIRE(second == TestCRCElementReceiver::Status::invalid_parse);
       }
       THEN(
-          "After the transform method is called, the value returned by the crc accessor method is "
-          "equal to 0") {
-        uint32_t expected_crc = 0x00;
-        REQUIRE(crc_element.crc() == expected_crc);
-      }
-      THEN(
-          "the payload returned from the payload accessor method of the output_crcelement is equal "
-          "to the payload from the body") {
-        auto expected = crc_element.payload();
-        REQUIRE(expected.empty() == true);
+          "After the transform method is called, The ParsedCRCElement output parameter has the "
+          "following properties : ") {
+        THEN(
+            "the value returned by it's crc accessor method is equal to the crc field of the input "
+            "body's header") {
+          uint32_t expected_crc = 0x00;
+          REQUIRE(crc_element.crc() == expected_crc);
+        }
+        THEN(
+            "Its payload accessor method returns a reference to the payload given in its "
+            "constructor") {
+          auto expected = crc_element.payload();
+          REQUIRE(expected.empty() == true);
+        }
+        THEN("The data in its payload is independent of the data in input_buffer") {
+          input_buffer.push_back(0x02);
+          auto expected = crc_element.payload();
+          REQUIRE(expected.empty() == true);
+        }
       }
     }
 
@@ -704,19 +765,29 @@ SCENARIO(
       THEN("the transform method reports invalid crc status") {
         REQUIRE(transform_status == TestCRCElementReceiver::Status::invalid_crc);
       }
-
       THEN(
-          "After the transform method is called, the value returned by the crc accessor method is "
-          "equal to the crc field of the input "
-          "body's header") {
-        REQUIRE(crc_element.crc() == expected_crc);
+          "After the transform method is called, The ParsedCRCElement output parameter has the "
+          "following properties : ") {
+        THEN(
+            "the value returned by it's crc accessor method is equal to the crc field of the input "
+            "body's header") {
+          REQUIRE(crc_element.crc() == expected_crc);
+        }
+        auto expected = std::string("\x01\x05\x01\x02\x03\x04\x05", 7);
+        THEN(
+            "Its payload accessor method returns a reference to the payload given in its "
+            "constructor") {}
+        THEN("The data in its payload is independent of the data in input_buffer") {
+          input_buffer.push_back(0x02);
+          REQUIRE(crc_element.payload() == expected);
+        }
       }
     }
   }
 
   GIVEN(
       "A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an "
-      "empty payload buffer") {
+      "non-empty payload buffer") {
     constexpr size_t buffer_size = 254UL;
     using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
     using TestCRCElement = PF::Protocols::CRCElement<TestCRCElementProps::PayloadBuffer>;
@@ -744,24 +815,27 @@ SCENARIO(
         REQUIRE(transform_status == TestCRCElementReceiver::Status::ok);
       }
       THEN(
-          "After the transform method is called, the value returned by the crc accessor method is "
-          "equal to the crc field of the input "
-          "body's header") {
-        uint32_t expected_crc = 0x44EB775F;
-        REQUIRE(crc_element.crc() == expected_crc);
-      }
-      THEN(
-          "the payload returned from the payload accessor method is equal to the payload from the "
-          "body") {
-        auto expected_payload = std::string("\x01\x07\x07\x12\x36\x57\x66\x77\x18", 9);
-        REQUIRE(crc_element.payload() == expected_payload);
-      }
-      THEN("the payload buffer updated in the CRCElement is independent of the input body") {
-        // change input buffer
-        input_buffer.push_back(0x01);
+          "After the transform method is called, The ParsedCRCElement output parameter has the "
+          "following properties : ") {
+        THEN(
+            "the value returned by it's crc accessor method is equal to the crc field of the input "
+            "body's header") {
+          uint32_t expected_crc = 0x44EB775F;
+          REQUIRE(crc_element.crc() == expected_crc);
+        }
+        THEN(
+            "Its payload accessor method returns a reference to the payload given in its "
+            "constructor") {
+          auto expected_payload = std::string("\x01\x07\x07\x12\x36\x57\x66\x77\x18", 9);
+          REQUIRE(crc_element.payload() == expected_payload);
+        }
+        THEN("The data in its payload is independent of the data in input_buffer") {
+          // change input buffer
+          input_buffer.push_back(0x01);
 
-        auto expected_payload = std::string("\x01\x07\x07\x12\x36\x57\x66\x77\x18", 9);
-        REQUIRE(crc_element.payload() == expected_payload);
+          auto expected_payload = std::string("\x01\x07\x07\x12\x36\x57\x66\x77\x18", 9);
+          REQUIRE(crc_element.payload() == expected_payload);
+        }
       }
     }
 
@@ -774,15 +848,23 @@ SCENARIO(
         REQUIRE(transform_status == TestCRCElementReceiver::Status::invalid_parse);
       }
       THEN(
-          "After the transform method is called, the value returned by the crc accessor method is "
-          "equal to 0x00000000") {
-        uint32_t expected_crc = 0x00000000;
-        REQUIRE(crc_element.crc() == expected_crc);
-      }
-      THEN(
-          "After the transform method is called, the payload given in the ParsedCRCElement "
-          "constructor remains unchanged") {
-        REQUIRE(crc_element.payload() == body);
+          "After the transform method is called, The ParsedCRCElement output parameter has the "
+          "following properties : ") {
+        THEN(
+            "the value returned by it's crc accessor method is equal to the crc field of the input "
+            "body's header") {
+          uint32_t expected_crc = 0x00000000;
+          REQUIRE(crc_element.crc() == expected_crc);
+        }
+        THEN(
+            "Its payload accessor method returns a reference to the payload given in its "
+            "constructor") {
+          REQUIRE(crc_element.payload() == body);
+        }
+        THEN("The data in its payload is independent of the data in input_buffer") {
+          input_buffer.push_back(0x02);
+          REQUIRE(crc_element.payload() == body);
+        }
       }
     }
 
@@ -807,15 +889,21 @@ SCENARIO(
         REQUIRE(transform_status == TestCRCElementReceiver::Status::invalid_parse);
       }
       THEN(
-          "After the transform method is called, the value returned by the crc accessor method is "
-          "equal to '0x40D06D79'") {
-        uint32_t expected_crc = 0x40D06D79;
-        REQUIRE(crc_element.crc() == expected_crc);
-      }
-      THEN(
-          "After the transform method is called, the payload given in the ParsedCRCElement "
-          "constructor remains unchanged") {
-        REQUIRE(crc_element.payload() == body);
+          "After the transform method is called, The ParsedCRCElement output parameter has the "
+          "following properties : ") {
+        THEN("the value returned by it's crc accessor method is equal to '0x40D06D79'") {
+          uint32_t expected_crc = 0x40D06D79;
+          REQUIRE(crc_element.crc() == expected_crc);
+        }
+        THEN(
+            "Its payload accessor method returns a reference to the payload given in its "
+            "constructor") {
+          REQUIRE(crc_element.payload() == body);
+        }
+        THEN("The data in its payload is independent of the data in input_buffer") {
+          input_buffer.push_back(0x02);
+          REQUIRE(crc_element.payload() == body);
+        }
       }
     }
   }

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
@@ -1,0 +1,537 @@
+/*
+ * Copyright 2020, the Pez Globo team and the Pufferfish project contributors
+ *
+ * CRCElements.cpp
+ *
+ *  Created on: Nov 3, 2020
+ *      Author: Rohan Purohit, Renji Panicker
+ *
+ * Unit tests to confirm behavior of CRCElement
+ *
+ */
+
+#include "Pufferfish/Protocols/CRCElements.h"
+
+#include "Pufferfish/HAL/CRCChecker.h"
+#include "Pufferfish/Test/Util.h"
+#include "Pufferfish/Util/Array.h"
+#include "Pufferfish/Util/Endian.h"
+#include "catch2/catch.hpp"
+namespace PF = Pufferfish;
+
+constexpr size_t buffer_size = 254UL;
+using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
+using TestCRCElement = PF::Protocols::CRCElement<TestCRCElementProps::PayloadBuffer>;
+using TestCRCElementHeaderProps = PF::Protocols::CRCElementHeaderProps;
+
+SCENARIO(
+    "Protocols::CRCElement: The compute_body_crc function correctly computes crc from body",
+    "[CRCElement]") {
+  PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
+  GIVEN("A CRC element initialized with an empty payload") {
+    TestCRCElementProps::PayloadBuffer input_payload;
+
+    TestCRCElement crc_element{input_payload};
+
+    WHEN("the crc is computed from the payload") {
+      // Calculated using the Sunshine Online CRC Calculator
+      uint32_t expected_crc = 0x00000000;
+
+      TestCRCElementProps::PayloadBuffer output_payload;
+      output_payload.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
+      output_payload.copy_from(
+          input_payload.buffer(), input_payload.size(), TestCRCElementHeaderProps::payload_offset);
+
+      auto computed_crc = TestCRCElement::compute_body_crc(output_payload, crc32c);
+
+      THEN("the computed crc is equal to the expected crc") {
+        REQUIRE(computed_crc == expected_crc);
+      }
+    }
+  }
+
+  GIVEN("A CRC Element initialized with the payload '123456789'") {
+    TestCRCElementProps::PayloadBuffer input_payload;
+    auto data = std::string("123456789");
+    for (auto& ch : data) {
+      input_payload.push_back(ch);
+    }
+
+    TestCRCElement crc_element{input_payload};
+
+    WHEN("the crc is computed from the payload") {
+      // Calculated using the Sunshine Online CRC Calculator
+      uint32_t expected_crc = 0xe3069283;
+
+      TestCRCElementProps::PayloadBuffer output_payload;
+      output_payload.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
+      output_payload.copy_from(
+          input_payload.buffer(), input_payload.size(), TestCRCElementHeaderProps::payload_offset);
+
+      auto computed_crc = TestCRCElement::compute_body_crc(output_payload, crc32c);
+
+      THEN("the computed crc is equal to the expected crc") {
+        REQUIRE(computed_crc == expected_crc);
+      }
+    }
+  }
+
+  GIVEN("A crc element is initalised with payload 0x00") {
+    TestCRCElementProps::PayloadBuffer input_payload;
+    input_payload.push_back(0x00);
+
+    TestCRCElement crc_element{input_payload};
+
+    WHEN("the crc is computed from the payload") {
+      // Calculated using the Sunshine Online CRC Calculator
+      uint32_t expected_crc = 0x527d5351;
+
+      TestCRCElementProps::PayloadBuffer output_payload;
+
+      output_payload.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
+      output_payload.copy_from(
+          input_payload.buffer(), input_payload.size(), TestCRCElementHeaderProps::payload_offset);
+
+      auto computed_crc = TestCRCElement::compute_body_crc(output_payload, crc32c);
+
+      THEN("the computed crc is equal to the expected crc") {
+        REQUIRE(computed_crc == expected_crc);
+      }
+    }
+  }
+
+  GIVEN("A crc element is initalised with payload 0x01") {
+    TestCRCElementProps::PayloadBuffer input_payload;
+    input_payload.push_back(0x01);
+
+    TestCRCElement crc_element{input_payload};
+
+    WHEN("the crc is computed from the payload") {
+      // Calculated using the Sunshine Online CRC Calculator
+      uint32_t expected_crc = 0xa016d052;
+
+      TestCRCElementProps::PayloadBuffer output_payload;
+
+      output_payload.resize(TestCRCElementHeaderProps::header_size + input_payload.size());
+      output_payload.copy_from(
+          input_payload.buffer(), input_payload.size(), TestCRCElementHeaderProps::payload_offset);
+
+      auto computed_crc = TestCRCElement::compute_body_crc(output_payload, crc32c);
+
+      THEN("the computed crc is equal to the expected crc") {
+        REQUIRE(computed_crc == expected_crc);
+      }
+    }
+  }
+}
+
+SCENARIO(
+    "Protocols::CRCElement: The write function correctly generates body from computed crc and "
+    "payload",
+    "[CRCElement]") {
+  PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
+  GIVEN("A crc element initalised with payload=[0x01, 0x02, 0x05]") {
+    TestCRCElementProps::PayloadBuffer input_payload;
+    auto data = PF::Util::make_array<uint8_t>(0x01, 0x02, 0x05);
+    for (auto& bytes : data) {
+      input_payload.push_back(bytes);
+    }
+
+    TestCRCElement crc_element{input_payload};
+    WHEN("The crc and payload are written to the output buffer") {
+      TestCRCElementProps::PayloadBuffer output_buffer;
+      auto expected = std::string("\xD7\x91\x15\xF6\x01\x02\x05");
+
+      auto write_status = crc_element.write(output_buffer, crc32c);
+      auto crc_compute = crc32c.compute(input_payload.buffer(), input_payload.size());
+
+      THEN("crc computed in write method is same as crcchecker compute") {
+        REQUIRE(write_status == PF::IndexStatus::ok);
+        REQUIRE(crc_element.crc() == crc_compute);
+      }
+
+      THEN("The output buffer is as expected") { REQUIRE(output_buffer == expected); }
+    }
+  }
+
+  GIVEN("A crc element is initalised with an empty payload") {
+    TestCRCElementProps::PayloadBuffer input_payload;
+
+    TestCRCElement crc_element{input_payload};
+
+    WHEN("The crc and payload are written to the output buffer") {
+      PF::Util::ByteVector<buffer_size> output_buffer;
+
+      auto write_status = crc_element.write(output_buffer, crc32c);
+      auto crc_payload = crc_element.crc();
+      THEN("The write status reports ok") { REQUIRE(write_status == PF::IndexStatus::ok); }
+      THEN("The CRC returned by the crc() method is equal to 0") { REQUIRE(crc_payload == 0); }
+      THEN("The output buffer is as expected") {
+        auto expected_buffer = std::string("\x00\x00\x00\x00", 4);
+        REQUIRE(output_buffer == expected_buffer);
+      }
+    }
+  }
+}
+
+SCENARIO(
+    "Protocols::CRCElement: The parse function correctly updates internal crc and payload fields "
+    "from the input buffer",
+    "[CRCElement]") {
+  GIVEN("A CRC Element initialized with an empty payload buffer with a capacity of 254 bytes") {
+    constexpr size_t buffer_size = 254UL;
+    using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
+    using TestCRCElement = PF::Protocols::CRCElement<TestCRCElementProps::PayloadBuffer>;
+    PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
+
+    TestCRCElementProps::PayloadBuffer payload;
+
+    TestCRCElement crc_element{payload};
+
+    WHEN("A body with crc more than 4 bytes and equal to the crc of the payload is parsed") {
+      // Calculated using the Sunshine Online CRC Calculator
+      uint32_t expected_crc = 0x98DBE355;
+
+      auto body = std::string("\x98\xdb\xe3\x55\x01\x05\x01\x02\x03\x04\x05", 11);
+      auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05", 7);
+
+      PF::Util::ByteVector<buffer_size> input_buffer;
+      PF::Util::convert_string_to_byte_vector(body, input_buffer);
+
+      auto parse_status = crc_element.parse(input_buffer);
+      auto crc_check = crc_element.crc();
+      const auto& payload_check = crc_element.payload();
+
+      THEN("the parse method reports ok status") { REQUIRE(parse_status == PF::IndexStatus::ok); }
+
+      THEN("crc returned from the crc() method is equal to the crc in the body/input_buffer") {
+        REQUIRE(crc_check == expected_crc);
+      }
+
+      THEN("payload returned from the payload() method is equal to the payload from the body") {
+        REQUIRE(payload_check == expected_payload);
+      }
+    }
+
+    WHEN("A body of less than 4 bytes is parsed") {
+      auto body = std::string("\x98\xdb\xe3", 3);
+
+      PF::Util::ByteVector<buffer_size> input_buffer;
+      PF::Util::convert_string_to_byte_vector(body, input_buffer);
+
+      auto parse_status = crc_element.parse(input_buffer);
+
+      THEN("the parse method reports out of bounds status") {
+        REQUIRE(parse_status == PF::IndexStatus::out_of_bounds);
+      }
+    }
+
+    WHEN(
+        "A body with crc and payload is given, where the crc is not equal to the actual crc of the "
+        "payload") {
+      auto body = std::string("\x12\x34\x56\x78\x03\x04\x00\xed\x30\x00", 10);
+      auto expected_payload = std::string("\x03\x04\x00\xed\x30\x00", 6);
+
+      // Calculated using the Sunshine Online CRC Calculator
+      uint32_t expected_crc = 0x6D551F4C;
+
+      PF::Util::ByteVector<buffer_size> input_buffer;
+      PF::Util::convert_string_to_byte_vector(body, input_buffer);
+
+      auto parse_status = crc_element.parse(input_buffer);
+      auto crc_check = crc_element.crc();
+
+      auto payload_check = crc_element.payload();
+
+      THEN("the parse method reports ok status") { REQUIRE(parse_status == PF::IndexStatus::ok); }
+      THEN("The crc returned from the crc() method is equal to the crc in the body/input_buffer") {
+        uint32_t crc_body = 0x12345678;
+        REQUIRE(crc_check == crc_body);
+      }
+      THEN(
+          "The crc returned from the crc() method is not equal to the actual crc for the given "
+          "payload") {
+        REQUIRE(crc_check != expected_crc);
+      }
+      THEN("The payload returned from the payload() method is equal to the payload from the body") {
+        REQUIRE(payload_check == expected_payload);
+      }
+    }
+  }
+}
+
+SCENARIO("Protocols::CRCElement: The crc element correctly writes and parses to a buffer") {
+  GIVEN("A CRC Element initialized with a non empty payload buffer with a capacity of 254 bytes") {
+    constexpr size_t buffer_size = 254UL;
+    using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
+    using TestCRCElement = PF::Protocols::CRCElement<TestCRCElementProps::PayloadBuffer>;
+    PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
+
+    auto data = PF::Util::make_array<uint8_t>(0x01, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05);
+
+    TestCRCElementProps::PayloadBuffer payload;
+    for (auto& bytes : data) {
+      payload.push_back(bytes);
+    }
+
+    TestCRCElement crc_element{payload};
+
+    WHEN("A body with crc and payload is generated, parsed and generated again") {
+      PF::Util::ByteVector<buffer_size> output_buffer;
+
+      auto write_status = crc_element.write(output_buffer, crc32c);
+
+      THEN("The status of write function returns ok") {
+        REQUIRE(write_status == PF::IndexStatus::ok);
+      }
+      THEN("The crc from the crc element is equal to expected") {
+        // Calculated using the Sunshine Online CRC Calculator
+        uint32_t expected_crc = 0x98DBE355;
+        REQUIRE(crc_element.crc() == expected_crc);
+      }
+      THEN("The payload of the crc element is as expected") {
+        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05");
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+      THEN("The output buffer is as expected") {
+        auto expected_buffer = std::string("\x98\xDB\xE3\x55\x01\x05\x01\x02\x03\x04\x05");
+        REQUIRE(output_buffer == expected_buffer);
+      }
+
+      auto parse_status = crc_element.parse(output_buffer);
+      THEN("The status of parse function returns ok") {
+        REQUIRE(parse_status == PF::IndexStatus::ok);
+      }
+      THEN("The crc from the CRCElement is equal to the crc in the body") {
+        uint32_t crc_body = 0x98DBE355;
+        REQUIRE(crc_element.crc() == crc_body);
+      }
+      THEN("payload from the CRCElement is equal to the expected payload from the body") {
+        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05");
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+
+      auto write = crc_element.write(output_buffer, crc32c);
+      THEN("The status of write function returns ok") { REQUIRE(write == PF::IndexStatus::ok); }
+      THEN("The crc from the crc element is equal to expected") {
+        // Calculated using the Sunshine Online CRC Calculator
+        uint32_t expected_crc = 0x98DBE355;
+        REQUIRE(crc_element.crc() == expected_crc);
+      }
+      THEN("The payload of the crc element is as expected") {
+        auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05");
+        REQUIRE(crc_element.payload() == expected_payload);
+      }
+      THEN("The output buffer is as expected") {
+        auto expected_buffer = std::string("\x98\xDB\xE3\x55\x01\x05\x01\x02\x03\x04\x05");
+        REQUIRE(output_buffer == expected_buffer);
+      }
+    }
+  }
+}
+
+SCENARIO(
+    "Protocols::CRCElementReceiver: The crc element receiver correctly parses datagrams into "
+    "payloads",
+    "[CRCElementReceiver]") {
+  GIVEN("A CRC element receiver of capacity 254 bytes") {
+    constexpr size_t buffer_size = 254UL;
+    using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
+    using TestCRCElement = PF::Protocols::CRCElement<TestCRCElementProps::PayloadBuffer>;
+    using TestCRCElementReceiver = PF::Protocols::CRCElementReceiver<buffer_size>;
+    PF::Util::ByteVector<buffer_size> input_buffer;
+
+    PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
+    PF::Protocols::CRCElementReceiver<buffer_size> crc_element_receiver{crc32c};
+
+    TestCRCElementProps::PayloadBuffer input_payload;
+    TestCRCElement crc_element{input_payload};
+
+    WHEN(
+        "A body with crc more than 4 bytes and equal to the crc of the payload is given to the "
+        "crc_element receiver") {
+      auto body = std::string("\x98\xdb\xe3\x55\x01\x05\x01\x02\x03\x04\x05", 11);
+      PF::Util::ByteVector<buffer_size> input_buffer;
+      PF::Util::convert_string_to_byte_vector(body, input_buffer);
+
+      uint32_t expected_crc = 0x98dbe355;
+      auto expected_payload = std::string("\x01\x05\x01\x02\x03\x04\x05", 7);
+
+      auto transform_status = crc_element_receiver.transform(input_buffer, crc_element);
+      auto payload = crc_element.payload();
+
+      THEN("the transform method reports ok status") {
+        REQUIRE(transform_status == TestCRCElementReceiver::Status::ok);
+      }
+
+      THEN("the crc returned from the crc() method is equal to the crc in the body/input_buffer") {
+        REQUIRE(crc_element.crc() == expected_crc);
+      }
+
+      THEN("the payload returned from the payload() method is equal to the payload from the body") {
+        REQUIRE(payload == expected_payload);
+      }
+    }
+
+    WHEN("body with 0 bytes is given to the crc element receiver") {
+      TestCRCElementProps::PayloadBuffer input_payload;
+      TestCRCElement crc_element{input_payload};
+
+      PF::Util::ByteVector<buffer_size> input_buffer;
+
+      auto transform_status = crc_element_receiver.transform(input_buffer, crc_element);
+
+      uint32_t expected_crc = 0x00000000;
+
+      THEN("the transform status is equal to invalid parse") {
+        REQUIRE(transform_status == TestCRCElementReceiver::Status::invalid_parse);
+      }
+
+      THEN("The crc returned from the crc() method is equal to 0") {
+        REQUIRE(crc_element.crc() == expected_crc);
+      }
+    }
+
+    WHEN("body with less than 4 bytes is given to the crc element receiver") {
+      TestCRCElementProps::PayloadBuffer input_payload;
+      TestCRCElement crc_element{input_payload};
+
+      PF::Util::ByteVector<buffer_size> input_buffer;
+
+      // body of length 1 byte
+      auto input = PF::Util::make_array<uint8_t>(0x00);
+
+      for (auto& bytes : input) {
+        input_buffer.push_back(bytes);
+      }
+      auto status = crc_element_receiver.transform(input_buffer, crc_element);
+
+      THEN("the transform status is equal to invalid parse") {
+        REQUIRE(status == TestCRCElementReceiver::Status::invalid_parse);
+      }
+      THEN("The crc returned from the crc() method is equal to 0") {
+        uint32_t expected_crc = 0x00;
+        REQUIRE(crc_element.crc() == expected_crc);
+      }
+
+      // body of length 2 bytes
+      auto input1 = std::string("\x01", 1);
+      input_buffer.clear();
+
+      for (auto& bytes : input1) {
+        input_buffer.push_back(bytes);
+      }
+      auto first = crc_element_receiver.transform(input_buffer, crc_element);
+
+      THEN("the transform status is equal to invalid parse") {
+        REQUIRE(first == TestCRCElementReceiver::Status::invalid_parse);
+      }
+      THEN("The crc returned from the crc() method is equal to 0") {
+        uint32_t expected_crc = 0x00;
+        REQUIRE(crc_element.crc() == expected_crc);
+      }
+
+      // body of length 3 bytes
+      auto input2 = std::string("\x00\x01", 2);
+      input_buffer.clear();
+
+      for (auto& bytes : input2) {
+        input_buffer.push_back(bytes);
+      }
+      auto second = crc_element_receiver.transform(input_buffer, crc_element);
+
+      THEN("the transform status is equal to invalid parse") {
+        REQUIRE(second == TestCRCElementReceiver::Status::invalid_parse);
+      }
+      THEN("The crc returned from the crc() method is equal to 0") {
+        uint32_t expected_crc = 0x00;
+        REQUIRE(crc_element.crc() == expected_crc);
+      }
+    }
+
+    WHEN(
+        "The CRC stored in the input body is inconsistent with the payload stored in the input "
+        "body") {
+      auto body = std::string("\x12\x34\x56\x78\x01\x05\x01\x02\x03\x04\x05", 11);
+      PF::Util::ByteVector<buffer_size> input_buffer;
+      PF::Util::convert_string_to_byte_vector(body, input_buffer);
+
+      uint32_t expected_crc = 0x12345678;
+
+      auto transform_status = crc_element_receiver.transform(input_buffer, crc_element);
+
+      THEN("the transform method reports invalid crc status") {
+        REQUIRE(transform_status == TestCRCElementReceiver::Status::invalid_crc);
+      }
+
+      THEN(
+          "the crc returned from the crc() method is equal to the invalid crc given in input "
+          "body") {
+        REQUIRE(crc_element.crc() == expected_crc);
+      }
+    }
+  }
+}
+
+SCENARIO(
+    "Protocols::CRCElementSender: The crc element receiver correctly generates datagrams from "
+    "payload",
+    "[CRCElementSender]") {
+  GIVEN("A CRC element sender of capacity 254 bytes") {
+    constexpr size_t buffer_size = 254UL;
+    using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
+    using TestCRCElementSender = PF::Protocols::CRCElementSender<buffer_size>;
+
+    PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
+    TestCRCElementSender crc_element_sender{crc32c};
+
+    WHEN("A payload is given along with a sufficiently large output buffer") {
+      auto body = std::string("\x13\x03\x05\x06\x23", 5);
+
+      // Calculated using the Sunshine Online CRC Calculator
+      uint32_t expected_crc = 0x81FC3457;
+      auto expected_output = std::string("\x81\xfc\x34\x57\x13\x03\x05\x06\x23", 9);
+
+      TestCRCElementProps::PayloadBuffer input_payload;
+      PF::Util::convert_string_to_byte_vector(body, input_payload);
+
+      PF::Util::ByteVector<buffer_size> output_buffer;
+
+      auto transform_status = crc_element_sender.transform(input_payload, output_buffer);
+
+      THEN("the transform status is ok") {
+        REQUIRE(transform_status == TestCRCElementSender::Status::ok);
+      }
+      THEN("output buffer is as expected, equal to (crc + input_buffer)") {
+        REQUIRE(output_buffer == expected_output);
+      }
+    }
+  }
+
+  GIVEN("A CRC element sender of buffer size 20 bytes") {
+    constexpr size_t buffer_size = 20UL;
+    using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
+    using TestCRCElementSender = PF::Protocols::CRCElementSender<buffer_size>;
+
+    PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
+    TestCRCElementSender crc_element_sender{crc32c};
+
+    WHEN("The output buffer is not large enough for the input payload") {
+      auto body = std::string("\x81\xfc\x34\x57\x13\x03\x05\x06\x23\x01\x09", 11);
+      constexpr size_t output_buffer_size = 10UL;
+
+      TestCRCElementProps::PayloadBuffer input_payload;
+      for (auto& data : body) {
+        input_payload.push_back(data);
+      }
+
+      PF::Util::ByteVector<output_buffer_size> output_buffer;
+
+      auto transform_status = crc_element_sender.transform(input_payload, output_buffer);
+
+      THEN("the transform status is equal to invalid_length") {
+        REQUIRE(transform_status == TestCRCElementSender::Status::invalid_length);
+      }
+    }
+  }
+}

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
@@ -108,8 +108,8 @@ SCENARIO(
 }
 
 SCENARIO(
-    "Protocols::CRCElement: The write function correctly generates body from computed crc and "
-    "payload",
+    "Protocols::ConstructedCRCElement: The write method correctly generates a body from the "
+    "payload given in the constructor",
     "[CRCElement]") {
   PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
   GIVEN("A crc element initalised with payload=[0x01, 0x02, 0x05]") {
@@ -294,7 +294,7 @@ SCENARIO(
     }
   }
 
-  GIVEN("A CRC Element initialized with a non-empty payload buffer of capacity 254 bytes") {
+  GIVEN("A CRCElement constructed with a non-empty payload buffer of capacity 254 bytes") {
     TestCRCElementProps::PayloadBuffer payload;
     auto data = std::string("\x12\x13\x14\x15\x16", 5);
     PF::Util::convert_string_to_byte_vector(data, payload);

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
@@ -620,6 +620,40 @@ SCENARIO(
       }
     }
   }
+
+  GIVEN("A CRC element receiver of capacity 10 bytes") {
+    WHEN(
+        "A body of size 20 bytes with a complete 4-byte header, And a payload of capacity 16 bytes "
+        "completely filled "
+        "with data is given to the receiver") {
+      constexpr size_t new_size = 10UL;
+      using TestCRCElementProps = PF::Protocols::CRCElementProps<new_size>;
+      using TestCRCElement = PF::Protocols::CRCElement<TestCRCElementProps::PayloadBuffer>;
+      using CRCElementReceiver = PF::Protocols::CRCElementReceiver<new_size>;
+
+      TestCRCElementProps::PayloadBuffer input_payload;
+      TestCRCElement crc_element{input_payload};
+
+      PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
+      PF::Protocols::CRCElementReceiver<new_size> crc_receiver{crc32c};
+
+      constexpr size_t input_size = 20UL;
+      PF::Util::ByteVector<input_size> input_buffer;
+
+      auto data = std::string("\x18\xD5\xD6\x0A\x00\x14", 6);
+      PF::Util::convert_string_to_byte_vector(data, input_buffer);
+
+      for (size_t i = 0; i < 14; ++i) {
+        uint8_t val = 10;
+        input_buffer.push_back(val);
+      }
+
+      auto transform_status = crc_receiver.transform(input_buffer, crc_element);
+      THEN("the transform method reports invalid_parse status") {
+        REQUIRE(transform_status == CRCElementReceiver::Status::invalid_parse);
+      }
+    }
+  }
 }
 
 SCENARIO(

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
@@ -361,6 +361,7 @@ SCENARIO(
 
         REQUIRE(crc_element.payload() == data);
       }
+      THEN("the constructor's payload buffer remains unchanged") { REQUIRE(payload == data); }
     }
 
     WHEN(
@@ -671,6 +672,9 @@ SCENARIO(
         auto expected = crc_element.payload();
         REQUIRE(expected.empty() == true);
       }
+      THEN("the constructor's payload buffer remains unchanged") {
+        REQUIRE(input_payload.empty() == true);
+      }
     }
 
     WHEN("body with less than 4 bytes is given to the crc element receiver") {
@@ -706,6 +710,9 @@ SCENARIO(
         auto expected = crc_element.payload();
         REQUIRE(expected.empty() == true);
       }
+      THEN("the constructor's payload buffer remains unchanged") {
+        REQUIRE(input_payload.empty() == true);
+      }
 
       // body of length 2 bytes
       auto input1 = std::string("\x01", 1);
@@ -738,6 +745,9 @@ SCENARIO(
         auto expected = crc_element.payload();
         REQUIRE(expected.empty() == true);
       }
+      THEN("the constructor's payload buffer remains unchanged") {
+        REQUIRE(input_payload.empty() == true);
+      }
 
       // body of length 3 bytes
       auto input2 = std::string("\x00\x01", 2);
@@ -769,6 +779,9 @@ SCENARIO(
         input_buffer.push_back(0x02);
         auto expected = crc_element.payload();
         REQUIRE(expected.empty() == true);
+      }
+      THEN("the constructor's payload buffer remains unchanged") {
+        REQUIRE(input_payload.empty() == true);
       }
     }
 
@@ -890,6 +903,7 @@ SCENARIO(
         input_buffer.push_back(0x02);
         REQUIRE(crc_element.payload() == body);
       }
+      THEN("the constructor's payload buffer remains unchanged") { REQUIRE(input_payload == body); }
     }
 
     WHEN(
@@ -974,6 +988,7 @@ SCENARIO(
         input_buffer.push_back(0x02);
         REQUIRE(crc_element.payload() == body);
       }
+      THEN("the constructor's payload buffer remains unchanged") { REQUIRE(input_payload == body); }
     }
 
     WHEN(
@@ -1018,8 +1033,8 @@ SCENARIO(
       THEN("the transform status is ok") {
         REQUIRE(transform_status == TestCRCElementSender::Status::ok);
       }
+      auto expected_output = std::string("\x81\xfc\x34\x57\x13\x03\x05\x06\x23", 9);
       THEN("output buffer is as expected, equal to (crc + input_buffer)") {
-        auto expected_output = std::string("\x81\xfc\x34\x57\x13\x03\x05\x06\x23", 9);
         REQUIRE(output_buffer == expected_output);
       }
       THEN("The CRC field of the output buffer's header is consistent with the input_payload.") {
@@ -1027,6 +1042,9 @@ SCENARIO(
         uint32_t expected_crc = 0x81FC3457;
         auto crc_compute = crc32c.compute(input_payload.buffer(), input_payload.size());
         REQUIRE(expected_crc == crc_compute);
+      }
+      THEN("The contents of the output buffer remains unchanged") {
+        REQUIRE(output_buffer == expected_output);
       }
     }
   }

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -1,6 +1,7 @@
 /* compute_body_crc
 Scenario: CRCElement: The compute_body_crc method correctly computes the CRC of a payload from a CRCElement body given as input
   GIVEN("The CRCElement::compute_body_crc static method")
+ 
     WHEN("The compute_body_crc is called on an input_buffer body with an empty payload")
       THEN("the computed CRC is '0x00000000'")
 
@@ -16,6 +17,7 @@ Scenario: CRCElement: The compute_body_crc method correctly computes the CRC of 
 /* write function
 Scenario: ConstructedCRCElement: The write method correctly generates a body from the payload given in the constructor
   GIVEN("A crc element constructed with payload=[0x01, 0x02, 0x05]")
+
     WHEN("The crc and payload are written to the output buffer")
       THEN("the crc accessor method returns 0 before the write method is called")
       THEN("After the write method is called, the crc accessor method returns a value equal to the result of directly computing a CRC on the payload.")
@@ -24,6 +26,7 @@ Scenario: ConstructedCRCElement: The write method correctly generates a body fro
       THEN("The output buffer is as expected")
 
   GIVEN("A crc element constructed with an empty payload")
+
     WHEN("The crc and payload are written to the output buffer")
       THEN("the crc accessor method returns 0 before the write method is called")
       THEN("After the write method is called, the crc accessor method returns 0")      
@@ -33,32 +36,38 @@ Scenario: ConstructedCRCElement: The write method correctly generates a body fro
 
 /* parse function
 Scenario: CRCElement: The parse method correctly updates its internal crc value and the constructor's payload buffer from the input buffer
+  
   GIVEN("A CRCElement constructed with an empty payload buffer with a capacity of 254 bytes")
 
     WHEN("A body without a complete 4-byte header is parsed")
       THEN("the parse method reports out of bounds status")
-      THEN("the constructor's payload buffer remains unchanged")
+      THEN("the crc accessor method returns 0")
+      THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
+      THEN("the payload given in the CRCElement constructor is independent of the input buffer body")
 
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
       THEN("the parse method reports ok status")
       THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
       THEN("the payload returned from the payload accessor method is equal to the payload from the body")
-      THEN("the payload given in the CRCElement constructor is independent of the input body")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor") 
+      THEN("the payload given in the CRCElement constructor is independent of the input buffer body")
 
     WHEN("A body with a complete 4-byte header, and a payload inconsistent with the CRC field of the header, is parsed")
       THEN("the parse method reports ok status")
       THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
       THEN("the value returned by the crc accessor method is inconsistent with the payload")
       THEN("the payload returned from the payload accessor method is equal to the payload from the body")
-      THEN("the payload given in the CRCElement constructor is independent of the input body")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
+      THEN("the payload given in the CRCElement constructor is independent of the input buffer body")
 
   GIVEN("A CRCElement constructed with a non-empty payload buffer of capacity 254 bytes")
+
     WHEN("A body without a complete 4-byte header is parsed")
       THEN("the parse method reports out of bounds status")
-      THEN("The bytes in the constructor's payload buffer are '0x12 0x13 0x14 0x15 0x16' ")
-      THEN("The payload accesor method returns the constructor's payload buffer")
+      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("The payload buffer given to it's constructor is '0x12 0x13 0x14 0x15 0x16' ")
+      THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
+      THEN("the payload given in the CRCElement constructor is independent of the input buffer body")      
   
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
       THEN("the crc accessor method returns 0 before the parse method is called")
@@ -67,13 +76,8 @@ Scenario: CRCElement: The parse method correctly updates its internal crc value 
       THEN("the parse method reports ok status")
       THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
       THEN("the payload returned from the payload accessor method is equal to the payload from the body")
-      THEN("the payload given in the CRCElement constructor is independent of the input body")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
-
-  GIVEN("A CRC element constructed with an empty payload buffer with a capacity of 10 bytes")
-    WHEN("A body of size 20 bytes with a complete 4-byte header, and a payload of capacity 16 bytes is parsed")
-      THEN("the parse method reports out of bounds status")
-      THEN("the constructor's payload buffer remains unchanged")
+      THEN("the payload given in the CRCElement constructor is independent of the input buffer body")
 
 /* write parse roundtrip
 Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
@@ -104,61 +108,79 @@ Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
 Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs consistency checking on them
 
   GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an empty payload buffer")
+
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
-      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to the crc field of the input body's header")
-      THEN("the payload returned from the payload accessor method of the output_crcelement is equal to the payload from the body")
-      THEN("the payload buffer updated in the CRCElement is independent of the input body")
+      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
+      THEN("the value returned by it's crc accessor method is equal to the crc field of the input body's header")
+      THEN("the payload given to it's constructor is empty")
+      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in its payload is independent of the data in input_buffer")
 
     WHEN("An empty input_buffer is given to the crc element receiver")
       THEN("the transform method reports invalid parse status")
-      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x00000000")
-      THEN("the payload returned from the payload accessor method of the output_crcelement is equal to the payload from the body")
+      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
+      THEN("the value returned by it's crc accessor method is equal to the crc field of the input body's header")
+      THEN("the payload given to it's constructor is empty")
+      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in its payload is independent of the data in input_buffer")
 
     WHEN("body with less than 4 bytes is given to the crc element receiver")
       // body of length 1,2,3 bytes is passed, passing 4 bytes will give a invalid_crc error instead
-      THEN("the transform method reports invalid parse status") // for each time
-      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x00000000") // for each time
-      THEN("the payload returned from the payload accessor method of the output_crcelement is equal to the payload from the body")
+      THEN("the transform method reports invalid parse status")
+      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
+      THEN("the value returned by it's crc accessor method is equal to the crc field of the input body's header")
+      THEN("the payload given to it's constructor is empty")
+      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in its payload is independent of the data in input_buffer")
 
     WHEN("A body with a complete 4-byte header, and a payload inconsistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports invalid crc status")
-      THEN("After the transform method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
+      THEN("the value returned by it's crc accessor method is equal to the crc field of the input body's header")
+      THEN("the payload given to it's constructor is empty")
+      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in its payload is independent of the data in input_buffer")
 
   GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an non-empty payload buffer")
+
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
-      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to the crc field of the input body's header")
-      THEN("the output_crcelement contains the payload buffer given to the constructor")
-      THEN("the payload buffer updated in the CRCElement is independent of the input body")
+      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
+      THEN("the value returned by it's crc accessor method is equal to the crc field of the input body's header")
+      THEN("the payload given to it's constructor is '0x01 0x05 0x12 0x13 0x14 0x15 0x16'")
+      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in its payload is independent of the data in input_buffer")
   
     WHEN("An empty input_buffer is given to the crc element receiver")
       THEN("the transform method reports invalid parse status")
-      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x00000000")
-      THEN("After the transform method is called, the payload given in the ParsedCRCElement constructor remains unchanged")
+      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
+      THEN("it's crc accessor method returns 0")
+      THEN("the payload given to it's constructor is '0x01 0x05 0x12 0x13 0x14 0x15 0x16'")
+      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in its payload is independent of the data in input_buffer")
 
     WHEN("An empty input_buffer is given to the crc element receiver and output_crcelement with a non-zero crc member")
       THEN("The write method of output_crcelement reports ok status")
       THEN("The value returned by the crc accessor method of output_crcelement is '0x40D06D79'")
       THEN("the transform status is equal to invalid parse")
-      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x40D06D79")
-      THEN("After the transform method is called, the payload given in the ParsedCRCElement constructor remains unchanged")
-
-  GIVEN("A CRC element receiver of capacity 10 bytes")
-    WHEN("A body of size 20 bytes with a complete 4-byte header, and a payload of capacity 16 bytes is given to the receiver")
-      THEN("the transform method reports invalid parse status")
-      THEN("After the transform method is called, the crc accessor method returns 0")
-      THEN("The payload buffer returned by the payload accesor method of the output_crcelement is empty")
+      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
+      THEN("the value returned by it's crc accessor method is equal to '0x40D06D79'")
+      THEN("the payload given to it's constructor is '0x01 0x05 0x12 0x13 0x14 0x15 0x16'")
+      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in its payload is independent of the data in input_buffer")      
 
 /* CRCElementSender
 Scenario: CRCElementSender: correctly generates CRCElement bodies from payloads
 
   GIVEN("A CRC element sender of capacity 254 bytes")
+
     WHEN("A payload is given along with a sufficiently large output buffer")
       THEN("the transform method reports ok status")
       THEN("output buffer is as expected, equal to (crc + input_buffer)")
       THEN("The CRC field of the output buffer's header is consistent with the input_payload.")
 
   GIVEN("A CRC element sender of buffer size 20 bytes")
+
     WHEN("The output buffer is not large enough for the input payload")
       THEN("the transform status is equal to invalid_length")

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -1,103 +1,130 @@
 /* compute_body_crc
-Scenario: CRCElement: The compute_body_crc function correctly computes crc from body
-  GIVEN("A CRC element initialized with an empty payload")
-    WHEN("the crc is computed from the payload")
-      THEN("the computed crc is equal to the expected crc")
+Scenario: CRCElement: The compute_body_crc method correctly computes the CRC of a payload from a CRCElement body given as input
+  GIVEN("A CRC element initialized with an empty payload of capacity 250 bytes")
+    WHEN("the crc is computed on an input_buffer with empty payload")
+      THEN("the computed CRC is '0x00000000'")
 
-  GIVEN("A CRC Element initialized with the payload '123456789'")
-    WHEN("the crc is computed from the payload")
-      THEN("the computed crc is equal to the expected crc")
+    WHEN("the crc is computed on an input_buffer with payload '123456789'")
+      THEN("the computed crc is '0xe3069283'")
 
-  GIVEN("A crc element is initalised with payload 0x00")
-    WHEN("the crc is computed from the payload")
-      THEN("the computed crc is equal to the expected crc")
+    WHEN("the CRC is computed on an input_buffer with payload '0x00' ")
+      THEN("the computed crc is '0x527d5351'")
 
-  GIVEN("A crc element is initalised with payload 0x01")
-    WHEN("the crc is computed from the payload")
-      THEN("the computed crc is equal to the expected crc")
+    WHEN("the crc is computed on an input_buffer with payload '0x01' ")
+      THEN("the computed crc is '0xa016d052'")
 
 /* write function
 Scenario: CRCElement: The write function correctly generates body from computed crc and payload
   GIVEN("A crc element initalised with payload=[0x01, 0x02, 0x05]")
     WHEN("The crc and payload are written to the output buffer")
-      THEN("crc computed in write method is same as crcchecker compute")
+      THEN("the crc accessor method returns 0 before the write method is called")
+      THEN("After the write method is called, the crc accessor method returns a value equal to the result of directly computing a CRC on the payload.")
+      THEN("The CRC field of the body's header matches the value returned by the crc accessor method.")
+      THEN("The body's payload section correctly stores the payload as 0x01 0x02 0x05")
       THEN("The output buffer is as expected")
 
   GIVEN("A crc element is initalised with an empty payload")
     WHEN("The crc and payload are written to the output buffer")
-      THEN("The CRC returned by the crc() method is equal to 0")
+      THEN("the crc accessor method returns 0 before the write method is called")
+      THEN("The CRC field of the body's header matches the value returned by the crc accessor method.")
+      THEN("The body's payload section is empty")
       THEN("The output buffer is as expected")
 
 /* parse function
-Scenario: CRCElement: The parse function correctly updates internal crc and payload fields from the input buffer
-
+Scenario: CRCElement: The parse method correctly updates its internal crc value and the constructor's payload buffer from the input buffer
   GIVEN("A CRC Element initialized with an empty payload buffer with a capacity of 254 bytes")
 
-    WHEN("A body with crc more than 4 bytes and equal to the crc of the payload is parsed")
-      THEN("the parse method reports ok status")
-      THEN("crc returned from the crc() method is same as the crc of the payload in input body")
-      THEN("payload returned from the payload() method is equal to the payload from the body")
-
-    WHEN("A body of less than 4 bytes is parsed")
+    WHEN("A body without a complete 4-byte header is parsed")
       THEN("the parse method reports out of bounds status")
 
-    WHEN("A body with crc and payload is given, where the crc is not equal to the actual crc of the payload")
+    WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
       THEN("the parse method reports ok status")
-      THEN("The crc returned from the crc() method is equal to the crc in the body/input_buffer")
-      THEN("The crc returned from the crc() method is not equal to the actual crc for the given payload")
-      THEN("The payload returned from the payload() method is equal to the payload from the body")
+      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("the payload returned from the payload accessor method is equal to the payload from the body")
+      THEN("the payload given in the CRCElement constructor is independent of the input body")
+      THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor") 
+
+    WHEN("A body with a complete 4-byte header, and a payload inconsistent with the CRC field of the header, is parsed")
+      THEN("the parse method reports ok status")
+      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("the value returned by the crc accessor method is inconsistent with the payload")
+      THEN("the payload returned from the payload accessor method is equal to the payload from the body")
+      THEN("the payload given in the CRCElement constructor is independent of the input body")
+      THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
+
+  GIVEN("A CRC Element initialized with a non-empty payload buffer of capacity 254 bytes")
+    WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
+      THEN("the crc accessor method returns 0 before the parse method is called")
+      THEN("the payload returned from the payload accessor method is equal to the payload buffer given in the CRCElement constructor")
+      THEN("the parse method reports ok status")
+      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("the payload returned from the payload accessor method is equal to the payload from the body")
+      THEN("the payload given in the CRCElement constructor is independent of the input body")
+      THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
 
 /* write parse roundtrip
-Scenario: The crc element correctly writes and parses to a buffer
+Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
 
   GIVEN("A CRC Element initialized with a non empty payload buffer with a capacity of 254 bytes")
 
     WHEN("A body with crc and payload is generated, parsed and generated again")
       # write  
-      THEN("The status of write function returns ok")
-      THEN("The crc from the crc element is equal to expected")
-      THEN("The payload of the crc element is as expected")
+      THEN("the crc accessor method returns 0 before the first write method is called")
+      THEN("The first write method call returns ok status")
+      THEN("After the first write method is called, the crc accessor method returns a value equal to the result of directly computing a CRC on the payload.")
+      THEN("The CRC field of the body's header matches the value returned by the crc accessor method.")
+      THEN("The body's payload section correctly stores the payload as '0x01 0x05 0x01 0x02 0x03 0x04 0x05'")
       THEN("The output buffer is as expected")
       # parse
-      THEN("The status of parse function returns ok")
-      THEN("The crc from the CRCElement is equal to the crc in the body")
-      THEN("payload from the CRCElement is equal to the expected payload from the body")
+      THEN("The parse method reports ok status")
+      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("the payload returned from the payload accessor method is equal to the payload from the body")
+      THEN("the payload given in the CRCElement constructor is independent of the input body")
+      THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
       # write  
-      THEN("The status of write function returns ok")
-      THEN("The crc from the crc element is equal to expected")
-      THEN("The payload of the crc element is as expected")
+      THEN("The second write method call returns ok status")
+      THEN("After the second write method is called, the crc accessor method returns a value equal to the result of directly computing a CRC on the payload.")
+      THEN("The CRC field of the body's header matches the value returned by the crc accessor method.")
+      THEN("The body's payload section correctly stores the payload as '0x01 0x05 0x01 0x02 0x03 0x04 0x05'")
       THEN("The output buffer is as expected")
 
-
 /* CRCElementReceiver
-Scenario: CRCElementReceiver: The crc element receiver correctly parses datagrams into payloads
+Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs consistency checking on them
 
   GIVEN("A CRC element receiver of capacity 254 bytes")
-    WHEN("A body with crc more than 4 bytes and equal to the crc of the payload is given to the crc_element receiver")
+    WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
-      THEN("crc returned from the crc() method is equal to the crc in the body/input_buffer")
-      THEN("payload returned from the payload() method is equal to the payload from the body")
+      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("the payload returned from the payload accessor method is equal to the payload from the body")
+      THEN("the payload buffer updated in the CRCElement is independent of the input body")
 
-    WHEN("body with 0 bytes is given to the crc element receiver")
+    WHEN("A body without a complete 4-byte header and empty payload is given to the crc element receiver")
       THEN("the transform status is equal to invalid parse")
-      THEN("the crc in output crc_element is equal to the given crc in input_buffer")
+      THEN("the value returned by the crc accessor method is equal to 0x00000000r")
+      THEN("The body's payload section is empty")
 
     WHEN("body with less than 4 bytes is given to the crc element receiver")
       // body of length 1,2,3 bytes is passed, passing 4 bytes will give a invalid_crc error instead
       THEN("the transform status is equal to invalid parse") // for each time
-      THEN("The crc returned from the crc() method is equal to 0") // for each time
+      THEN("the value returned by the crc accessor method is equal to 0x00000000") // for each time
 
-    WHEN("The CRC stored in the input body is inconsistent with the payload stored in the input body")
+    WHEN("A body with a complete 4-byte header, and a payload inconsistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports invalid crc status")
-      THEN("the crc returned from the crc() method is equal to the invalid crc given in input body")
+      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+
+  GIVEN("A CRC element receiver of capacity 10 bytes")
+    WHEN("A body with a complete 4-byte header, And a payload of size 20 bytes completely filled with data")
+      THEN("the transform method reports ok status")
+      THEN("the output buffer contains only 4 bytes of crc + 6 bytes of the payload")
 
 /* CRCElementSender
-Scenario: CRCElementSender: The crc element receiver correctly generates datagrams from payload
+Scenario: CRCElementSender: correctly generates CRCElement bodies from payloads
 
   GIVEN("A CRC element sender of capacity 254 bytes")
     WHEN("A payload is given along with a sufficiently large output buffer")
       THEN("the transform status is ok")
       THEN("output buffer is as expected, equal to (crc + input_buffer)")
+      THEN("The CRC field of the output buffer's header is consistent with the input_payload.")
 
   GIVEN("A CRC element sender of buffer size 20 bytes")
     WHEN("The output buffer is not large enough for the input payload")

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -1,21 +1,21 @@
 /* compute_body_crc
 Scenario: CRCElement: The compute_body_crc method correctly computes the CRC of a payload from a CRCElement body given as input
-  GIVEN("A CRC element initialized with an empty payload of capacity 250 bytes")
-    WHEN("the crc is computed on an input_buffer with empty payload")
+  GIVEN("The CRCElement::compute_body_crc static method")
+    WHEN("The compute_body_crc is called on an input_buffer body with an empty payload")
       THEN("the computed CRC is '0x00000000'")
 
-    WHEN("the crc is computed on an input_buffer with payload '123456789'")
+    WHEN("the compute_body_crc is called on an input_buffer body with payload '123456789'")
       THEN("the computed crc is '0xe3069283'")
 
-    WHEN("the CRC is computed on an input_buffer with payload '0x00' ")
+    WHEN("the compute_body_crc is called on an input_buffer body with payload '0x00' ")
       THEN("the computed crc is '0x527d5351'")
 
-    WHEN("the crc is computed on an input_buffer with payload '0x01' ")
+    WHEN("the compute_body_crc is called on an input_buffer body with payload '0x01' ")
       THEN("the computed crc is '0xa016d052'")
 
 /* write function
 Scenario: ConstructedCRCElement: The write method correctly generates a body from the payload given in the constructor
-  GIVEN("A crc element initalised with payload=[0x01, 0x02, 0x05]")
+  GIVEN("A crc element constructed with payload=[0x01, 0x02, 0x05]")
     WHEN("The crc and payload are written to the output buffer")
       THEN("the crc accessor method returns 0 before the write method is called")
       THEN("After the write method is called, the crc accessor method returns a value equal to the result of directly computing a CRC on the payload.")
@@ -23,9 +23,10 @@ Scenario: ConstructedCRCElement: The write method correctly generates a body fro
       THEN("The body's payload section correctly stores the payload as 0x01 0x02 0x05")
       THEN("The output buffer is as expected")
 
-  GIVEN("A crc element is initalised with an empty payload")
+  GIVEN("A crc element constructed with an empty payload")
     WHEN("The crc and payload are written to the output buffer")
       THEN("the crc accessor method returns 0 before the write method is called")
+      THEN("After the write method is called, the crc accessor method returns 0")      
       THEN("The CRC field of the body's header matches the value returned by the crc accessor method.")
       THEN("The body's payload section is empty")
       THEN("The output buffer is as expected")
@@ -36,17 +37,18 @@ Scenario: CRCElement: The parse method correctly updates its internal crc value 
 
     WHEN("A body without a complete 4-byte header is parsed")
       THEN("the parse method reports out of bounds status")
+      THEN("the constructor's payload buffer remains unchanged")
 
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
       THEN("the parse method reports ok status")
-      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
       THEN("the payload returned from the payload accessor method is equal to the payload from the body")
       THEN("the payload given in the CRCElement constructor is independent of the input body")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor") 
 
     WHEN("A body with a complete 4-byte header, and a payload inconsistent with the CRC field of the header, is parsed")
       THEN("the parse method reports ok status")
-      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
       THEN("the value returned by the crc accessor method is inconsistent with the payload")
       THEN("the payload returned from the payload accessor method is equal to the payload from the body")
       THEN("the payload given in the CRCElement constructor is independent of the input body")
@@ -57,7 +59,7 @@ Scenario: CRCElement: The parse method correctly updates its internal crc value 
       THEN("the crc accessor method returns 0 before the parse method is called")
       THEN("the payload returned from the payload accessor method is equal to the payload buffer given in the CRCElement constructor")
       THEN("the parse method reports ok status")
-      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
       THEN("the payload returned from the payload accessor method is equal to the payload from the body")
       THEN("the payload given in the CRCElement constructor is independent of the input body")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
@@ -65,9 +67,9 @@ Scenario: CRCElement: The parse method correctly updates its internal crc value 
 /* write parse roundtrip
 Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
 
-  GIVEN("A CRC Element initialized with a non empty payload buffer with a capacity of 254 bytes")
+  GIVEN("A CRC Element constructed with a non empty payload buffer with a capacity of 254 bytes")
 
-    WHEN("A body with crc and payload is generated, parsed and generated again")
+    WHEN("A body with CRC and payload is generated, parsed into a new ParsedCRCElement object, and generated again with a new ConstructedCRCElement object")
       # write  
       THEN("the crc accessor method returns 0 before the first write method is called")
       THEN("The first write method call returns ok status")
@@ -77,10 +79,9 @@ Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
       THEN("The output buffer is as expected")
       # parse
       THEN("The parse method reports ok status")
-      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
       THEN("the payload returned from the payload accessor method is equal to the payload from the body")
-      THEN("the payload given in the CRCElement constructor is independent of the input body")
-      THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
+      THEN("the payload given in the ParsedCRCElement constructor is independent of the input body")
       # write  
       THEN("The second write method call returns ok status")
       THEN("After the second write method is called, the crc accessor method returns a value equal to the result of directly computing a CRC on the payload.")
@@ -91,38 +92,51 @@ Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
 /* CRCElementReceiver
 Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs consistency checking on them
 
-  GIVEN("A CRC element receiver of capacity 254 bytes")
+  GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an empty payload")
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
-      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
-      THEN("the payload returned from the payload accessor method is equal to the payload from the body")
+      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to the crc field of the input body's header")
+      THEN("the payload returned from the payload accessor method of the output_crcelement is equal to the payload from the body")
       THEN("the payload buffer updated in the CRCElement is independent of the input body")
 
-    WHEN("A body without a complete 4-byte header and empty payload is given to the crc element receiver")
-      THEN("the transform status is equal to invalid parse")
-      THEN("the value returned by the crc accessor method is equal to 0x00000000r")
-      THEN("The body's payload section is empty")
+    WHEN("An empty input_buffer is given to the crc element receiver")
+      THEN("the transform method reports invalid parse status")
+      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x00000000")
+      THEN("The payload buffer returned by the payload accesor method is empty")
 
     WHEN("body with less than 4 bytes is given to the crc element receiver")
       // body of length 1,2,3 bytes is passed, passing 4 bytes will give a invalid_crc error instead
-      THEN("the transform status is equal to invalid parse") // for each time
-      THEN("the value returned by the crc accessor method is equal to 0x00000000") // for each time
+      THEN("the transform method reports invalid parse status") // for each time
+      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x00000000") // for each time
 
     WHEN("A body with a complete 4-byte header, and a payload inconsistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports invalid crc status")
-      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("After the transform method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
 
-  GIVEN("A CRC element receiver of capacity 10 bytes") {
-
-    WHEN("A body of size 20 bytes with a complete 4-byte header, And a payload of capacity 16 bytes completely filled with data is given to the receiver")
+  GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with a payload buffer '0x01 0x05 0x12 0x13 0x14 0x15 0x16'")
+    WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
+      THEN("the transform method reports ok status")
+      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to the crc field of the input body's header")
+      THEN("the payload returned from the payload accessor method of the output_crcelement is equal to the payload from the body")
+      THEN("the payload buffer updated in the CRCElement is independent of the input body")
+  
+    WHEN("An empty input_buffer is given to the crc element receiver")
       THEN("the transform method reports invalid parse status")
+      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x00000000")
+      THEN("The payload buffer returned by the payload accesor method is empty")
+
+  GIVEN("A CRC element receiver of capacity 10 bytes")
+    WHEN("A body of size 20 bytes with a complete 4-byte header, and a payload of capacity 16 bytes is given to the receiver")
+      THEN("the transform method reports invalid parse status")
+      THEN("After the transform method is called, the crc accessor method returns 0")
+      THEN("The payload buffer returned by the payload accesor method of the output_crcelement is empty")
 
 /* CRCElementSender
 Scenario: CRCElementSender: correctly generates CRCElement bodies from payloads
 
   GIVEN("A CRC element sender of capacity 254 bytes")
     WHEN("A payload is given along with a sufficiently large output buffer")
-      THEN("the transform status is ok")
+      THEN("the transform method reports ok status")
       THEN("output buffer is as expected, equal to (crc + input_buffer)")
       THEN("The CRC field of the output buffer's header is consistent with the input_payload.")
 

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -112,10 +112,10 @@ Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs con
       THEN("the transform method reports invalid crc status")
       THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
 
-  GIVEN("A CRC element receiver of capacity 10 bytes")
-    WHEN("A body with a complete 4-byte header, And a payload of size 20 bytes completely filled with data")
-      THEN("the transform method reports ok status")
-      THEN("the output buffer contains only 4 bytes of crc + 6 bytes of the payload")
+  GIVEN("A CRC element receiver of capacity 10 bytes") {
+
+    WHEN("A body of size 20 bytes with a complete 4-byte header, And a payload of capacity 16 bytes completely filled with data is given to the receiver")
+      THEN("the transform method reports invalid parse status")
 
 /* CRCElementSender
 Scenario: CRCElementSender: correctly generates CRCElement bodies from payloads

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -55,9 +55,15 @@ Scenario: CRCElement: The parse method correctly updates its internal crc value 
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
 
   GIVEN("A CRCElement constructed with a non-empty payload buffer of capacity 254 bytes")
+    WHEN("A body without a complete 4-byte header is parsed")
+      THEN("the parse method reports out of bounds status")
+      THEN("The bytes in the constructor's payload buffer are '0x12 0x13 0x14 0x15 0x16' ")
+      THEN("The payload accesor method returns the constructor's payload buffer")
+  
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
       THEN("the crc accessor method returns 0 before the parse method is called")
-      THEN("the payload returned from the payload accessor method is equal to the payload buffer given in the CRCElement constructor")
+      THEN("The bytes in the constructor's payload buffer are '0x12 0x13 0x14 0x15 0x16' ")
+      THEN("The payload accesor method returns the constructor's payload buffer")
       THEN("the parse method reports ok status")
       THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
       THEN("the payload returned from the payload accessor method is equal to the payload from the body")
@@ -119,11 +125,11 @@ Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs con
       THEN("the transform method reports invalid crc status")
       THEN("After the transform method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
 
-  GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an empty payload buffer")
+  GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an non-empty payload buffer")
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
       THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to the crc field of the input body's header")
-      THEN("the payload returned from the payload accessor method of the output_crcelement is equal to the payload from the body")
+      THEN("the output_crcelement contains the payload buffer given to the constructor")
       THEN("the payload buffer updated in the CRCElement is independent of the input body")
   
     WHEN("An empty input_buffer is given to the crc element receiver")

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -1,0 +1,104 @@
+/* compute_body_crc
+Scenario: CRCElement: The compute_body_crc function correctly computes crc from body
+  GIVEN("A CRC element initialized with an empty payload")
+    WHEN("the crc is computed from the payload")
+      THEN("the computed crc is equal to the expected crc")
+
+  GIVEN("A CRC Element initialized with the payload '123456789'")
+    WHEN("the crc is computed from the payload")
+      THEN("the computed crc is equal to the expected crc")
+
+  GIVEN("A crc element is initalised with payload 0x00")
+    WHEN("the crc is computed from the payload")
+      THEN("the computed crc is equal to the expected crc")
+
+  GIVEN("A crc element is initalised with payload 0x01")
+    WHEN("the crc is computed from the payload")
+      THEN("the computed crc is equal to the expected crc")
+
+/* write function
+Scenario: CRCElement: The write function correctly generates body from computed crc and payload
+  GIVEN("A crc element initalised with payload=[0x01, 0x02, 0x05]")
+    WHEN("The crc and payload are written to the output buffer")
+      THEN("crc computed in write method is same as crcchecker compute")
+      THEN("The output buffer is as expected")
+
+  GIVEN("A crc element is initalised with an empty payload")
+    WHEN("The crc and payload are written to the output buffer")
+      THEN("The CRC returned by the crc() method is equal to 0")
+      THEN("The output buffer is as expected")
+
+/* parse function
+Scenario: CRCElement: The parse function correctly updates internal crc and payload fields from the input buffer
+
+  GIVEN("A CRC Element initialized with an empty payload buffer with a capacity of 254 bytes")
+
+    WHEN("A body with crc more than 4 bytes and equal to the crc of the payload is parsed")
+      THEN("the parse method reports ok status")
+      THEN("crc returned from the crc() method is same as the crc of the payload in input body")
+      THEN("payload returned from the payload() method is equal to the payload from the body")
+
+    WHEN("A body of less than 4 bytes is parsed")
+      THEN("the parse method reports out of bounds status")
+
+    WHEN("A body with crc and payload is given, where the crc is not equal to the actual crc of the payload")
+      THEN("the parse method reports ok status")
+      THEN("The crc returned from the crc() method is equal to the crc in the body/input_buffer")
+      THEN("The crc returned from the crc() method is not equal to the actual crc for the given payload")
+      THEN("The payload returned from the payload() method is equal to the payload from the body")
+
+/* write parse roundtrip
+Scenario: The crc element correctly writes and parses to a buffer
+
+  GIVEN("A CRC Element initialized with a non empty payload buffer with a capacity of 254 bytes")
+
+    WHEN("A body with crc and payload is generated, parsed and generated again")
+      # write  
+      THEN("The status of write function returns ok")
+      THEN("The crc from the crc element is equal to expected")
+      THEN("The payload of the crc element is as expected")
+      THEN("The output buffer is as expected")
+      # parse
+      THEN("The status of parse function returns ok")
+      THEN("The crc from the CRCElement is equal to the crc in the body")
+      THEN("payload from the CRCElement is equal to the expected payload from the body")
+      # write  
+      THEN("The status of write function returns ok")
+      THEN("The crc from the crc element is equal to expected")
+      THEN("The payload of the crc element is as expected")
+      THEN("The output buffer is as expected")
+
+
+/* CRCElementReceiver
+Scenario: CRCElementReceiver: The crc element receiver correctly parses datagrams into payloads
+
+  GIVEN("A CRC element receiver of capacity 254 bytes")
+    WHEN("A body with crc more than 4 bytes and equal to the crc of the payload is given to the crc_element receiver")
+      THEN("the transform method reports ok status")
+      THEN("crc returned from the crc() method is equal to the crc in the body/input_buffer")
+      THEN("payload returned from the payload() method is equal to the payload from the body")
+
+    WHEN("body with 0 bytes is given to the crc element receiver")
+      THEN("the transform status is equal to invalid parse")
+      THEN("the crc in output crc_element is equal to the given crc in input_buffer")
+
+    WHEN("body with less than 4 bytes is given to the crc element receiver")
+      // body of length 1,2,3 bytes is passed, passing 4 bytes will give a invalid_crc error instead
+      THEN("the transform status is equal to invalid parse") // for each time
+      THEN("The crc returned from the crc() method is equal to 0") // for each time
+
+    WHEN("The CRC stored in the input body is inconsistent with the payload stored in the input body")
+      THEN("the transform method reports invalid crc status")
+      THEN("the crc returned from the crc() method is equal to the invalid crc given in input body")
+
+/* CRCElementSender
+Scenario: CRCElementSender: The crc element receiver correctly generates datagrams from payload
+
+  GIVEN("A CRC element sender of capacity 254 bytes")
+    WHEN("A payload is given along with a sufficiently large output buffer")
+      THEN("the transform status is ok")
+      THEN("output buffer is as expected, equal to (crc + input_buffer)")
+
+  GIVEN("A CRC element sender of buffer size 20 bytes")
+    WHEN("The output buffer is not large enough for the input payload")
+      THEN("the transform status is equal to invalid_length")

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -97,7 +97,7 @@ Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
 /* CRCElementReceiver
 Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs consistency checking on them
 
-  GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an empty payload")
+  GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an empty payload buffer")
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
       THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to the crc field of the input body's header")
@@ -107,18 +107,19 @@ Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs con
     WHEN("An empty input_buffer is given to the crc element receiver")
       THEN("the transform method reports invalid parse status")
       THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x00000000")
-      THEN("The payload buffer returned by the payload accesor method is empty")
+      THEN("the payload returned from the payload accessor method of the output_crcelement is equal to the payload from the body")
 
     WHEN("body with less than 4 bytes is given to the crc element receiver")
       // body of length 1,2,3 bytes is passed, passing 4 bytes will give a invalid_crc error instead
       THEN("the transform method reports invalid parse status") // for each time
       THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x00000000") // for each time
+      THEN("the payload returned from the payload accessor method of the output_crcelement is equal to the payload from the body")
 
     WHEN("A body with a complete 4-byte header, and a payload inconsistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports invalid crc status")
       THEN("After the transform method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
 
-  GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with a payload buffer '0x01 0x05 0x12 0x13 0x14 0x15 0x16'")
+  GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an empty payload buffer")
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
       THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to the crc field of the input body's header")
@@ -128,7 +129,14 @@ Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs con
     WHEN("An empty input_buffer is given to the crc element receiver")
       THEN("the transform method reports invalid parse status")
       THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x00000000")
-      THEN("The payload buffer returned by the payload accesor method is empty")
+      THEN("After the transform method is called, the payload given in the ParsedCRCElement constructor remains unchanged")
+
+    WHEN("An empty input_buffer is given to the crc element receiver and output_crcelement with a non-zero crc member")
+      THEN("The write method of output_crcelement reports ok status")
+      THEN("The value returned by the crc accessor method of output_crcelement is '0x40D06D79'")
+      THEN("the transform status is equal to invalid parse")
+      THEN("After the transform method is called, the value returned by the crc accessor method of the output_crcelement is equal to 0x40D06D79")
+      THEN("After the transform method is called, the payload given in the ParsedCRCElement constructor remains unchanged")
 
   GIVEN("A CRC element receiver of capacity 10 bytes")
     WHEN("A body of size 20 bytes with a complete 4-byte header, and a payload of capacity 16 bytes is given to the receiver")

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -64,6 +64,11 @@ Scenario: CRCElement: The parse method correctly updates its internal crc value 
       THEN("the payload given in the CRCElement constructor is independent of the input body")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
 
+  GIVEN("A CRC element constructed with an empty payload buffer with a capacity of 10 bytes")
+    WHEN("A body of size 20 bytes with a complete 4-byte header, and a payload of capacity 16 bytes is parsed")
+      THEN("the parse method reports out of bounds status")
+      THEN("the constructor's payload buffer remains unchanged")
+
 /* write parse roundtrip
 Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
 

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -16,19 +16,25 @@ Scenario: CRCElement: The compute_body_crc method correctly computes the CRC of 
 
 /* write function
 Scenario: ConstructedCRCElement: The write method correctly generates a body from the payload given in the constructor
-  GIVEN("A crc element constructed with payload=[0x01, 0x02, 0x05]")
+  GIVEN("A crc element constructed with a non-empty payload buffer with a capacity of 254 bytes")
+    // assertions carried out in GIVEN:
+    // The crc accessor method returns 0  
+    // The payload buffer returned by the payload accessor method is '0x01, 0x02, 0x05'
 
     WHEN("The crc and payload are written to the output buffer")
-      THEN("the crc accessor method returns 0 before the write method is called")
+      THEN("The write method reports ok status")
       THEN("After the write method is called, the crc accessor method returns a value equal to the result of directly computing a CRC on the payload.")
       THEN("The CRC field of the body's header matches the value returned by the crc accessor method.")
       THEN("The body's payload section correctly stores the payload as 0x01 0x02 0x05")
       THEN("The output buffer is as expected")
 
   GIVEN("A crc element constructed with an empty payload")
+    // assertions carried out in GIVEN:
+    // The crc accessor method returns 0
+    // The payload buffer returned by the payload accessor method is empty
 
     WHEN("The crc and payload are written to the output buffer")
-      THEN("the crc accessor method returns 0 before the write method is called")
+      THEN("The write method reports ok status")
       THEN("After the write method is called, the crc accessor method returns 0")      
       THEN("The CRC field of the body's header matches the value returned by the crc accessor method.")
       THEN("The body's payload section is empty")
@@ -38,46 +44,64 @@ Scenario: ConstructedCRCElement: The write method correctly generates a body fro
 Scenario: CRCElement: The parse method correctly updates its internal crc value and the constructor's payload buffer from the input buffer
   
   GIVEN("A CRCElement constructed with an empty payload buffer with a capacity of 254 bytes")
+    // assertions carried out in GIVEN:
+    // The crc accessor method returns 0
+    // The payload buffer returned by the payload accessor method is empty
 
     WHEN("A body without a complete 4-byte header is parsed")
       THEN("the parse method reports out of bounds status")
-      THEN("the crc accessor method returns 0")
-      THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
-      THEN("the payload given in the CRCElement constructor is independent of the input buffer body")
+      THEN("After the parse method is called, The value returned by the crc accessor method remains unchanged")
+      THEN("the constructor's payload buffer remains unchanged")
 
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
       THEN("the parse method reports ok status")
-      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
-      THEN("the payload returned from the payload accessor method is equal to the payload from the body")
+      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input_buffer body's header")
+      THEN("the payload returned from the payload accessor method is equal to the payload from the input_buffer body")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor") 
       THEN("the payload given in the CRCElement constructor is independent of the input buffer body")
 
     WHEN("A body with a complete 4-byte header, and a payload inconsistent with the CRC field of the header, is parsed")
       THEN("the parse method reports ok status")
-      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input_buffer body's header")
       THEN("the value returned by the crc accessor method is inconsistent with the payload")
-      THEN("the payload returned from the payload accessor method is equal to the payload from the body")
+      THEN("the payload returned from the payload accessor method is equal to the payload from the input_buffer body")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
       THEN("the payload given in the CRCElement constructor is independent of the input buffer body")
 
   GIVEN("A CRCElement constructed with a non-empty payload buffer of capacity 254 bytes")
+    // assertions carried out in GIVEN:
+    // The crc accessor method returns 0
+    // The payload buffer returned by the payload accessor method is '0x12 0x13 0x14 0x15 0x16'
 
     WHEN("A body without a complete 4-byte header is parsed")
       THEN("the parse method reports out of bounds status")
-      THEN("the value returned by the crc accessor method is equal to the crc field of the input body's header")
-      THEN("The payload buffer given to it's constructor is '0x12 0x13 0x14 0x15 0x16' ")
+      THEN("After the parse method is called, the value returned by the crc accessor method remains unchanged")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
       THEN("the payload given in the CRCElement constructor is independent of the input buffer body")      
   
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
-      THEN("the crc accessor method returns 0 before the parse method is called")
-      THEN("The bytes in the constructor's payload buffer are '0x12 0x13 0x14 0x15 0x16' ")
-      THEN("The payload accesor method returns the constructor's payload buffer")
       THEN("the parse method reports ok status")
-      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
-      THEN("the payload returned from the payload accessor method is equal to the payload from the body")
+      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input_buffer body's header")
+      THEN("the payload returned from the payload accessor method is equal to the payload from the input_buffer body")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
       THEN("the payload given in the CRCElement constructor is independent of the input buffer body")
+
+  GIVEN("A CRCElement constructed with a non-empty payload buffer of capacity 254 bytes, and a non-zero crc member")
+    // assertions carried out in GIVEN:
+    // The crc accessor method returns 0x34CD15AD
+    // The payload buffer returned by the payload accessor method is '0x0d 0xf0 0x07 0xc3 0xac'
+
+    WHEN("A body without a complete 4-byte header is parsed")
+      THEN("the parse method reports out of bounds status")
+      THEN("After the parse method is called, The value returned by the crc accessor method remains unchanged")
+      THEN("the constructor's payload buffer remains unchanged")   
+
+    WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
+      THEN("the parse method reports ok status")
+      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input_buffer body's header")
+      THEN("the payload returned from the payload accessor method is equal to the payload from the input_buffer body")
+      THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
+      THEN("the payload given in the CRCElement constructor is independent of the input buffer body") 
 
 /* write parse roundtrip
 Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
@@ -94,9 +118,9 @@ Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
       THEN("The output buffer is as expected")
       # parse
       THEN("The parse method reports ok status")
-      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input body's header")
+      THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input_buffer body's header")
       THEN("the payload returned from the payload accessor method is equal to the payload from the body")
-      THEN("the payload given in the ParsedCRCElement constructor is independent of the input body")
+      THEN("the payload given in the ParsedCRCElement constructor is independent of the input_buffer body")
       # write  
       THEN("The second write method call returns ok status")
       THEN("After the second write method is called, the crc accessor method returns a value equal to the result of directly computing a CRC on the payload.")
@@ -107,68 +131,70 @@ Scenario: CRCElement correctly preserves data in roundtrip writing and parsing
 /* CRCElementReceiver
 Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs consistency checking on them
 
-  GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an empty payload buffer")
-
-    WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
-      THEN("the transform method reports ok status")
-      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
-      THEN("the value returned by it's crc accessor method is equal to the crc field of the input body's header")
-      THEN("the payload given to it's constructor is empty")
-      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
-      THEN("The data in its payload is independent of the data in input_buffer")
+  GIVEN("A CRC element receiver of capacity 254 bytes and an output_crcelement constructed with an empty payload buffer")
+    // assertions carried out in GIVEN:
+    // The output_crcelement's crc accessor method returns 0
+    // The payload buffer returned by the output_crcelement's payload accessor method is empty
 
     WHEN("An empty input_buffer is given to the crc element receiver")
       THEN("the transform method reports invalid parse status")
-      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
-      THEN("the value returned by it's crc accessor method is equal to the crc field of the input body's header")
-      THEN("the payload given to it's constructor is empty")
-      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
-      THEN("The data in its payload is independent of the data in input_buffer")
+      THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method remains unchanged")
+      THEN("The output_crcelement's payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
 
-    WHEN("body with less than 4 bytes is given to the crc element receiver")
+    WHEN("A body with less than 4 bytes is given to the crc element receiver")
       // body of length 1,2,3 bytes is passed, passing 4 bytes will give a invalid_crc error instead
       THEN("the transform method reports invalid parse status")
-      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
-      THEN("the value returned by it's crc accessor method is equal to the crc field of the input body's header")
-      THEN("the payload given to it's constructor is empty")
-      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
-      THEN("The data in its payload is independent of the data in input_buffer")
+      THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method remains unchanged")
+      THEN("The output_crcelement's payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
+
+    WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
+      THEN("the transform method reports ok status")
+      THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method is equal to the crc field of the input_buffer body's header")
+      THEN("The payload buffer returned by the output_crcelement's payload accessor method is equal to the payload from the input_buffer body")
+      THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
 
     WHEN("A body with a complete 4-byte header, and a payload inconsistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports invalid crc status")
-      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
-      THEN("the value returned by it's crc accessor method is equal to the crc field of the input body's header")
-      THEN("the payload given to it's constructor is empty")
-      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
-      THEN("The data in its payload is independent of the data in input_buffer")
+      THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method is equal to the crc field of the input_buffer body's header")
+      THEN("the value returned by the crc accessor method is inconsistent with the payload")
+      THEN("The payload buffer returned by the output_crcelement's payload accessor method is equal to the payload from the input_buffer body")
+      THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
 
-  GIVEN("A CRC element receiver of capacity 254 bytes and output_crcelement constructed with an non-empty payload buffer")
+  GIVEN("A CRC element receiver of capacity 254 bytes and an output_crcelement constructed with an non-empty payload buffer")
+    // assertions carried out in GIVEN:
+    // The output_crcelement's crc accessor method returns 0
+    // The payload buffer returned by the output_crcelement's payload accessor method is '0x1e 0xe2 0x9a 0xf8 0x4f'
+
+    WHEN("An empty input_buffer is given to the crc element receiver")
+      THEN("the transform method reports invalid parse status")
+      THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method remains unchanged")
+      THEN("The output_crcelement's payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
 
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
-      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
-      THEN("the value returned by it's crc accessor method is equal to the crc field of the input body's header")
-      THEN("the payload given to it's constructor is '0x01 0x05 0x12 0x13 0x14 0x15 0x16'")
-      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
-      THEN("The data in its payload is independent of the data in input_buffer")
-  
+      THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method is equal to the crc field of the input_buffer body's header")
+      THEN("The payload buffer returned by the output_crcelement's payload accessor method is equal to the payload from the input_buffer body")
+      THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
+
+  GIVEN("A CRC element receiver of capacity 254 bytes, and output_crcelement constructed with an non-empty payload buffer and non-zero crc member")
+    // assertions carried out in GIVEN:
+    // The value returned by the output_crcelement's crc accessor method is '0x40D06D79'
+    // The payload buffer returned by the output_crcelement's payload accessor method is '0x23 0x84 0xf5 0x6a 0xac 0xae'
+
     WHEN("An empty input_buffer is given to the crc element receiver")
       THEN("the transform method reports invalid parse status")
-      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
-      THEN("it's crc accessor method returns 0")
-      THEN("the payload given to it's constructor is '0x01 0x05 0x12 0x13 0x14 0x15 0x16'")
-      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
-      THEN("The data in its payload is independent of the data in input_buffer")
+      THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method remains unchanged")
+      THEN("The output_crcelement's payload accessor method returns a reference to the payload given in its constructor")
+      THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
 
-    WHEN("An empty input_buffer is given to the crc element receiver and output_crcelement with a non-zero crc member")
-      THEN("The write method of output_crcelement reports ok status")
-      THEN("The value returned by the crc accessor method of output_crcelement is '0x40D06D79'")
-      THEN("the transform status is equal to invalid parse")
-      THEN("After the transform method is called, The ParsedCRCElement output parameter has the following properties : ")
-      THEN("the value returned by it's crc accessor method is equal to '0x40D06D79'")
-      THEN("the payload given to it's constructor is '0x01 0x05 0x12 0x13 0x14 0x15 0x16'")
-      THEN("Its payload accessor method returns a reference to the payload given in its constructor")
-      THEN("The data in its payload is independent of the data in input_buffer")      
+    WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
+      THEN("the transform method reports ok status")
+      THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method is equal to the crc field of the input_buffer body's header")
+      THEN("The payload buffer returned by the output_crcelement's payload accessor method is equal to the payload from the input_buffer body")
+      THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")      
 
 /* CRCElementSender
 Scenario: CRCElementSender: correctly generates CRCElement bodies from payloads

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -14,7 +14,7 @@ Scenario: CRCElement: The compute_body_crc method correctly computes the CRC of 
       THEN("the computed crc is '0xa016d052'")
 
 /* write function
-Scenario: CRCElement: The write function correctly generates body from computed crc and payload
+Scenario: ConstructedCRCElement: The write method correctly generates a body from the payload given in the constructor
   GIVEN("A crc element initalised with payload=[0x01, 0x02, 0x05]")
     WHEN("The crc and payload are written to the output buffer")
       THEN("the crc accessor method returns 0 before the write method is called")
@@ -32,7 +32,7 @@ Scenario: CRCElement: The write function correctly generates body from computed 
 
 /* parse function
 Scenario: CRCElement: The parse method correctly updates its internal crc value and the constructor's payload buffer from the input buffer
-  GIVEN("A CRC Element initialized with an empty payload buffer with a capacity of 254 bytes")
+  GIVEN("A CRCElement constructed with an empty payload buffer with a capacity of 254 bytes")
 
     WHEN("A body without a complete 4-byte header is parsed")
       THEN("the parse method reports out of bounds status")
@@ -52,7 +52,7 @@ Scenario: CRCElement: The parse method correctly updates its internal crc value 
       THEN("the payload given in the CRCElement constructor is independent of the input body")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
 
-  GIVEN("A CRC Element initialized with a non-empty payload buffer of capacity 254 bytes")
+  GIVEN("A CRCElement constructed with a non-empty payload buffer of capacity 254 bytes")
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
       THEN("the crc accessor method returns 0 before the parse method is called")
       THEN("the payload returned from the payload accessor method is equal to the payload buffer given in the CRCElement constructor")

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/crcelements.txt
@@ -78,7 +78,8 @@ Scenario: CRCElement: The parse method correctly updates its internal crc value 
       THEN("After the parse method is called, the value returned by the crc accessor method remains unchanged")
       THEN("the payload accessor method returns a reference to the payload buffer given in the CRCElement constructor")
       THEN("the payload given in the CRCElement constructor is independent of the input buffer body")      
-  
+      THEN("the constructor's payload buffer remains unchanged")
+
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is parsed")
       THEN("the parse method reports ok status")
       THEN("After the parse method is called, the value returned by the crc accessor method is equal to the crc field of the input_buffer body's header")
@@ -141,6 +142,7 @@ Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs con
       THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method remains unchanged")
       THEN("The output_crcelement's payload accessor method returns a reference to the payload given in its constructor")
       THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
+      THEN("the constructor's payload buffer remains unchanged")
 
     WHEN("A body with less than 4 bytes is given to the crc element receiver")
       // body of length 1,2,3 bytes is passed, passing 4 bytes will give a invalid_crc error instead
@@ -148,6 +150,7 @@ Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs con
       THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method remains unchanged")
       THEN("The output_crcelement's payload accessor method returns a reference to the payload given in its constructor")
       THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
+      THEN("the constructor's payload buffer remains unchanged")      
 
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
@@ -172,6 +175,7 @@ Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs con
       THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method remains unchanged")
       THEN("The output_crcelement's payload accessor method returns a reference to the payload given in its constructor")
       THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
+      THEN("the constructor's payload buffer remains unchanged")
 
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
@@ -189,6 +193,7 @@ Scenario: CRCElementReceiver correctly parses CRCElement bodies and performs con
       THEN("After the transform method is called, the value returned by the output_crcelement's crc accessor method remains unchanged")
       THEN("The output_crcelement's payload accessor method returns a reference to the payload given in its constructor")
       THEN("The data in the output_crcelement's payload buffer is independent of the data in input_buffer")
+      THEN("the constructor's payload buffer remains unchanged")
 
     WHEN("A body with a complete 4-byte header, and a payload consistent with the CRC field of the header, is given to the receiver")
       THEN("the transform method reports ok status")
@@ -205,6 +210,7 @@ Scenario: CRCElementSender: correctly generates CRCElement bodies from payloads
       THEN("the transform method reports ok status")
       THEN("output buffer is as expected, equal to (crc + input_buffer)")
       THEN("The CRC field of the output buffer's header is consistent with the input_payload.")
+      THEN("The contents of the output buffer remains unchanged")
 
   GIVEN("A CRC element sender of buffer size 20 bytes")
 

--- a/firmware/ventilator-controller-stm32/Docs/ClassDiagram.md
+++ b/firmware/ventilator-controller-stm32/Docs/ClassDiagram.md
@@ -1,0 +1,76 @@
+```mermaid
+classDiagram
+      class BackendNS
+      <<namespace>> BackendNS
+      BackendNS *-- Backend:Composition
+      BackendNS o-- BackendMessage:Aggregation
+      BackendNS : +Array<Message> message_descriptors
+
+      class Backend
+      Backend *-- BackendReceiver
+      Backend *-- BackendSender
+      Backend : +Array<Message> message_descriptors
+
+      class BackendReceiver
+      BackendReceiver --> FrameReceiver
+      BackendReceiver --> BackendCRCReceiver
+      BackendReceiver --> BackendDatagramReceiver
+      BackendReceiver --> BackendMessageReceiver
+
+      class BackendCRCReceiver
+      CRCElementReceiver <|-- BackendCRCReceiver
+
+      class BackendParsedCRC
+      ParsedCRCElement <|-- BackendParsedCRC
+
+      class BackendDatagramReceiver
+      DatagramReceiver <|-- BackendDatagramReceiver
+      BackendDatagramReceiver ..> BackendCRCReceiver
+
+      class BackendParsedDatagram
+      ParsedDatagram <|-- BackendParsedDatagram
+      BackendParsedDatagram ..> BackendCRCReceiver
+
+      class BackendMessageReceiver
+      MessageReceiver <|-- BackendMessageReceiver
+      BackendMessageReceiver ..> BackendMessage
+
+      class BackendSender
+      BackendSender --> FrameSender
+      BackendSender --> BackendCRCSender
+      BackendSender --> BackendDatagramSender
+      BackendSender --> BackendMessageSender
+
+      class BackendCRCSender
+      CRCElementSender <|-- BackendCRCSender
+
+      class BackendDatagramSender
+      DatagramSender <|-- BackendDatagramSender
+
+      class BackendMessageSender
+      MessageSender <|-- BackendMessageSender
+
+      BackendMessage <|-- Message
+
+      class Message{
+      }
+
+      Message <|-- UnrecognizedMessage
+      Message <|-- Alarms
+      Message <|-- SensorMeasurements
+      Message <|-- CycleMeasurements
+      Message <|-- Parameters
+      Message <|-- ParametersRequest
+      Message <|-- Ping
+      Message <|-- Announcement
+
+      class UnrecognizedMessage {
+      }
+
+      class Alarms {
+        +uint32 time
+        +bool alarm_one
+        +bool alarm_two
+      }
+
+```

--- a/firmware/ventilator-controller-stm32/clang-tidy-all.sh
+++ b/firmware/ventilator-controller-stm32/clang-tidy-all.sh
@@ -44,7 +44,7 @@ LINE_FILTERS="[$EXCLUDE_FILTERS,$STM32_USER_FILTERS,$INCLUDE_FILTERS]"
 # Check files
 SOURCE_FILES=`find Core/Src/Pufferfish -iname *.cpp | xargs`
 if [ "$1" == "TestCatch2" ]; then
-  TEST_FILES=`find Core/Test -iname *.cpp | xargs`
+  TEST_FILES=`find Core/Test -iname *.cpp -o -iname *.h | xargs`
   FILES="$TEST_FILES"
   CHECK_OVERRIDES="-readability-magic-numbers"
 elif [ "$1" == "Clang" ]; then

--- a/firmware/ventilator-controller-stm32/cmake/CodeCoverage.cmake
+++ b/firmware/ventilator-controller-stm32/cmake/CodeCoverage.cmake
@@ -1,0 +1,436 @@
+# Copyright (c) 2012 - 2017, Lars Bilke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# CHANGES:
+#
+# 2012-01-31, Lars Bilke
+# - Enable Code Coverage
+#
+# 2013-09-17, Joakim Söderberg
+# - Added support for Clang.
+# - Some additional usage instructions.
+#
+# 2016-02-03, Lars Bilke
+# - Refactored functions to use named parameters
+#
+# 2017-06-02, Lars Bilke
+# - Merged with modified version from github.com/ufz/ogs
+#
+# 2019-05-06, Anatolii Kurotych
+# - Remove unnecessary --coverage flag
+#
+# 2019-12-13, FeRD (Frank Dana)
+# - Deprecate COVERAGE_LCOVR_EXCLUDES and COVERAGE_GCOVR_EXCLUDES lists in favor
+#   of tool-agnostic COVERAGE_EXCLUDES variable, or EXCLUDE setup arguments.
+# - CMake 3.4+: All excludes can be specified relative to BASE_DIRECTORY
+# - All setup functions: accept BASE_DIRECTORY, EXCLUDE list
+# - Set lcov basedir with -b argument
+# - Add automatic --demangle-cpp in lcovr, if 'c++filt' is available (can be
+#   overridden with NO_DEMANGLE option in setup_target_for_coverage_lcovr().)
+# - Delete output dir, .info file on 'make clean'
+# - Remove Python detection, since version mismatches will break gcovr
+# - Minor cleanup (lowercase function names, update examples...)
+#
+# 2019-12-19, FeRD (Frank Dana)
+# - Rename Lcov outputs, make filtered file canonical, fix cleanup for targets
+#
+# 2020-01-19, Bob Apthorpe
+# - Added gfortran support
+#
+# 2020-02-17, FeRD (Frank Dana)
+# - Make all add_custom_target()s VERBATIM to auto-escape wildcard characters
+#   in EXCLUDEs, and remove manual escaping from gcovr targets
+#
+# USAGE:
+#
+# 1. Copy this file into your cmake modules path.
+#
+# 2. Add the following line to your CMakeLists.txt (best inside an if-condition
+#    using a CMake option() to enable it just optionally):
+#      include(CodeCoverage)
+#
+# 3. Append necessary compiler flags:
+#      append_coverage_compiler_flags()
+#
+# 3.a (OPTIONAL) Set appropriate optimization flags, e.g. -O0, -O1 or -Og
+#
+# 4. If you need to exclude additional directories from the report, specify them
+#    using full paths in the COVERAGE_EXCLUDES variable before calling
+#    setup_target_for_coverage_*().
+#    Example:
+#      set(COVERAGE_EXCLUDES
+#          '${PROJECT_SOURCE_DIR}/src/dir1/*'
+#          '/path/to/my/src/dir2/*')
+#    Or, use the EXCLUDE argument to setup_target_for_coverage_*().
+#    Example:
+#      setup_target_for_coverage_lcov(
+#          NAME coverage
+#          EXECUTABLE testrunner
+#          EXCLUDE "${PROJECT_SOURCE_DIR}/src/dir1/*" "/path/to/my/src/dir2/*")
+#
+# 4.a NOTE: With CMake 3.4+, COVERAGE_EXCLUDES or EXCLUDE can also be set
+#     relative to the BASE_DIRECTORY (default: PROJECT_SOURCE_DIR)
+#     Example:
+#       set(COVERAGE_EXCLUDES "dir1/*")
+#       setup_target_for_coverage_gcovr_html(
+#           NAME coverage
+#           EXECUTABLE testrunner
+#           BASE_DIRECTORY "${PROJECT_SOURCE_DIR}/src"
+#           EXCLUDE "dir2/*")
+#
+# 5. Use the functions described below to create a custom make target which
+#    runs your test executable and produces a code coverage report.
+#
+# 6. Build a Debug build:
+#      cmake -DCMAKE_BUILD_TYPE=Debug ..
+#      make
+#      make my_coverage_target
+#
+
+include(CMakeParseArguments)
+
+# Check prereqs
+find_program( GCOV_PATH gcov )
+find_program( LCOV_PATH  NAMES lcov lcov.bat lcov.exe lcov.perl)
+find_program( GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat )
+find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
+find_program( CPPFILT_PATH NAMES c++filt )
+
+if(NOT GCOV_PATH)
+    message(FATAL_ERROR "gcov not found! Aborting...")
+endif() # NOT GCOV_PATH
+
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+    if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 3)
+        message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
+    endif()
+elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
+    if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "[Ff]lang")
+        # Do nothing; exit conditional without error if true
+    elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
+        # Do nothing; exit conditional without error if true
+    else()
+        message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+    endif()
+endif()
+
+set(COVERAGE_COMPILER_FLAGS "-g -fprofile-arcs -ftest-coverage"
+    CACHE INTERNAL "")
+
+set(CMAKE_Fortran_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
+    CACHE STRING "Flags used by the Fortran compiler during coverage builds."
+    FORCE )
+set(CMAKE_CXX_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
+    CACHE STRING "Flags used by the C++ compiler during coverage builds."
+    FORCE )
+set(CMAKE_C_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
+    CACHE STRING "Flags used by the C compiler during coverage builds."
+    FORCE )
+set(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used for linking binaries during coverage builds."
+    FORCE )
+set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
+    FORCE )
+mark_as_advanced(
+    CMAKE_Fortran_FLAGS_COVERAGE
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
+endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    link_libraries(gcov)
+endif()
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_lcov(
+#     NAME testrunner_coverage                    # New target name
+#     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES testrunner                     # Dependencies to build first
+#     BASE_DIRECTORY "../"                        # Base directory for report
+#                                                 #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"           # Patterns to exclude (can be relative
+#                                                 #  to BASE_DIRECTORY, with CMake 3.4+)
+#     NO_DEMANGLE                                 # Don't demangle C++ symbols
+#                                                 #  even if c++filt is found
+# )
+function(setup_target_for_coverage_lcov)
+
+    set(options NO_DEMANGLE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT LCOV_PATH)
+        message(FATAL_ERROR "lcov not found! Aborting...")
+    endif() # NOT LCOV_PATH
+
+    if(NOT GENHTML_PATH)
+        message(FATAL_ERROR "genhtml not found! Aborting...")
+    endif() # NOT GENHTML_PATH
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(${Coverage_BASE_DIRECTORY})
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(LCOV_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_LCOV_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES LCOV_EXCLUDES)
+
+    # Conditional arguments
+    if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
+      set(GENHTML_EXTRA_ARGS "--demangle-cpp")
+    endif()
+
+    # Setup target
+    add_custom_target(${Coverage_NAME}
+
+        # Cleanup lcov
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory . -b ${BASEDIR} --zerocounters
+        # Create baseline to make sure untouched files show up in the report
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b ${BASEDIR} -o ${Coverage_NAME}.base
+
+        # Run tests
+        COMMAND ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+
+        # Capturing lcov counters and generating report
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
+        # add baseline counters
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
+        # filter collected data to final coverage report
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
+
+        # Generate HTML output
+        COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info
+
+        # Set output files as GENERATED (will be removed on 'make clean')
+        BYPRODUCTS
+            ${Coverage_NAME}.base
+            ${Coverage_NAME}.capture
+            ${Coverage_NAME}.total
+            ${Coverage_NAME}.info
+            ${Coverage_NAME}  # report directory
+
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+    )
+
+    # Show where to find the lcov info report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
+    )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+    )
+
+endfunction() # setup_target_for_coverage_lcov
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_gcovr_xml(
+#     NAME ctest_coverage                    # New target name
+#     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES executable_target         # Dependencies to build first
+#     BASE_DIRECTORY "../"                   # Base directory for report
+#                                            #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
+#                                            #  to BASE_DIRECTORY, with CMake 3.4+)
+# )
+function(setup_target_for_coverage_gcovr_xml)
+
+    set(options NONE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(${Coverage_BASE_DIRECTORY})
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(GCOVR_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+
+    # Combine excludes to several -e arguments
+    set(GCOVR_EXCLUDE_ARGS "")
+    foreach(EXCLUDE ${GCOVR_EXCLUDES})
+        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
+    endforeach()
+
+    add_custom_target(${Coverage_NAME}
+        # Run tests
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+
+        # Running gcovr
+        COMMAND ${GCOVR_PATH} --xml
+            -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
+            --object-directory=${PROJECT_BINARY_DIR}
+            -o ${Coverage_NAME}.xml
+        BYPRODUCTS ${Coverage_NAME}.xml
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Running gcovr to produce Cobertura code coverage report."
+    )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
+    )
+endfunction() # setup_target_for_coverage_gcovr_xml
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_gcovr_html(
+#     NAME ctest_coverage                    # New target name
+#     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES executable_target         # Dependencies to build first
+#     BASE_DIRECTORY "../"                   # Base directory for report
+#                                            #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
+#                                            #  to BASE_DIRECTORY, with CMake 3.4+)
+# )
+function(setup_target_for_coverage_gcovr_html)
+
+    set(options NONE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(${Coverage_BASE_DIRECTORY})
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(GCOVR_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+
+    # Combine excludes to several -e arguments
+    set(GCOVR_EXCLUDE_ARGS "")
+    foreach(EXCLUDE ${GCOVR_EXCLUDES})
+        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
+    endforeach()
+
+    add_custom_target(${Coverage_NAME}
+        # Run tests
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+
+        # Create folder
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/${Coverage_NAME}
+
+        # Running gcovr
+        COMMAND ${GCOVR_PATH} --html --html-details
+            -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
+            --object-directory=${PROJECT_BINARY_DIR}
+            -o ${Coverage_NAME}/index.html
+
+        BYPRODUCTS ${PROJECT_BINARY_DIR}/${Coverage_NAME}  # report directory
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Running gcovr to produce HTML code coverage report."
+    )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+    )
+
+endfunction() # setup_target_for_coverage_gcovr_html
+
+function(append_coverage_compiler_flags)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
+endfunction() # append_coverage_compiler_flags


### PR DESCRIPTION
This PR includes:
- Unit test cases for Protocols/CRCElements

Changes from #269 PR :
- Resolved clang-tidy checks
- added Util.h under clang-tidy checks & resolved them
- Updated test case descriptions 