### PR TITLE
firmware: Overwrite chunks input on receiving a delimiter

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
@@ -57,7 +57,7 @@ using BackendMessage = Protocols::Message<
 
 class BackendReceiver {
  public:
-  enum class InputStatus { ok = 0, output_ready, invalid_frame_length };
+  enum class InputStatus { ok = 0, output_ready, invalid_frame_length, input_overwritten };
   enum class OutputStatus {
     available = 0,
     waiting,

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
@@ -19,6 +19,8 @@ BackendReceiver::InputStatus BackendReceiver::input(uint8_t new_byte) {
       return InputStatus::output_ready;
     case FrameProps::InputStatus::invalid_length:
       return InputStatus::invalid_frame_length;
+    case FrameProps::InputStatus::input_overwritten:
+      return InputStatus::input_overwritten;
     case FrameProps::InputStatus::ok:
       break;
   }
@@ -134,6 +136,7 @@ Backend::Status Backend::input(uint8_t new_byte) {
     case BackendReceiver::InputStatus::output_ready:
       break;
     case BackendReceiver::InputStatus::invalid_frame_length:
+    case BackendReceiver::InputStatus::input_overwritten:
       // TODO(lietk12): handle error case first
     case BackendReceiver::InputStatus::ok:
       return Status::waiting;

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Frames.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Frames.h
@@ -23,7 +23,7 @@ struct FrameProps {
   using EncodedBuffer = Util::ByteVector<encoded_max_size>;
   using PayloadBuffer = Util::ByteVector<payload_max_size>;
 
-  using InputStatus = Protocols::ChunkInputStatus;
+  enum class InputStatus { ok = 0, output_ready, invalid_length, input_overwritten };
   using OutputStatus = Protocols::ChunkOutputStatus;
 };
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/FDO2/Device.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/FDO2/Device.h
@@ -20,7 +20,7 @@ static const char frame_end = 0x0d;
 
 class ResponseReceiver {
  public:
-  enum class InputStatus { ok = 0, output_ready, invalid_frame_length };
+  enum class InputStatus { ok = 0, output_ready, invalid_frame_length, input_overwritten };
   enum class OutputStatus {
     available = 0,
     waiting,

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Chunks.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Chunks.h
@@ -25,7 +25,7 @@ class ChunkSplitter {
       : delimiter(delimiter), include_delimiter(include_delimiter) {}
 
   // Call this until it returns available, then call output
-  ChunkInputStatus input(uint8_t new_byte);
+  ChunkInputStatus input(uint8_t new_byte, bool &input_overwritten);
   ChunkOutputStatus output(Util::Vector<Byte, buffer_size> &output_buffer);
 
  private:

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Chunks.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Chunks.tpp
@@ -14,7 +14,14 @@ namespace Pufferfish::Protocols {
 // ChunkSplitter
 
 template <size_t buffer_size, typename Byte>
-ChunkInputStatus ChunkSplitter<buffer_size, Byte>::input(uint8_t new_byte) {
+ChunkInputStatus ChunkSplitter<buffer_size, Byte>::input(
+    uint8_t new_byte, bool &input_overwritten) {
+  if (input_status_ == ChunkInputStatus::output_ready) {
+    buffer_.clear();
+    input_overwritten = true;
+    input_status_ = ChunkInputStatus::ok;
+  }
+
   if (include_delimiter || new_byte != delimiter) {
     if (buffer_.push_back(new_byte) != IndexStatus::ok) {
       input_status_ = ChunkInputStatus::invalid_length;

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/Backend/Frames.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/Backend/Frames.cpp
@@ -12,7 +12,22 @@ namespace Pufferfish::Driver::Serial::Backend {
 // FrameReceiver
 
 FrameProps::InputStatus FrameReceiver::input(uint8_t new_byte) {
-  return chunk_splitter_.input(new_byte);
+  bool input_overwritten = false;
+  auto status = chunk_splitter_.input(new_byte, input_overwritten);
+  if (input_overwritten) {
+    return FrameProps::InputStatus::input_overwritten;
+  }
+
+  switch (status) {
+    case Protocols::ChunkInputStatus::output_ready:
+      return FrameProps::InputStatus::output_ready;
+    case Protocols::ChunkInputStatus::invalid_length:
+      return FrameProps::InputStatus::invalid_length;
+    case Protocols::ChunkInputStatus::ok:
+      break;
+  }
+
+  return FrameProps::InputStatus::ok;
 }
 
 FrameProps::OutputStatus FrameReceiver::output(FrameProps::PayloadBuffer &output_buffer) {


### PR DESCRIPTION
Before the changes in this PR, If we passed a multiple delimited bytes input to chunks, and called output, it would have copied all the bytes to the output_buffer and returned a `Status::ok` status code.
After the changes in this PR, if we receive a delimiter input, and input is called again immediately after that, then we will firstly clear the buffer and return an input_status_ as `ChunkInputStatus::ok`, and set `input_overwritten` output parameter to true. Therefore the input before receiving a delimiter is discarded and new input is considered for output.

Changes:
- Add input_overwritten bool output parameter to chunks::input
- Add a different enum for Frame::InputStatus
- update input methods for chunksplitter in Frames and FDO2/Device