### PR TITLE
firmware: Vector::copy_from: detect when copy is truncated

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
@@ -38,8 +38,11 @@ IndexStatus CRCElement<PayloadBuffer>::write_protected(
     return IndexStatus::out_of_bounds;
   }
 
-  output_buffer.copy_from(
-      payload_.buffer(), payload_.size(), CRCElementHeaderProps::payload_offset);
+  if (output_buffer.copy_from(
+          payload_.buffer(), payload_.size(), CRCElementHeaderProps::payload_offset) !=
+      IndexStatus::ok) {
+    return IndexStatus::out_of_bounds;
+  };
   return IndexStatus::ok;
 }
 
@@ -53,10 +56,12 @@ IndexStatus CRCElement<PayloadBuffer>::parse(const Util::ByteVector<input_size> 
   if (input_buffer.size() < CRCElementHeaderProps::header_size) {
     return IndexStatus::out_of_bounds;
   }
+  if (payload_.copy_from(
+          input_buffer.buffer() + CRCElementHeaderProps::payload_offset,
+          input_buffer.size() - CRCElementHeaderProps::payload_offset) != IndexStatus::ok) {
+    return IndexStatus::out_of_bounds;
+  };
   Util::read_ntoh(input_buffer.buffer(), crc_);
-  payload_.copy_from(
-      input_buffer.buffer() + CRCElementHeaderProps::payload_offset,
-      input_buffer.size() - CRCElementHeaderProps::payload_offset);
   return IndexStatus::ok;
 }
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/CRCElements.tpp
@@ -56,12 +56,12 @@ IndexStatus CRCElement<PayloadBuffer>::parse(const Util::ByteVector<input_size> 
   if (input_buffer.size() < CRCElementHeaderProps::header_size) {
     return IndexStatus::out_of_bounds;
   }
+  Util::read_ntoh(input_buffer.buffer(), crc_);
   if (payload_.copy_from(
           input_buffer.buffer() + CRCElementHeaderProps::payload_offset,
           input_buffer.size() - CRCElementHeaderProps::payload_offset) != IndexStatus::ok) {
     return IndexStatus::out_of_bounds;
   };
-  Util::read_ntoh(input_buffer.buffer(), crc_);
   return IndexStatus::ok;
 }
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Chunks.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Chunks.tpp
@@ -37,7 +37,9 @@ ChunkOutputStatus ChunkSplitter<buffer_size, Byte>::output(
     return ChunkOutputStatus::waiting;
   }
 
-  output_buffer.copy_from(buffer_);
+  if (output_buffer.copy_from(buffer_) != IndexStatus::ok) {
+    return ChunkOutputStatus::invalid_length;
+  };
   buffer_.clear();
   ChunkOutputStatus output_status = ChunkOutputStatus::ok;
   if (input_status_ == ChunkInputStatus::invalid_length) {

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Datagrams.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Datagrams.tpp
@@ -23,14 +23,14 @@ IndexStatus Datagram<PayloadBuffer>::write(Util::ByteVector<output_size> &output
     return IndexStatus::out_of_bounds;
   }
 
+  output_buffer[DatagramHeaderProps::seq_offset] = seq_;
+  length_ = static_cast<uint8_t>(payload_.size());
+  output_buffer[DatagramHeaderProps::length_offset] = length_;
   if (output_buffer.copy_from(
           payload_.buffer(), payload_.size(), DatagramHeaderProps::payload_offset) !=
       IndexStatus::ok) {
     return IndexStatus::out_of_bounds;
   };
-  output_buffer[DatagramHeaderProps::seq_offset] = seq_;
-  length_ = static_cast<uint8_t>(payload_.size());
-  output_buffer[DatagramHeaderProps::length_offset] = length_;
   return IndexStatus::ok;
 }
 
@@ -44,13 +44,13 @@ IndexStatus Datagram<PayloadBuffer>::parse(const Util::ByteVector<input_size> &i
   if (input_buffer.size() < DatagramHeaderProps::header_size) {
     return IndexStatus::out_of_bounds;
   }
+  seq_ = input_buffer[DatagramHeaderProps::seq_offset];
+  length_ = input_buffer[DatagramHeaderProps::length_offset];
   if (payload_.copy_from(
           input_buffer.buffer() + DatagramHeaderProps::payload_offset,
           input_buffer.size() - DatagramHeaderProps::payload_offset) != IndexStatus::ok) {
     return IndexStatus::out_of_bounds;
   };
-  seq_ = input_buffer[DatagramHeaderProps::seq_offset];
-  length_ = input_buffer[DatagramHeaderProps::length_offset];
   return IndexStatus::ok;
 }
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Datagrams.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Datagrams.tpp
@@ -23,10 +23,14 @@ IndexStatus Datagram<PayloadBuffer>::write(Util::ByteVector<output_size> &output
     return IndexStatus::out_of_bounds;
   }
 
+  if (output_buffer.copy_from(
+          payload_.buffer(), payload_.size(), DatagramHeaderProps::payload_offset) !=
+      IndexStatus::ok) {
+    return IndexStatus::out_of_bounds;
+  };
   output_buffer[DatagramHeaderProps::seq_offset] = seq_;
   length_ = static_cast<uint8_t>(payload_.size());
   output_buffer[DatagramHeaderProps::length_offset] = length_;
-  output_buffer.copy_from(payload_.buffer(), payload_.size(), DatagramHeaderProps::payload_offset);
   return IndexStatus::ok;
 }
 
