### PR TITLE
firmware: remove handling of data inputs from StateSynchronizer

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
@@ -47,7 +47,7 @@ class States {
  public:
   States() = default;
   enum class InputStatus { ok = 0, invalid_type };
-  enum class OutputStatus { ok = 0, waiting, invalid_type };
+  enum class OutputStatus { ok = 0, invalid_type };
 
   [[nodiscard]] const ParametersRequest &parameters_request() const;
   Parameters &parameters();

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
@@ -46,6 +46,8 @@ struct StateSegments {
 class States {
  public:
   States() = default;
+  enum class InputStatus { ok = 0, invalid_type };
+  enum class OutputStatus { ok = 0, waiting, invalid_type };
 
   [[nodiscard]] const ParametersRequest &parameters_request() const;
   Parameters &parameters();
@@ -54,8 +56,8 @@ class States {
 
   static constexpr bool should_input(MessageTypes type);
 
-  void input(const StateSegment &input);
-  void output(MessageTypes type, StateSegment &output) const;
+  InputStatus input(const StateSegment &input);
+  OutputStatus output(MessageTypes type, StateSegment &output) const;
 
  private:
   StateSegments state_segments_;

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
@@ -54,8 +54,6 @@ class States {
   SensorMeasurements &sensor_measurements();
   CycleMeasurements &cycle_measurements();
 
-  static constexpr bool should_input(MessageTypes type);
-
   InputStatus input(const StateSegment &input);
   OutputStatus output(MessageTypes type, StateSegment &output) const;
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.tpp
@@ -20,8 +20,4 @@ union StateSegmentUnion {
   AlarmLimitsRequest alarm_limits_request;
 };
 
-constexpr bool States::should_input(MessageTypes type) {
-  return type == MessageTypes::parameters_request || type == MessageTypes::alarm_limits_request;
-}
-
 }  // namespace Pufferfish::Application

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
@@ -128,7 +128,10 @@ class Backend {
   enum class Status { ok = 0, waiting, invalid };
 
   Backend(HAL::CRC32 &crc32c, Application::States &states)
-      : receiver_(crc32c), sender_(crc32c), synchronizer_(states, state_sync_schedule) {}
+      : receiver_(crc32c),
+        sender_(crc32c),
+        states_(states),
+        synchronizer_(states, state_sync_schedule) {}
 
   Status input(uint8_t new_byte);
   void update_clock(uint32_t current_time);
@@ -143,6 +146,7 @@ class Backend {
 
   BackendReceiver receiver_;
   BackendSender sender_;
+  Application::States &states_;
   BackendStateSynchronizer synchronizer_;
 };
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
@@ -133,6 +133,7 @@ class Backend {
         states_(states),
         synchronizer_(states, state_sync_schedule) {}
 
+  static constexpr bool accept_message(Application::MessageTypes type);
   Status input(uint8_t new_byte);
   void update_clock(uint32_t current_time);
   Status output(FrameProps::ChunkBuffer &output_buffer);

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
@@ -161,10 +161,10 @@ Backend::Status Backend::input(uint8_t new_byte) {
   }
 
   // Input into state synchronization
-  switch (synchronizer_.input(message.payload)) {
-    case BackendStateSynchronizer::InputStatus::ok:
+  switch (states_.input(message.payload)) {
+    case Application::States::InputStatus::ok:
       break;
-    case BackendStateSynchronizer::InputStatus::invalid_type:
+    case Application::States::InputStatus::invalid_type:
       // TODO(lietk12): handle error case
       return Status::invalid;
   }
@@ -180,8 +180,10 @@ Backend::Status Backend::output(FrameProps::ChunkBuffer &output_buffer) {
   // Output from state synchronization
   BackendMessage message;
   switch (synchronizer_.output(message.payload)) {
-    case BackendStateSynchronizer::OutputStatus::available:
+    case BackendStateSynchronizer::OutputStatus::ok:
       break;
+    case BackendStateSynchronizer::OutputStatus::invalid_type:
+      return Status::invalid;
     case BackendStateSynchronizer::OutputStatus::waiting:
       return Status::waiting;
   }

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
@@ -160,6 +160,10 @@ Backend::Status Backend::input(uint8_t new_byte) {
       return Status::waiting;
   }
 
+  if (!states_.should_input(message.payload.tag)) {
+    return Status::invalid;
+  }
+
   // Input into state synchronization
   switch (states_.input(message.payload)) {
     case Application::States::InputStatus::ok:

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
@@ -160,7 +160,7 @@ Backend::Status Backend::input(uint8_t new_byte) {
       return Status::waiting;
   }
 
-  if (!states_.should_input(message.payload.tag)) {
+  if (!accept_message(message.payload.tag)) {
     return Status::invalid;
   }
 
@@ -178,6 +178,11 @@ Backend::Status Backend::input(uint8_t new_byte) {
 
 void Backend::update_clock(uint32_t current_time) {
   synchronizer_.input(current_time);
+}
+
+constexpr bool Backend::accept_message(Application::MessageTypes type) {
+  return type == Application::MessageTypes::parameters_request ||
+         type == Application::MessageTypes::alarm_limits_request;
 }
 
 Backend::Status Backend::output(FrameProps::ChunkBuffer &output_buffer) {

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/States.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/States.h
@@ -28,14 +28,13 @@ template <typename States, typename StateSegment, typename MessageTypes, size_t 
 class StateSynchronizer {
  public:
   enum class InputStatus { ok = 0, invalid_type };
-  enum class OutputStatus { available = 0, waiting };
+  enum class OutputStatus { ok = 0, waiting, invalid_type };
 
   StateSynchronizer(
       States &all_states, const StateOutputSchedule<MessageTypes, schedule_size> &schedule)
       : all_states_(all_states), output_schedule_(schedule) {}
 
   InputStatus input(uint32_t time);
-  InputStatus input(const StateSegment &input);
   OutputStatus output(StateSegment &output);
 
  private:

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/States.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/States.h
@@ -27,14 +27,13 @@ using StateOutputSchedule = std::array<const StateOutputScheduleEntry<MessageTyp
 template <typename States, typename StateSegment, typename MessageTypes, size_t schedule_size>
 class StateSynchronizer {
  public:
-  enum class InputStatus { ok = 0, invalid_type };
   enum class OutputStatus { ok = 0, waiting, invalid_type };
 
   StateSynchronizer(
       States &all_states, const StateOutputSchedule<MessageTypes, schedule_size> &schedule)
       : all_states_(all_states), output_schedule_(schedule) {}
 
-  InputStatus input(uint32_t time);
+  void input(uint32_t time);
   OutputStatus output(StateSegment &output);
 
  private:

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/States.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/States.tpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "Pufferfish/Util/Timeouts.h"
 #include "States.h"
 
 namespace Pufferfish::Protocols {
@@ -21,34 +22,27 @@ StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::input(uint
 }
 
 template <typename States, typename StateSegment, typename MessageTypes, size_t schedule_size>
-typename StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::InputStatus
-StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::input(
-    const StateSegment &input) {
-  if (all_states_.should_input(input.tag)) {
-    all_states_.input(input);
-    return InputStatus::ok;
-  }
-
-  return InputStatus::invalid_type;
-}
-
-template <typename States, typename StateSegment, typename MessageTypes, size_t schedule_size>
 typename StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::OutputStatus
 StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::output(StateSegment &output) {
-  if (!should_output()) {
+  if (should_output()) {
     return OutputStatus::waiting;
   }
 
-  all_states_.output(output_schedule_[current_schedule_entry_].type, output);
+  if (all_states_.output(output_schedule_[current_schedule_entry_].type, output) !=
+      States::OutputStatus::ok) {
+    return OutputStatus::invalid_type;
+  }
   current_schedule_entry_ = (current_schedule_entry_ + 1) % output_schedule_.size();
   current_schedule_entry_start_time_ = current_time_;
-  return OutputStatus::available;
+  return OutputStatus::ok;
 }
 
 template <typename States, typename StateSegment, typename MessageTypes, size_t schedule_size>
 bool StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::should_output() const {
-  return (current_time_ - current_schedule_entry_start_time_) >=
-         output_schedule_[current_schedule_entry_].delay;
+  return Util::within_timeout(
+      current_schedule_entry_start_time_,
+      output_schedule_[current_schedule_entry_].delay,
+      current_time_);
 }
 
 }  // namespace Pufferfish::Protocols

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/States.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/States.tpp
@@ -15,16 +15,14 @@ namespace Pufferfish::Protocols {
 // StateSynchronizer
 
 template <typename States, typename StateSegment, typename MessageTypes, size_t schedule_size>
-typename StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::InputStatus
-StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::input(uint32_t time) {
+void StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::input(uint32_t time) {
   current_time_ = time;
-  return InputStatus::ok;
 }
 
 template <typename States, typename StateSegment, typename MessageTypes, size_t schedule_size>
 typename StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::OutputStatus
 StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::output(StateSegment &output) {
-  if (should_output()) {
+  if (!should_output()) {
     return OutputStatus::waiting;
   }
 
@@ -39,7 +37,7 @@ StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::output(Sta
 
 template <typename States, typename StateSegment, typename MessageTypes, size_t schedule_size>
 bool StateSynchronizer<States, StateSegment, MessageTypes, schedule_size>::should_output() const {
-  return Util::within_timeout(
+  return !Util::within_timeout(
       current_schedule_entry_start_time_,
       output_schedule_[current_schedule_entry_].delay,
       current_time_);

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Application/States.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Application/States.cpp
@@ -28,8 +28,7 @@
 // clang-format off
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define STATESEGMENT_GET_TAGGED(field, segment) \
-  if ((segment).tag == MessageTypes::field) {\
-    state_segments_.field = (segment).value.field; return; } // NOLINT(cppcoreguidelines-pro-type-union-access)
+  state_segments_.field = (segment).value.field; // NOLINT(cppcoreguidelines-pro-type-union-access)
 // clang-format on
 
 namespace Pufferfish::Util {
@@ -66,37 +65,53 @@ CycleMeasurements &States::cycle_measurements() {
   return state_segments_.cycle_measurements;
 }
 
-void States::input(const StateSegment &input) {
-  STATESEGMENT_GET_TAGGED(sensor_measurements, input);
-  STATESEGMENT_GET_TAGGED(cycle_measurements, input);
-  STATESEGMENT_GET_TAGGED(parameters, input);
-  STATESEGMENT_GET_TAGGED(parameters_request, input);
-  STATESEGMENT_GET_TAGGED(alarm_limits, input);
-  STATESEGMENT_GET_TAGGED(alarm_limits_request, input);
+States::InputStatus States::input(const StateSegment &input) {
+  switch (input.tag) {
+    case MessageTypes::sensor_measurements:
+      STATESEGMENT_GET_TAGGED(sensor_measurements, input);
+      return InputStatus::ok;
+    case MessageTypes::cycle_measurements:
+      STATESEGMENT_GET_TAGGED(cycle_measurements, input);
+      return InputStatus::ok;
+    case MessageTypes::parameters:
+      STATESEGMENT_GET_TAGGED(parameters, input);
+      return InputStatus::ok;
+    case MessageTypes::parameters_request:
+      STATESEGMENT_GET_TAGGED(parameters_request, input);
+      return InputStatus::ok;
+    case MessageTypes::alarm_limits:
+      STATESEGMENT_GET_TAGGED(alarm_limits, input);
+      return InputStatus::ok;
+    case MessageTypes::alarm_limits_request:
+      STATESEGMENT_GET_TAGGED(alarm_limits_request, input);
+      return InputStatus::ok;
+    default:
+      return InputStatus::invalid_type;
+  }
 }
 
-void States::output(MessageTypes type, StateSegment &output) const {
+States::OutputStatus States::output(MessageTypes type, StateSegment &output) const {
   switch (type) {
     case MessageTypes::sensor_measurements:
       output.set(state_segments_.sensor_measurements);
-      return;
+      return OutputStatus::ok;
     case MessageTypes::cycle_measurements:
       output.set(state_segments_.cycle_measurements);
-      return;
+      return OutputStatus::ok;
     case MessageTypes::parameters:
       output.set(state_segments_.parameters);
-      return;
+      return OutputStatus::ok;
     case MessageTypes::parameters_request:
       output.set(state_segments_.parameters_request);
-      return;
+      return OutputStatus::ok;
     case MessageTypes::alarm_limits:
       output.set(state_segments_.alarm_limits);
-      return;
+      return OutputStatus::ok;
     case MessageTypes::alarm_limits_request:
       output.set(state_segments_.alarm_limits_request);
-      return;
+      return OutputStatus::ok;
     default:
-      return;
+      return OutputStatus::invalid_type;
   }
 }
 


### PR DESCRIPTION
This PR resolves #279 
Changes:
- Application/State input & output methods return error codes
- states is responsible for handling inupt in backend.tpp
- remove status code for StateSynchronizer::input 
- Add an invalid_type error code for StateSynchronizer::output
- Use Util::within_timeout in StateSynchronizer::should_output
- Update states::input method
- Move Application/States should_input method to backend.tpp

For records-keeping:

1. This project is licensed under Apache License v2.0 for any software, and Solderpad Hardware License v2.1 for any hardware - do you agree that your contributions to this project will be under these licenses, too? Yes
2. Were any of these contributions also part of work you did for an employer or a client? No
3. Does this work include, or is it based on, any third-party work which you did not create? No
