### PR TITLE
Add Rotary encoder support in Clicker  & PR comments resolved

### DIFF
--- a/frontend/src/modules/app/EventAlerts.tsx
+++ b/frontend/src/modules/app/EventAlerts.tsx
@@ -5,7 +5,7 @@ import { Button, Grid, makeStyles, Theme, Typography } from '@material-ui/core';
 import VolumeOffIcon from '@material-ui/icons/VolumeOff';
 import VolumeUpIcon from '@material-ui/icons/VolumeUp';
 import { LogEventCode } from '../../store/controller/proto/mcu_pb';
-import { BMIN, PERCENT } from '../info/units';
+import { BMIN, BPM, PERCENT } from '../info/units';
 import {
   getActiveLogEventIds,
   getAlarmMuteStatus,
@@ -137,12 +137,14 @@ export const getEventType = (
       return {
         type: ALARM_EVENT_PATIENT,
         label: 'spO2 is too low',
+        stateKey: 'spo2',
         unit: PERCENT,
       };
     case LogEventCode.spo2_too_high:
       return {
         type: ALARM_EVENT_PATIENT,
         label: 'spO2 is too high',
+        stateKey: 'spo2',
         unit: PERCENT,
       };
     case LogEventCode.battery_low:
@@ -156,6 +158,18 @@ export const getEventType = (
         type: ALARM_EVENT_SYSTEM,
         label: 'Screen is locked',
         unit: '',
+      };
+    case LogEventCode.hr_too_low:
+      return {
+        type: ALARM_EVENT_SYSTEM,
+        label: 'HR is too low',
+        unit: BPM,
+      };
+    case LogEventCode.hr_too_high:
+      return {
+        type: ALARM_EVENT_SYSTEM,
+        label: 'HR is too high',
+        unit: BPM,
       };
     case BACKEND_CONNECTION_LOST_CODE:
       return {

--- a/frontend/src/modules/app/EventAlerts.tsx
+++ b/frontend/src/modules/app/EventAlerts.tsx
@@ -4,8 +4,8 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Button, Grid, makeStyles, Theme, Typography } from '@material-ui/core';
 import VolumeOffIcon from '@material-ui/icons/VolumeOff';
 import VolumeUpIcon from '@material-ui/icons/VolumeUp';
-import { LogEventCode } from '../../store/controller/proto/mcu_pb';
-import { BMIN, BPM, PERCENT } from '../info/units';
+import { LogEventCode, LogEventType } from '../../store/controller/proto/mcu_pb';
+import { BMIN, BPM, LMIN, PERCENT } from '../info/units';
 import {
   getActiveLogEventIds,
   getAlarmMuteStatus,
@@ -16,9 +16,6 @@ import LogsPage from '../logs/LogsPage';
 import { BellIcon } from '../icons';
 import { updateCommittedState } from '../../store/controller/actions';
 import { ALARM_MUTE, BACKEND_CONNECTION_LOST_CODE } from '../../store/controller/types';
-
-export const ALARM_EVENT_PATIENT = 'Patient';
-export const ALARM_EVENT_SYSTEM = 'System';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -101,13 +98,18 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export const getEventType = (
-  code: LogEventCode,
-): { type: string; label: string; unit: string; head?: string; stateKey?: string } => {
+export interface EventType {
+  type: LogEventType;
+  label: string;
+  unit: string;
+  head?: string;
+  stateKey?: string;
+}
+export const getEventType = (code: LogEventCode): EventType => {
   switch (code) {
     case LogEventCode.fio2_too_low:
       return {
-        type: ALARM_EVENT_PATIENT,
+        type: LogEventType.patient,
         label: 'fiO2 is too low',
         head: 'FiO2',
         stateKey: 'fio2',
@@ -115,7 +117,7 @@ export const getEventType = (
       };
     case LogEventCode.fio2_too_high:
       return {
-        type: ALARM_EVENT_PATIENT,
+        type: LogEventType.patient,
         label: 'fiO2 is too high',
         head: 'FiO2',
         stateKey: 'fio2',
@@ -123,62 +125,80 @@ export const getEventType = (
       };
     case LogEventCode.rr_too_low:
       return {
-        type: ALARM_EVENT_PATIENT,
+        type: LogEventType.patient,
         label: 'Respiratory Rate is too low',
+        stateKey: 'rr',
         unit: BMIN,
       };
     case LogEventCode.rr_too_high:
       return {
-        type: ALARM_EVENT_PATIENT,
+        type: LogEventType.patient,
         label: 'Respiratory Rate is too high',
+        stateKey: 'rr',
         unit: BMIN,
+      };
+    case LogEventCode.hr_too_low:
+      return {
+        type: LogEventType.patient,
+        label: 'Heart Rate is too low',
+        stateKey: 'hr',
+        unit: BPM,
+      };
+    case LogEventCode.hr_too_high:
+      return {
+        type: LogEventType.patient,
+        label: 'Heart Rate is too high',
+        stateKey: 'hr',
+        unit: BPM,
       };
     case LogEventCode.spo2_too_low:
       return {
-        type: ALARM_EVENT_PATIENT,
+        type: LogEventType.patient,
         label: 'spO2 is too low',
         stateKey: 'spo2',
         unit: PERCENT,
       };
     case LogEventCode.spo2_too_high:
       return {
-        type: ALARM_EVENT_PATIENT,
+        type: LogEventType.patient,
         label: 'spO2 is too high',
         stateKey: 'spo2',
         unit: PERCENT,
       };
+    case LogEventCode.fio2_setting_changed:
+      return {
+        type: LogEventType.control,
+        label: 'Fio2 Settings changed',
+        stateKey: 'fio2',
+        unit: PERCENT,
+      };
+    case LogEventCode.flow_setting_changed:
+      return {
+        type: LogEventType.control,
+        label: 'Flow Settings changed',
+        stateKey: 'flow',
+        unit: LMIN,
+      };
     case LogEventCode.battery_low:
       return {
-        type: ALARM_EVENT_SYSTEM,
+        type: LogEventType.system,
         label: 'Battery power is low',
         unit: PERCENT,
       };
     case LogEventCode.screen_locked:
       return {
-        type: ALARM_EVENT_SYSTEM,
+        type: LogEventType.system,
         label: 'Screen is locked',
         unit: '',
       };
-    case LogEventCode.hr_too_low:
-      return {
-        type: ALARM_EVENT_SYSTEM,
-        label: 'HR is too low',
-        unit: BPM,
-      };
-    case LogEventCode.hr_too_high:
-      return {
-        type: ALARM_EVENT_SYSTEM,
-        label: 'HR is too high',
-        unit: BPM,
-      };
     case BACKEND_CONNECTION_LOST_CODE:
       return {
-        type: ALARM_EVENT_SYSTEM,
+        type: LogEventType.system,
         label: 'Software connectivity lost',
         unit: '',
       };
     default:
-      return { type: '', label: '', unit: '' };
+      return { type: LogEventType.system, label: '', unit: '' };
   }
 };
 
@@ -237,7 +257,7 @@ export const EventAlerts = ({ label }: Props): JSX.Element => {
   useEffect(() => {
     if (popupEventLog) {
       const eventType = getEventType(popupEventLog.code);
-      if (eventType.type) {
+      if (eventType.label) {
         setAlertCount(activeLog.length);
         setAlert({ label: eventType.label });
       }

--- a/frontend/src/modules/app/Service.tsx
+++ b/frontend/src/modules/app/Service.tsx
@@ -4,14 +4,11 @@ import { distinctUntilChanged } from 'rxjs/operators';
 const isMultiPopupOpen = new BehaviorSubject<boolean>(false);
 const currentStateKey = new Subject<string>();
 const isScreenLockPopupOpen = new Subject<boolean>();
+const activeRotaryReference = new Subject<string | null>();
 
 export function setMultiPopupOpen(state: boolean, stateKey?: string): void {
   isMultiPopupOpen.next(state);
   currentStateKey.next(stateKey);
-}
-
-export function setScreenLockPopup(state: boolean): void {
-  isScreenLockPopupOpen.next(state);
 }
 
 export function getMultiPopupOpenState(): Observable<boolean> {
@@ -22,6 +19,18 @@ export function getcurrentStateKey(): Observable<string> {
   return currentStateKey.asObservable();
 }
 
+export function setScreenLockPopup(state: boolean): void {
+  isScreenLockPopupOpen.next(state);
+}
+
 export function getScreenLockPopup(): Observable<boolean> {
   return isScreenLockPopupOpen.asObservable();
+}
+
+export function setActiveRotaryReference(refString: string | null): void {
+  activeRotaryReference.next(refString);
+}
+
+export function getActiveRotaryReference(): Observable<string | null> {
+  return activeRotaryReference.asObservable();
 }

--- a/frontend/src/modules/app/ToolBar.tsx
+++ b/frontend/src/modules/app/ToolBar.tsx
@@ -12,7 +12,9 @@ import {
   getIsVentilating,
   getParametersRequestMode,
   getParametersRequestStandby,
+  getPopupEventLog,
 } from '../../store/controller/selectors';
+import { BACKEND_CONNECTION_LOST_CODE } from '../../store/controller/types';
 import ViewDropdown from '../dashboard/views/ViewDropdown';
 import { BackIcon } from '../icons';
 import ClockIcon from '../icons/ClockIcon';
@@ -53,7 +55,7 @@ export const HeaderClock = (): JSX.Element => {
   return <span className={classes.paddingRight}>{clockTime}</span>;
 };
 
-const PowerIndicator = (): JSX.Element => {
+export const PowerIndicator = (): JSX.Element => {
   const classes = useStyles();
   const batteryPower = useSelector(getBatteryPower);
   const chargingStatus = useSelector(getChargingStatus);
@@ -105,11 +107,13 @@ export const ToolBar = ({
   const dispatch = useDispatch();
   const history = useHistory();
   const currentMode = useSelector(getParametersRequestMode);
+  const popupEventLog = useSelector(getPopupEventLog, shallowEqual);
   const parameterRequestStandby = useSelector(getParametersRequestStandby, shallowEqual);
   const ventilating = useSelector(getIsVentilating);
   const [isVentilatorOn, setIsVentilatorOn] = React.useState(ventilating);
   const [label, setLabel] = useState('Start Ventilation');
-  const isDisabled = !isVentilatorOn && location.pathname !== QUICKSTART_ROUTE.path;
+  const [isDisabled, setIsDisabled] = useState(false);
+  // const isDisabled = !isVentilatorOn && location.pathname !== QUICKSTART_ROUTE.path;
   const updateVentilationStatus = () => {
     if (!staticStart) {
       dispatch(updateCommittedParameter({ ventilating: !isVentilatorOn }));
@@ -149,6 +153,14 @@ export const ToolBar = ({
       }
     }
   }, [isVentilatorOn, parameterRequestStandby, currentMode, dispatch]);
+
+  useEffect(() => {
+    if (popupEventLog && popupEventLog.code === BACKEND_CONNECTION_LOST_CODE) {
+      setIsDisabled(true);
+    } else {
+      setIsDisabled(false);
+    }
+  }, [popupEventLog]);
 
   useEffect(() => {
     initParameterUpdate();

--- a/frontend/src/modules/app/UserActivity.tsx
+++ b/frontend/src/modules/app/UserActivity.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { getIsVentilating } from '../../store/controller/selectors';
+import { setMultiPopupOpen } from './Service';
 
 const IdleTimer = ({ timeout, onTimeOut }: { timeout: number; onTimeOut(): void }): JSX.Element => {
   const idle = useCallback(() => {
@@ -52,6 +53,7 @@ export const UserActivity = (): JSX.Element => {
 
   const onTimeOut = () => {
     if (ventilating) {
+      setMultiPopupOpen(false);
       history.push('/screensaver');
     }
   };

--- a/frontend/src/modules/app/layouts/ScreensaverRoute.tsx
+++ b/frontend/src/modules/app/layouts/ScreensaverRoute.tsx
@@ -2,14 +2,12 @@ import { AppBar, Grid, makeStyles, Theme } from '@material-ui/core';
 import React, { PropsWithChildren, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { Route, RouteProps, useHistory } from 'react-router-dom';
-import { getBatteryPower, getIsVentilating } from '../../../store/controller/selectors';
+import { getIsVentilating } from '../../../store/controller/selectors';
 import ClockIcon from '../../icons/ClockIcon';
-import PowerFullIcon from '../../icons/PowerFullIcon';
-import { PERCENT } from '../../info/units';
 import { DASHBOARD_ROUTE, LOGS_ROUTE, QUICKSTART_ROUTE } from '../../navigation/constants';
 import EventAlerts from '../EventAlerts';
 import UserActivity from '../UserActivity';
-import { HeaderClock } from '../ToolBar';
+import { HeaderClock, PowerIndicator } from '../ToolBar';
 import OverlayScreen from '../OverlayScreen';
 import { getAlarmNotifyStatus } from '../../../store/app/selectors';
 
@@ -80,7 +78,6 @@ const ContentComponent = React.memo(({ children }: PropsWithChildren<unknown>) =
   const classes = useStyles();
   const history = useHistory();
   const ventilating = useSelector(getIsVentilating);
-  const batteryPower = useSelector(getBatteryPower);
   const notifyAlarm = useSelector(getAlarmNotifyStatus);
   const [showBorder, setShowBorder] = React.useState(false);
 
@@ -106,10 +103,7 @@ const ContentComponent = React.memo(({ children }: PropsWithChildren<unknown>) =
             <EventAlerts label={LOGS_ROUTE.label} />
           </Grid>
           <Grid container item xs justify="flex-end" alignItems="center">
-            <span className={classes.paddingRight}>{`${
-              batteryPower !== undefined ? batteryPower.toFixed(0) : '--'
-            }${PERCENT}`}</span>
-            <PowerFullIcon style={{ fontSize: '2.5rem' }} />
+            <PowerIndicator />
             <HeaderClock />
             <ClockIcon style={{ fontSize: '2.5rem' }} />
           </Grid>

--- a/frontend/src/modules/controllers/ModalPopup.tsx
+++ b/frontend/src/modules/controllers/ModalPopup.tsx
@@ -19,12 +19,18 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.palette.text.primary,
     border: `1px solid ${theme.palette.text.primary}`,
     borderRadius: 6,
+    padding: '5px',
   },
   dialogActions: {
     padding: 0,
   },
   popupWidth: {
     '& .MuiDialog-container': {
+      '& .MuiPaper-root': {
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: 'calc(100% - 64px)',
+      },
       '& .MuiDialog-paperWidthSm': {
         maxWidth: '750px',
 
@@ -37,6 +43,34 @@ const useStyles = makeStyles((theme: Theme) => ({
           overflow: 'hidden',
         },
       },
+    },
+  },
+  containerClass: {
+    maxWidth: '80%',
+    maxHeight: '80%',
+    margin: '0 auto',
+  },
+  wrapper: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    marginTop: 'auto',
+    marginBottom: 'auto',
+  },
+  wrapperFlex: {
+    width: '100%',
+    '& .MuiDialogTitle-root': {
+      padding: '0px 24px',
+    },
+  },
+  actionButtons: {
+    marginBottom: '10px',
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    '& .MuiGrid-item': {
+      padding: '0px 10px',
     },
   },
 }));
@@ -58,15 +92,17 @@ interface ActionProps {
 }
 
 const ModalAction = ({ onClose, onConfirm }: ActionProps): JSX.Element => {
+  const classes = useStyles();
   return (
-    <Grid container justify="center" style={{ marginBottom: '10px' }}>
-      <Grid container item xs justify="center">
-        <Button onClick={onClose} variant="contained" color="primary" style={{ width: '90%' }}>
+    <Grid container justify="center" className={classes.actionButtons}>
+      <Grid item justify="center">
+        <Button onClick={onClose} variant="contained" color="primary">
+          {/* style={{ width: '90%' }} */}
           Cancel
         </Button>
       </Grid>
-      <Grid container item xs justify="center">
-        <Button onClick={onConfirm} variant="contained" color="secondary" style={{ width: '90%' }}>
+      <Grid item justify="center">
+        <Button onClick={onConfirm} variant="contained" color="secondary">
           Confirm
         </Button>
       </Grid>
@@ -84,8 +120,8 @@ export const ModalPopup = (props: PropsWithChildren<Props>): JSX.Element => {
     children,
     withAction,
     onConfirm,
-    fullWidth = false,
-    maxWidth = 'sm',
+    fullWidth = true,
+    maxWidth = 'xl',
   } = props;
   return (
     <Dialog
@@ -96,24 +132,32 @@ export const ModalPopup = (props: PropsWithChildren<Props>): JSX.Element => {
       className={classes.popupWidth}
       scroll="paper"
     >
-      <DialogTitle id="form-dialog-title">
-        <Grid container alignItems="center">
-          <Grid item xs>
-            <Typography variant="h4">{label}</Typography>
+      <Grid alignItems="center" className={classes.wrapper}>
+        <Grid alignItems="center" className={classes.wrapperFlex}>
+          <DialogTitle id="form-dialog-title">
+            <Grid container alignItems="center">
+              {label && (
+                <Grid item xs>
+                  <Typography variant="h4">{label}</Typography>
+                </Grid>
+              )}
+              <Grid item>
+                {showCloseIcon && (
+                  <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>
+                    <CloseIcon />
+                  </IconButton>
+                )}
+              </Grid>
+            </Grid>
+          </DialogTitle>
+          <Grid container alignItems="center" className={classes.containerClass}>
+            <DialogContent>{children}</DialogContent>
           </Grid>
-          <Grid item>
-            {showCloseIcon && (
-              <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>
-                <CloseIcon />
-              </IconButton>
-            )}
-          </Grid>
+          <DialogActions className={classes.dialogActions}>
+            {withAction && <ModalAction onClose={onClose} onConfirm={onConfirm} />}
+          </DialogActions>
         </Grid>
-      </DialogTitle>
-      <DialogContent>{children}</DialogContent>
-      <DialogActions className={classes.dialogActions}>
-        {withAction && <ModalAction onClose={onClose} onConfirm={onConfirm} />}
-      </DialogActions>
+      </Grid>
     </Dialog>
   );
 };

--- a/frontend/src/modules/controllers/RotaryEncodeController.tsx
+++ b/frontend/src/modules/controllers/RotaryEncodeController.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { useSelector, shallowEqual } from 'react-redux';
+import { getRotaryEncoder } from '../../store/controller/selectors';
+
+interface Props {
+  value: number;
+  onClick: (value: number) => void;
+  min?: number;
+  max?: number;
+  isActive: boolean;
+}
+
+/**
+ * RotaryEncodeController
+ *
+ * A re-usable "RotaryEncoder" component for adjusting ValueClicker value
+ */
+export const RotaryEncodeController = ({
+  value,
+  onClick,
+  min = 0,
+  max = 100,
+  isActive,
+}: Props): JSX.Element => {
+  const rotaryEncoder = useSelector(getRotaryEncoder, shallowEqual);
+  const isInitialMount = useRef(true);
+
+  const updateRotaryData = useCallback(
+    () => {
+      if (isInitialMount.current) {
+        isInitialMount.current = false;
+      } else if (!Number.isNaN(rotaryEncoder?.stepDiff)) {
+        const stepDiff = rotaryEncoder?.stepDiff || 0;
+        const valueClone = value >= min ? value : min;
+        const newValue = valueClone + stepDiff;
+        if (newValue < min) {
+          onClick(min);
+        } else if (newValue > max) {
+          onClick(max);
+        } else {
+          onClick(newValue);
+        }
+        // if (rotaryEncoder.buttonPressed) {
+        //   handleConfirm();
+        // }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [rotaryEncoder?.step, rotaryEncoder?.buttonPressed, min, max],
+  );
+
+  useEffect(() => {
+    if (isActive) {
+      updateRotaryData();
+    }
+  }, [updateRotaryData, isActive]);
+
+  return <React.Fragment />;
+};
+
+export default RotaryEncodeController;

--- a/frontend/src/modules/controllers/SimpleTable.tsx
+++ b/frontend/src/modules/controllers/SimpleTable.tsx
@@ -53,6 +53,7 @@ export function stableSort<T>(array: T[], comparator: (a: T, b: T) => number): T
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
+    tableRowStyle: {},
     tableContainer: {
       width: '100%',
       border: `2px dashed ${theme.palette.background.default}`,
@@ -62,6 +63,13 @@ const useStyles = makeStyles((theme: Theme) =>
       minWidth: 500,
       padding: '3px solid black',
       backgroundColor: theme.palette.background.paper,
+      '& tbody': {
+        '& tr': {
+          '& td': {
+            borderBottom: 'none',
+          },
+        },
+      },
     },
     visuallyHidden: {
       border: 0,
@@ -138,7 +146,7 @@ function EnhancedTableHead(props: EnhancedTableProps) {
 
   return (
     <TableHead>
-      <TableRow>
+      <TableRow className={classes.tableRowStyle}>
         {headCells.map((headCell: HeadCell) => (
           <StyledTableCell
             key={headCell.id}

--- a/frontend/src/modules/controllers/SimpleTable.tsx
+++ b/frontend/src/modules/controllers/SimpleTable.tsx
@@ -94,6 +94,7 @@ export interface HeadCell {
   id: string | number;
   label: string;
   numeric: boolean;
+  enableSort: boolean;
 }
 
 export interface EnhancedTableProps {
@@ -145,7 +146,7 @@ function EnhancedTableHead(props: EnhancedTableProps) {
             padding="default"
             sortDirection={orderBy === headCell.id ? order : false}
           >
-            {orderBy ? (
+            {headCell.enableSort && orderBy ? (
               <TableSortLabel
                 active={orderBy === headCell.id}
                 direction={orderBy === headCell.id ? order : 'asc'}

--- a/frontend/src/modules/controllers/ValueController.tsx
+++ b/frontend/src/modules/controllers/ValueController.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { RefObject } from 'react';
 import { Grid, makeStyles, Theme } from '@material-ui/core';
 import { ValueClicker } from '.';
 import ValueDisplay from '../displays/ValueDisplay';
@@ -19,6 +19,8 @@ interface Props {
   min?: number;
   max?: number;
   units?: string;
+  reference: RefObject<HTMLDivElement>;
+  referenceKey: string;
 }
 
 /**
@@ -33,16 +35,24 @@ const ValueController = ({
   max = 100,
   onClick,
   units,
+  reference,
+  referenceKey,
 }: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
-    <Grid container className={classes.root}>
+    <Grid ref={reference} container className={classes.root}>
       <Grid item xs>
         <ValueDisplay value={value} label={label} units={units} />
       </Grid>
       <Grid item>
-        <ValueClicker value={value} onClick={onClick} min={min} max={max} />
+        <ValueClicker
+          referenceKey={referenceKey}
+          value={value}
+          onClick={onClick}
+          min={min}
+          max={max}
+        />
       </Grid>
     </Grid>
   );

--- a/frontend/src/modules/controllers/ValueSlider.tsx
+++ b/frontend/src/modules/controllers/ValueSlider.tsx
@@ -12,7 +12,7 @@ const boxShadow = '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.13),0 0 0 1p
 
 const StyledSlider = withStyles({
   root: {
-    color: '#3880ff',
+    color: 'rgb(41 71 98) !important',
     height: 2,
     padding: '15px 0',
     '& .Mui-disabled': {
@@ -20,7 +20,7 @@ const StyledSlider = withStyles({
       width: '32px',
       marginTop: '-14px',
       marginLeft: '-14px',
-      backgroundColor: '#bfbfbf',
+      backgroundColor: 'rgb(41 71 98)',
     },
   },
   thumb: {
@@ -55,7 +55,7 @@ const StyledSlider = withStyles({
   rail: {
     height: 2,
     opacity: 0.5,
-    backgroundColor: '#bfbfbf',
+    backgroundColor: 'rgb(41 71 98)',
   },
   mark: {
     backgroundColor: '#bfbfbf',

--- a/frontend/src/modules/controllers/ValueSlider.tsx
+++ b/frontend/src/modules/controllers/ValueSlider.tsx
@@ -15,15 +15,22 @@ const StyledSlider = withStyles({
     color: '#3880ff',
     height: 2,
     padding: '15px 0',
+    '& .Mui-disabled': {
+      height: '28px',
+      width: '32px',
+      marginTop: '-14px',
+      marginLeft: '-14px',
+      backgroundColor: '#bfbfbf',
+    },
   },
   thumb: {
-    height: 28,
-    width: 32,
+    height: '28px',
+    width: '32px',
     backgroundColor: '#0053b1',
     borderRadius: 5,
     boxShadow,
-    marginTop: -14,
-    marginLeft: -14,
+    marginTop: '-14px',
+    marginLeft: '-14px',
     '&:focus, &:hover, &$active': {
       border: '1px solid #fff',
       boxShadow: '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.3),0 0 0 1px rgba(0,0,0,0.02)',
@@ -68,9 +75,17 @@ interface Props {
   onChange?(values: number[]): void;
   rangeValues?: number[];
   step?: number;
+  disabled?: boolean;
 }
 
-export const ValueSlider = ({ min, max, onChange, rangeValues, step }: Props): JSX.Element => {
+export const ValueSlider = ({
+  min,
+  max,
+  onChange,
+  rangeValues,
+  step,
+  disabled = false,
+}: Props): JSX.Element => {
   const classes = useStyles();
   const [value, setValue] = React.useState<number[]>([min, max]);
   if (rangeValues) {
@@ -102,6 +117,7 @@ export const ValueSlider = ({ min, max, onChange, rangeValues, step }: Props): J
             step={step || 1}
             onChange={handleChange}
             defaultValue={60}
+            disabled={disabled}
           />
         </Grid>
         <Grid container item xs justify="center" alignItems="center">

--- a/frontend/src/modules/dashboard/containers/ValueInfo.tsx
+++ b/frontend/src/modules/dashboard/containers/ValueInfo.tsx
@@ -351,7 +351,11 @@ const GridControlValuesDisplay = ({
  * Component for showing information.
  *
  */
-const ValueInfo = (props: ValueInfoProps): JSX.Element => {
+const ValueInfo = (props: {
+  mainContainer: Props;
+  subContainer1?: Props;
+  subContainer2?: Props;
+}): JSX.Element => {
   const { mainContainer, subContainer1, subContainer2 } = props;
   const classes = useStyles();
   const Render = () => {

--- a/frontend/src/modules/logs/LogsPage.tsx
+++ b/frontend/src/modules/logs/LogsPage.tsx
@@ -7,6 +7,7 @@ import { LogEvent } from '../../store/controller/proto/mcu_pb';
 import { getActiveLogEventIds, getNextLogEvents } from '../../store/controller/selectors';
 import { EXPECTED_LOG_EVENT_ID } from '../../store/controller/types';
 import { ALARM_EVENT_PATIENT, getEventType } from '../app/EventAlerts';
+import { setMultiPopupOpen } from '../app/Service';
 import { AlarmModal } from '../controllers';
 import ModalPopup from '../controllers/ModalPopup';
 import SimpleTable, {
@@ -39,11 +40,11 @@ interface Data {
 //
 
 const headCells: HeadCell[] = [
-  { id: 'type', numeric: false, disablePadding: true, label: 'Type' },
-  { id: 'alarm', numeric: true, disablePadding: false, label: 'Alarm' },
-  { id: 'time', numeric: true, disablePadding: false, label: 'Time/Date' },
-  { id: 'details', numeric: false, disablePadding: false, label: 'Details' },
-  { id: 'settings', numeric: true, disablePadding: false, label: 'Settings' },
+  { id: 'type', numeric: false, disablePadding: true, label: 'Type', enableSort: false },
+  { id: 'alarm', numeric: true, disablePadding: false, label: 'Alarm', enableSort: false },
+  { id: 'time', numeric: true, disablePadding: false, label: 'Time/Date', enableSort: true },
+  { id: 'details', numeric: false, disablePadding: false, label: 'Details', enableSort: false },
+  { id: 'settings', numeric: true, disablePadding: false, label: 'Settings', enableSort: false },
 ];
 
 const useStyles = makeStyles(() =>
@@ -114,6 +115,7 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
   const loggedEvents = useSelector(getNextLogEvents, shallowEqual);
   const activeLogEventIds = useSelector(getActiveLogEventIds, shallowEqual);
+  const settingsAllowed = ['hr', 'spo2'];
 
   const updateLogEvent = useCallback(
     (maxId) => {
@@ -206,7 +208,10 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
   };
 
   const onSettings = (row: Data) => {
-    setAlarmOpen(true);
+    // setAlarmOpen(true);
+    if (row.stateKey) {
+      setMultiPopupOpen(true, row.stateKey);
+    }
     setCurrentRow(row);
   };
 
@@ -284,7 +289,7 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
                   {row.details}
                 </TableCell>
                 <TableCell component="td">
-                  {row.type === ALARM_EVENT_PATIENT && row.stateKey && (
+                  {row.type === ALARM_EVENT_PATIENT && settingsAllowed.indexOf(row.stateKey) > -1 && (
                     <Button
                       variant="contained"
                       color="primary"

--- a/frontend/src/modules/logs/LogsPage.tsx
+++ b/frontend/src/modules/logs/LogsPage.tsx
@@ -3,13 +3,18 @@ import { createStyles, makeStyles, useTheme } from '@material-ui/core/styles';
 import React, { useCallback, useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { updateCommittedState } from '../../store/controller/actions';
-import { LogEvent } from '../../store/controller/proto/mcu_pb';
-import { getActiveLogEventIds, getNextLogEvents } from '../../store/controller/selectors';
+import { LogEvent, LogEventType, Range } from '../../store/controller/proto/mcu_pb';
+import {
+  getActiveLogEventIds,
+  getAlarmLimitsRequest,
+  getNextLogEvents,
+} from '../../store/controller/selectors';
 import { EXPECTED_LOG_EVENT_ID } from '../../store/controller/types';
-import { ALARM_EVENT_PATIENT, getEventType } from '../app/EventAlerts';
 import { setMultiPopupOpen } from '../app/Service';
+import { EventType, getEventType } from '../app/EventAlerts';
 import { AlarmModal } from '../controllers';
 import ModalPopup from '../controllers/ModalPopup';
+
 import SimpleTable, {
   getComparator,
   HeadCell,
@@ -26,7 +31,7 @@ import EventlogDetails from './container/EventlogDetails';
  */
 
 interface Data {
-  type: string;
+  type: LogEventType;
   alarm: string;
   time: number; // Note: Make this a date object?
   status: number;
@@ -89,8 +94,21 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
   const theme = useTheme();
   const dispatch = useDispatch();
 
+  const getEventTypeLabel = (type: LogEventType): string => {
+    switch (type) {
+      case LogEventType.patient:
+        return 'Patient';
+      case LogEventType.control:
+        return 'Control';
+      case LogEventType.system:
+        return 'System';
+      default:
+        return 'System';
+    }
+  };
+
   const createData = (
-    type: string,
+    type: LogEventType,
     alarm: string,
     time: number,
     status: number,
@@ -115,6 +133,10 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
   const loggedEvents = useSelector(getNextLogEvents, shallowEqual);
   const activeLogEventIds = useSelector(getActiveLogEventIds, shallowEqual);
+  const alarmLimits: Record<string, Range> = useSelector(
+    getAlarmLimitsRequest,
+    shallowEqual,
+  ) as Record<string, Range>;
   const settingsAllowed = ['hr', 'spo2'];
 
   const updateLogEvent = useCallback(
@@ -127,13 +149,25 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
   useEffect(() => {
     const eventIds: number[] = [];
     const data: Data[] = [];
+
+    const getDetails = (event: LogEvent, eventType: EventType) => {
+      if (event.type === LogEventType.patient) {
+        if (eventType?.stateKey) {
+          return eventType.label.includes('high')
+            ? `Upper limit of ${eventType?.stateKey} is ${alarmLimits[eventType.stateKey].upper}`
+            : `Lower limit of ${eventType?.stateKey} is ${alarmLimits[eventType.stateKey].lower}`;
+        }
+      } else if (event.type === LogEventType.control) {
+        return event.oldValue != null && event.newValue != null
+          ? `Control ${eventType?.stateKey} changed from ${event.oldValue} ${eventType.unit} to ${event.newValue} ${eventType.unit}`
+          : '';
+      }
+      return '';
+    };
+
     loggedEvents.sort((a: LogEvent, b: LogEvent) => a.time - b.time);
     loggedEvents.forEach((event: LogEvent) => {
       const eventType = getEventType(event.code);
-      const diffString =
-        event.oldValue != null && event.newValue != null
-          ? `(${event.oldValue} ${eventType.unit} to ${event.newValue} ${eventType.unit})`
-          : '';
       eventIds.push(event.id);
       if (filter) {
         setPage(0);
@@ -145,7 +179,7 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
               event.time,
               activeLogEventIds.indexOf(event.id) > -1 ? 1 : 0,
               event.id,
-              diffString,
+              getDetails(event, eventType),
               eventType.stateKey || '',
               eventType.head || '',
               eventType.unit || '',
@@ -160,7 +194,7 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
             event.time,
             activeLogEventIds.indexOf(event.id) > -1 ? 1 : 0,
             event.id,
-            diffString,
+            getDetails(event, eventType),
             eventType.stateKey || '',
             eventType.head || '',
             eventType.unit || '',
@@ -171,7 +205,7 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
     setRows(data.length ? data : []);
     // update ExpectedLogEvent
     updateLogEvent(Math.max(...eventIds));
-  }, [loggedEvents, activeLogEventIds, updateLogEvent, filter]);
+  }, [loggedEvents, activeLogEventIds, updateLogEvent, filter, alarmLimits]);
 
   const handleClose = () => {
     setOpen(false);
@@ -181,10 +215,10 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
     handleClose();
   };
 
-  const typeColor = (type: string | undefined) => {
-    if (type === 'Operator') return { backgroundColor: theme.palette.primary.main };
-    if (type === 'Patient') return { backgroundColor: '#92D25B', color: 'black' };
-    if (type === 'System') return { backgroundColor: '#E68619' };
+  const typeColor = (type: LogEventType | undefined) => {
+    if (type === LogEventType.control) return { backgroundColor: theme.palette.primary.main };
+    if (type === LogEventType.patient) return { backgroundColor: '#92D25B', color: 'black' };
+    if (type === LogEventType.system) return { backgroundColor: '#E68619' };
     return { backgroundColor: '#E68619' };
   };
 
@@ -208,7 +242,6 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
   };
 
   const onSettings = (row: Data) => {
-    // setAlarmOpen(true);
     if (row.stateKey) {
       setMultiPopupOpen(true, row.stateKey);
     }
@@ -245,7 +278,9 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
             return (
               <StyledTableRow
                 hover
-                onClick={(event: React.MouseEvent<unknown>) => handleClick(event, row.type)}
+                onClick={(event: React.MouseEvent<unknown>) =>
+                  handleClick(event, getEventTypeLabel(row.type))
+                }
                 tabIndex={-1}
                 key={row.id}
               >
@@ -255,7 +290,7 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
                     className={classes.eventType}
                     style={typeColor(row.type)}
                   >
-                    {row.type}
+                    {getEventTypeLabel(row.type)}
                   </Button>
                   {/* {row.status ? (
                     <Button
@@ -289,7 +324,7 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
                   {row.details}
                 </TableCell>
                 <TableCell component="td">
-                  {row.type === ALARM_EVENT_PATIENT && settingsAllowed.indexOf(row.stateKey) > -1 && (
+                  {row.type === LogEventType.patient && settingsAllowed.indexOf(row.stateKey) > -1 && (
                     <Button
                       variant="contained"
                       color="primary"
@@ -314,7 +349,7 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
         label={
           <Grid container direction="row" justify="space-around" alignItems="center">
             <Grid xs={2} className={classes.typeWrapper2} style={typeColor(currentRow?.type)}>
-              {currentRow?.type}
+              {getEventTypeLabel(currentRow?.type as LogEventType)}
             </Grid>
             <Grid xs={9}>
               <Typography variant="h4">{currentRow?.alarm}</Typography>

--- a/frontend/src/modules/logs/container/EventlogDetails.tsx
+++ b/frontend/src/modules/logs/container/EventlogDetails.tsx
@@ -43,8 +43,14 @@ const rows = [
 ];
 
 const headCells: HeadCell[] = [
-  { id: 'value', numeric: false, disablePadding: true, label: 'Value' },
-  { id: 'measurement', numeric: false, disablePadding: false, label: 'Measurement' },
+  { id: 'value', numeric: false, disablePadding: true, label: 'Value', enableSort: false },
+  {
+    id: 'measurement',
+    numeric: false,
+    disablePadding: false,
+    label: 'Measurement',
+    enableSort: false,
+  },
 ];
 
 /**

--- a/frontend/src/modules/settings/containers/constants.tsx
+++ b/frontend/src/modules/settings/containers/constants.tsx
@@ -1,0 +1,12 @@
+export const BRIGHTNESS_REFERENCE_KEY = 'brightness';
+export const HOUR_REFERENCE_KEY = 'hour';
+export const MINUTE_REFERENCE_KEY = 'minute';
+export const MONTH_REFERENCE_KEY = 'month';
+export const DAY_REFERENCE_KEY = 'day';
+export const YEAR_REFERENCE_KEY = 'year';
+
+export const PEEP_REFERENCE_KEY = 'peep';
+export const RR_REFERENCE_KEY = 'rr';
+export const FIO2_REFERENCE_KEY = 'fio2';
+export const TV_REFERENCE_KEY = 'tv';
+export const FLOW_REFERENCE_KEY = 'flow';

--- a/frontend/src/modules/utils/useRotaryReference.tsx
+++ b/frontend/src/modules/utils/useRotaryReference.tsx
@@ -1,0 +1,33 @@
+import { Theme } from '@material-ui/core';
+import { RefObject } from 'react';
+import { Subscription } from 'rxjs';
+import { getActiveRotaryReference } from '../app/Service';
+
+export const useRotaryReference = (
+  theme: Theme,
+): { initRefListener(elRefs: Record<string, RefObject<HTMLDivElement>>): void } => {
+  const initRefListener = (elRefs: Record<string, RefObject<HTMLDivElement>>) => {
+    const refSubscription: Subscription = getActiveRotaryReference().subscribe(
+      (refString: string | null) => {
+        Object.values(elRefs).forEach((elRef: RefObject<HTMLDivElement>) => {
+          const ref = elRef.current;
+          if (ref) ref.style.border = 'none';
+        });
+        if (refString) {
+          if (elRefs[refString] && elRefs[refString].current) {
+            const ref = elRefs[refString].current;
+            if (ref) ref.style.border = `1px solid ${theme.palette.text.primary}`;
+          }
+        }
+      },
+    );
+    return () => {
+      if (refSubscription) {
+        refSubscription.unsubscribe();
+      }
+    };
+  };
+  return { initRefListener };
+};
+
+export default useRotaryReference;

--- a/frontend/src/store/controller/proto/mcu_pb.ts
+++ b/frontend/src/store/controller/proto/mcu_pb.ts
@@ -75,6 +75,8 @@ export enum LogEventCode {
   rr_too_high = 5,
   battery_low = 6,
   screen_locked = 7,
+  hr_too_low = 8,
+  hr_too_high = 9,
   UNRECOGNIZED = -1,
 }
 
@@ -104,6 +106,12 @@ export function logEventCodeFromJSON(object: any): LogEventCode {
     case 7:
     case "screen_locked":
       return LogEventCode.screen_locked;
+    case 8:
+    case "hr_too_low":
+      return LogEventCode.hr_too_low;
+    case 9:
+    case "hr_too_high":
+      return LogEventCode.hr_too_high;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -129,6 +137,10 @@ export function logEventCodeToJSON(object: LogEventCode): string {
       return "battery_low";
     case LogEventCode.screen_locked:
       return "screen_locked";
+    case LogEventCode.hr_too_low:
+      return "hr_too_low";
+    case LogEventCode.hr_too_high:
+      return "hr_too_high";
     default:
       return "UNKNOWN";
   }

--- a/frontend/src/store/controller/proto/mcu_pb.ts
+++ b/frontend/src/store/controller/proto/mcu_pb.ts
@@ -73,10 +73,12 @@ export enum LogEventCode {
   spo2_too_high = 3,
   rr_too_low = 4,
   rr_too_high = 5,
-  battery_low = 6,
-  screen_locked = 7,
-  hr_too_low = 8,
-  hr_too_high = 9,
+  hr_too_low = 6,
+  hr_too_high = 7,
+  fio2_setting_changed = 8,
+  flow_setting_changed = 9,
+  battery_low = 10,
+  screen_locked = 11,
   UNRECOGNIZED = -1,
 }
 
@@ -101,9 +103,21 @@ export function logEventCodeFromJSON(object: any): LogEventCode {
     case "rr_too_high":
       return LogEventCode.rr_too_high;
     case 6:
+    case "hr_too_low":
+      return LogEventCode.hr_too_low;
+    case 7:
+    case "hr_too_high":
+      return LogEventCode.hr_too_high;
+    case 8:
+    case "fio2_setting_changed":
+      return LogEventCode.fio2_setting_changed;
+    case 9:
+    case "flow_setting_changed":
+      return LogEventCode.flow_setting_changed;
+    case 10:
     case "battery_low":
       return LogEventCode.battery_low;
-    case 7:
+    case 11:
     case "screen_locked":
       return LogEventCode.screen_locked;
     case 8:
@@ -133,6 +147,14 @@ export function logEventCodeToJSON(object: LogEventCode): string {
       return "rr_too_low";
     case LogEventCode.rr_too_high:
       return "rr_too_high";
+    case LogEventCode.hr_too_low:
+      return "hr_too_low";
+    case LogEventCode.hr_too_high:
+      return "hr_too_high";
+    case LogEventCode.fio2_setting_changed:
+      return "fio2_setting_changed";
+    case LogEventCode.flow_setting_changed:
+      return "flow_setting_changed";
     case LogEventCode.battery_low:
       return "battery_low";
     case LogEventCode.screen_locked:
@@ -141,6 +163,44 @@ export function logEventCodeToJSON(object: LogEventCode): string {
       return "hr_too_low";
     case LogEventCode.hr_too_high:
       return "hr_too_high";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+export enum LogEventType {
+  patient = 0,
+  system = 1,
+  control = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function logEventTypeFromJSON(object: any): LogEventType {
+  switch (object) {
+    case 0:
+    case "patient":
+      return LogEventType.patient;
+    case 1:
+    case "system":
+      return LogEventType.system;
+    case 2:
+    case "control":
+      return LogEventType.control;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return LogEventType.UNRECOGNIZED;
+  }
+}
+
+export function logEventTypeToJSON(object: LogEventType): string {
+  switch (object) {
+    case LogEventType.patient:
+      return "patient";
+    case LogEventType.system:
+      return "system";
+    case LogEventType.control:
+      return "control";
     default:
       return "UNKNOWN";
   }
@@ -251,6 +311,7 @@ export interface LogEvent {
   alarmLimits: Range | undefined;
   oldValue: number;
   newValue: number;
+  type: LogEventType;
 }
 
 export interface ExpectedLogEvent {
@@ -1850,6 +1911,7 @@ const baseLogEvent: object = {
   code: 0,
   oldValue: 0,
   newValue: 0,
+  type: 0,
 };
 
 export const LogEvent = {
@@ -1865,6 +1927,7 @@ export const LogEvent = {
     }
     writer.uint32(45).float(message.oldValue);
     writer.uint32(53).float(message.newValue);
+    writer.uint32(56).int32(message.type);
     return writer;
   },
 
@@ -1892,6 +1955,9 @@ export const LogEvent = {
           break;
         case 6:
           message.newValue = reader.float();
+          break;
+        case 7:
+          message.type = reader.int32() as any;
           break;
         default:
           reader.skipType(tag & 7);
@@ -1933,6 +1999,11 @@ export const LogEvent = {
     } else {
       message.newValue = 0;
     }
+    if (object.type !== undefined && object.type !== null) {
+      message.type = logEventTypeFromJSON(object.type);
+    } else {
+      message.type = 0;
+    }
     return message;
   },
 
@@ -1968,6 +2039,11 @@ export const LogEvent = {
     } else {
       message.newValue = 0;
     }
+    if (object.type !== undefined && object.type !== null) {
+      message.type = object.type;
+    } else {
+      message.type = 0;
+    }
     return message;
   },
 
@@ -1982,6 +2058,7 @@ export const LogEvent = {
         : undefined);
     message.oldValue !== undefined && (obj.oldValue = message.oldValue);
     message.newValue !== undefined && (obj.newValue = message.newValue);
+    message.type !== undefined && (obj.type = logEventTypeToJSON(message.type));
     return obj;
   },
 };

--- a/frontend/src/styles/customTheme.ts
+++ b/frontend/src/styles/customTheme.ts
@@ -20,6 +20,9 @@ function createCustomTheme(options: ThemeOptions) {
     panel: {
       borderRadius: 16,
     },
+    transitions: {
+      create: () => 'none',
+    },
     // End custom attributes.
     ...options,
   });

--- a/proto/mcu_pb.proto
+++ b/proto/mcu_pb.proto
@@ -120,6 +120,8 @@ enum LogEventCode {
   rr_too_high = 5;
   battery_low = 6;
   screen_locked = 7;
+  hr_too_low = 8;
+  hr_too_high = 9;
 }
 
 message LogEvent {

--- a/proto/mcu_pb.proto
+++ b/proto/mcu_pb.proto
@@ -118,10 +118,18 @@ enum LogEventCode {
   spo2_too_high = 3;
   rr_too_low = 4;
   rr_too_high = 5;
-  battery_low = 6;
-  screen_locked = 7;
-  hr_too_low = 8;
-  hr_too_high = 9;
+  hr_too_low = 6;
+  hr_too_high = 7;
+  fio2_setting_changed = 8;
+  flow_setting_changed = 9;
+  battery_low = 10;
+  screen_locked = 11;
+}
+
+enum LogEventType {
+  patient = 0;
+  system = 1;
+  control = 2;
 }
 
 message LogEvent {
@@ -131,6 +139,7 @@ message LogEvent {
   Range alarm_limits = 4;
   float old_value = 5;
   float new_value = 6;
+  LogEventType type = 7;
 }
 
 message ExpectedLogEvent {


### PR DESCRIPTION
This PR covers following points

* Added Rotary encoder support for all Clicker functions in Alarms page, Alarm Modal, Settings page & Quickstart page
* Added border around clicker to identify which value clicker is active
* Event Log settings popup updated to Multistep popup
* Added HR alarms in protobuf & Events log
* Start/Pause Ventilation is disabled when backend is disconnected
* Multistep popup on Cancel of Confirm/Cancel confirmation popup, reopens multistep popup with previous state
* Added Clicker in Alarms page & updated Slider CSS for disabled mode