@@ -40,11 +44,13 @@ IndexStatus Datagram<PayloadBuffer>::parse(const Util::ByteVector<input_size> &i
   if (input_buffer.size() < DatagramHeaderProps::header_size) {
     return IndexStatus::out_of_bounds;
   }
+  if (payload_.copy_from(
+          input_buffer.buffer() + DatagramHeaderProps::payload_offset,
+          input_buffer.size() - DatagramHeaderProps::payload_offset) != IndexStatus::ok) {
+    return IndexStatus::out_of_bounds;
+  };
   seq_ = input_buffer[DatagramHeaderProps::seq_offset];
   length_ = input_buffer[DatagramHeaderProps::length_offset];
-  payload_.copy_from(
-      input_buffer.buffer() + DatagramHeaderProps::payload_offset,
-      input_buffer.size() - DatagramHeaderProps::payload_offset);
   return IndexStatus::ok;
 }
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Vector.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Vector.h
@@ -42,9 +42,12 @@ class Vector {
   constexpr Element &operator[](size_t position);
 
   template <size_t source_size>
-  void copy_from(const std::array<Element, source_size> &source_bytes, size_t dest_start_index = 0);
-  void copy_from(const Vector<Element, array_size> &source_bytes, size_t dest_start_index = 0);
-  void copy_from(const Element *source_bytes, size_t source_size, size_t dest_start_index = 0);
+  IndexStatus copy_from(
+      const std::array<Element, source_size> &source_bytes, size_t dest_start_index = 0);
+  IndexStatus copy_from(
+      const Vector<Element, array_size> &source_bytes, size_t dest_start_index = 0);
+  IndexStatus copy_from(
+      const Element *source_bytes, size_t source_size, size_t dest_start_index = 0);
 
   [[nodiscard]] constexpr const Element *buffer() const { return buffer_.data(); }
   constexpr Element *buffer() { return buffer_.data(); }

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Vector.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Vector.tpp
@@ -83,18 +83,14 @@ IndexStatus Vector<Element, array_size>::copy_from(
 template <typename Element, size_t array_size>
 IndexStatus Vector<Element, array_size>::copy_from(
     const Element *source_bytes, size_t source_size, size_t dest_start_index) {
-  size_ = array_size;
-  if (source_size + dest_start_index > size_) {
+  if (source_size + dest_start_index > array_size) {
     return IndexStatus::out_of_bounds;
   }
-  if (source_size + dest_start_index <= size_) {
-    size_ = source_size + dest_start_index;
-
-    memcpy(
-        buffer_.data() + dest_start_index,
-        source_bytes,
-        sizeof(Element) * (size_ - dest_start_index));
-  }
+  size_ = source_size + dest_start_index;
+  memcpy(
+      buffer_.data() + dest_start_index,
+      source_bytes,
+      sizeof(Element) * (size_ - dest_start_index));
   return IndexStatus::ok;
 }
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Vector.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Vector.tpp
@@ -69,28 +69,33 @@ constexpr Element &Vector<Element, array_size>::operator[](size_t position) {
 
 template <typename Element, size_t array_size>
 template <size_t source_size>
-void Vector<Element, array_size>::copy_from(
+IndexStatus Vector<Element, array_size>::copy_from(
     const std::array<Element, source_size> &source_bytes, size_t dest_start_index) {
-  copy_from(source_bytes.data(), source_bytes.size(), dest_start_index);
+  return copy_from(source_bytes.data(), source_bytes.size(), dest_start_index);
 }
 
 template <typename Element, size_t array_size>
-void Vector<Element, array_size>::copy_from(
+IndexStatus Vector<Element, array_size>::copy_from(
     const Vector<Element, array_size> &source_bytes, size_t dest_start_index) {
-  copy_from(source_bytes.buffer(), source_bytes.size(), dest_start_index);
+  return copy_from(source_bytes.buffer(), source_bytes.size(), dest_start_index);
 }
 
 template <typename Element, size_t array_size>
-void Vector<Element, array_size>::copy_from(
+IndexStatus Vector<Element, array_size>::copy_from(
     const Element *source_bytes, size_t source_size, size_t dest_start_index) {
   size_ = array_size;
-  if (source_size + dest_start_index < size_) {
-    size_ = source_size + dest_start_index;
+  if (source_size + dest_start_index > size_) {
+    return IndexStatus::out_of_bounds;
   }
-  memcpy(
-      buffer_.data() + dest_start_index,
-      source_bytes,
-      sizeof(Element) * (size_ - dest_start_index));
+  if (source_size + dest_start_index <= size_) {
+    size_ = source_size + dest_start_index;
+
+    memcpy(
+        buffer_.data() + dest_start_index,
+        source_bytes,
+        sizeof(Element) * (size_ - dest_start_index));
+  }
+  return IndexStatus::ok;
 }
 
 }  // namespace Pufferfish::Util


### PR DESCRIPTION
This PR resolves #282 by adding return codes to Vector::copy_from, in it's current state it only copies source data to internal buffer if the source data size is less than or equal to the internal buffer size, if the size of the source data is greater than internal buffer size it returns an `IndexStatus::out_of_bounds` error code.

Also Wherever copy_from is used:
`CRCElement::parse`, `CRCElement::write`, `Datagram::parse`, `Datagram::write`, 
- The copy_from method is executed before other members are updated. 
for ex: In CRCElement::parse , we would not want to update the CRC if the payload in the input_buffer is too large for the internal payload to hold