### PR TITLE
Improve type code checking in firmware's Messages implementation

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "Pufferfish/Util/Enums.h"
 #include "Pufferfish/Util/TaggedUnion.h"
 #include "mcu_pb.h"
 
@@ -23,6 +24,18 @@ enum class MessageTypes : uint8_t {
   alarm_limits = 6,
   alarm_limits_request = 7
 };
+
+// MessageTypeValues should include all defined values of MessageTypes
+using MessageTypeValues = Util::EnumValues<
+    MessageTypes,
+    MessageTypes::unknown,
+    MessageTypes::sensor_measurements,
+    MessageTypes::cycle_measurements,
+    MessageTypes::parameters,
+    MessageTypes::parameters_request,
+    MessageTypes::alarm_limits,
+    MessageTypes::alarm_limits_request
+>;
 
 // Since nanopb is running dynamically, we cannot have extensive compile-time type-checking.
 // It's not clear how we might use variants to replace this union, since the nanopb functions

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
@@ -34,8 +34,7 @@ using MessageTypeValues = Util::EnumValues<
     MessageTypes::parameters,
     MessageTypes::parameters_request,
     MessageTypes::alarm_limits,
-    MessageTypes::alarm_limits_request
->;
+    MessageTypes::alarm_limits_request>;
 
 // Since nanopb is running dynamically, we cannot have extensive compile-time type-checking.
 // It's not clear how we might use variants to replace this union, since the nanopb functions

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
@@ -52,6 +52,7 @@ static const auto state_sync_schedule = Util::make_array<const StateOutputSchedu
 // Backend
 using BackendMessage = Protocols::Message<
     Application::StateSegment,
+    Application::MessageTypeValues,
     Protocols::DatagramProps<
         Driver::Serial::Backend::FrameProps::payload_max_size>::payload_max_size>;
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Messages.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Messages.h
@@ -19,7 +19,7 @@ enum class MessageStatus { ok = 0, invalid_length, invalid_type, invalid_encodin
 
 // Messages
 
-template <typename TaggedUnion, size_t max_size>
+template <typename TaggedUnion, typename MessageTypes, size_t max_size>
 class Message {
  public:
   static const size_t type_offset = 0;

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Messages.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Messages.tpp
@@ -15,9 +15,9 @@ namespace Pufferfish::Protocols {
 
 // Message
 
-template <typename TaggedUnion, size_t max_size>
+template <typename TaggedUnion, typename MessageTypes, size_t max_size>
 template <size_t output_size, size_t num_descriptors>
-MessageStatus Message<TaggedUnion, max_size>::write(
+MessageStatus Message<TaggedUnion, MessageTypes, max_size>::write(
     Util::ByteVector<output_size> &output_buffer,
     const Util::ProtobufDescriptors<num_descriptors> &pb_protobuf_descriptors) const {
   auto type = static_cast<uint8_t>(payload.tag);
@@ -49,9 +49,9 @@ MessageStatus Message<TaggedUnion, max_size>::write(
   return MessageStatus::ok;
 }
 
-template <typename TaggedUnion, size_t max_size>
+template <typename TaggedUnion, typename MessageTypes, size_t max_size>
 template <size_t input_size, size_t num_descriptors>
-MessageStatus Message<TaggedUnion, max_size>::parse(
+MessageStatus Message<TaggedUnion, MessageTypes, max_size>::parse(
     const Util::ByteVector<input_size> &input_buffer,
     const Util::ProtobufDescriptors<num_descriptors> &pb_protobuf_descriptors) {
   if (input_buffer.size() < Message::header_size) {
@@ -63,7 +63,9 @@ MessageStatus Message<TaggedUnion, max_size>::parse(
     return MessageStatus::invalid_type;
   }
 
-  // TODO(lietk12): add proper checking
+  if (!MessageTypes::includes(type)) {
+    return MessageStatus::invalid_type;
+  }
   payload.tag = static_cast<typename TaggedUnion::Tag>(type);
   const pb_msgdesc_t *fields = pb_protobuf_descriptors[type];
   if (fields == Util::get_protobuf_descriptor<Util::UnrecognizedMessage>()) {

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Messages.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Protocols/Messages.tpp
@@ -59,14 +59,15 @@ MessageStatus Message<TaggedUnion, MessageTypes, max_size>::parse(
   }
 
   type = input_buffer[Message::type_offset];
-  if (type > pb_protobuf_descriptors.size()) {
-    return MessageStatus::invalid_type;
-  }
-
   if (!MessageTypes::includes(type)) {
     return MessageStatus::invalid_type;
   }
+
   payload.tag = static_cast<typename TaggedUnion::Tag>(type);
+  if (type >= pb_protobuf_descriptors.size()) {
+    return MessageStatus::invalid_type;
+  }
+
   const pb_msgdesc_t *fields = pb_protobuf_descriptors[type];
   if (fields == Util::get_protobuf_descriptor<Util::UnrecognizedMessage>()) {
     return MessageStatus::invalid_type;

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Enums.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Enums.h
@@ -1,0 +1,38 @@
+/*
+ * Enums.h
+ *
+ *  Created on: May 16, 2020
+ *      Author: Ethan Li
+ *
+ *  Utilities for working with enums.
+ */
+
+#pragma once
+
+#include <array>
+
+namespace Pufferfish::Util {
+
+// EnumValues is inspired by https://stackoverflow.com/a/33091821 by user janm,
+// but the implementation of the variadic template recursion is different
+
+template <typename Enum, Enum... Values>
+class EnumValues;
+
+template <typename Enum>
+class EnumValues<Enum> {
+ public:
+  template <typename Underlying>
+  static bool constexpr includes(Underlying /*value*/) { return false; }
+};
+
+template <typename Enum, Enum Value, Enum... Values>
+class EnumValues<Enum, Value, Values...> {
+ public:
+  template <typename Underlying>
+  static bool constexpr includes(Underlying value) {
+    return value == static_cast<Underlying>(Value) || EnumValues<Enum, Values...>::includes(value);
+  }
+};
+
+}  // namespace Pufferfish::Util

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Enums.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Enums.h
@@ -23,7 +23,9 @@ template <typename Enum>
 class EnumValues<Enum> {
  public:
   template <typename Underlying>
-  static bool constexpr includes(Underlying /*value*/) { return false; }
+  static bool constexpr includes(Underlying /*value*/) {
+    return false;
+  }
 };
 
 template <typename Enum, Enum Value, Enum... Values>

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Enums.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Enums.h
@@ -23,17 +23,18 @@ template <typename Enum>
 class EnumValues<Enum> {
  public:
   template <typename Underlying>
-  static bool constexpr includes(Underlying /*value*/) {
+  static bool constexpr includes(Underlying /*test_value*/) {
     return false;
   }
 };
 
-template <typename Enum, Enum value, Enum... values>
-class EnumValues<Enum, value, values...> {
+template <typename Enum, Enum first_value, Enum... remaining_values>
+class EnumValues<Enum, first_value, remaining_values...> {
  public:
   template <typename Underlying>
-  static bool constexpr includes(Underlying value) {
-    return value == static_cast<Underlying>(value) || EnumValues<Enum, values...>::includes(value);
+  static bool constexpr includes(Underlying test_value) {
+    return test_value == static_cast<Underlying>(first_value) ||
+           EnumValues<Enum, remaining_values...>::includes(test_value);
   }
 };
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Enums.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/Enums.h
@@ -16,7 +16,7 @@ namespace Pufferfish::Util {
 // EnumValues is inspired by https://stackoverflow.com/a/33091821 by user janm,
 // but the implementation of the variadic template recursion is different
 
-template <typename Enum, Enum... Values>
+template <typename Enum, Enum... values>
 class EnumValues;
 
 template <typename Enum>
@@ -28,12 +28,12 @@ class EnumValues<Enum> {
   }
 };
 
-template <typename Enum, Enum Value, Enum... Values>
-class EnumValues<Enum, Value, Values...> {
+template <typename Enum, Enum value, Enum... values>
+class EnumValues<Enum, value, values...> {
  public:
   template <typename Underlying>
   static bool constexpr includes(Underlying value) {
-    return value == static_cast<Underlying>(Value) || EnumValues<Enum, Values...>::includes(value);
+    return value == static_cast<Underlying>(value) || EnumValues<Enum, values...>::includes(value);
   }
 };
 

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -309,7 +309,7 @@ PF::Driver::Serial::Nonin::Sensor nonin_oem(nonin_oem_dev);
 // Initializables
 
 auto initializables = PF::Util::make_array<std::reference_wrapper<PF::Driver::Initializable>>(
-    sfm3019_air, sfm3019_o2, /*fdo2, */nonin_oem);
+    sfm3019_air, sfm3019_o2, /*fdo2, */ nonin_oem);
 std::array<PF::InitializableState, initializables.size()> initialization_states;
 
 /*

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -309,7 +309,7 @@ PF::Driver::Serial::Nonin::Sensor nonin_oem(nonin_oem_dev);
 // Initializables
 
 auto initializables = PF::Util::make_array<std::reference_wrapper<PF::Driver::Initializable>>(
-    sfm3019_air, sfm3019_o2, fdo2, nonin_oem);
+    sfm3019_air, sfm3019_o2, /*fdo2, */nonin_oem);
 std::array<PF::InitializableState, initializables.size()> initialization_states;
 
 /*

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/Enums.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/Enums.cpp
@@ -9,26 +9,21 @@
  * Unit tests to confirm behavior of enums utilities
  *
  */
+#include "Pufferfish/Util/Enums.h"
+
 #include <algorithm>
 #include <limits>
-
-#include "Pufferfish/Util/Enums.h"
 
 #include "catch2/catch.hpp"
 
 namespace PF = Pufferfish;
 
-enum class TestEnum : uint8_t {
-  zero = 0,
-  two = 2,
-  three = 3,
-  seven = 7
-};
+enum class TestEnum : uint8_t { zero = 0, two = 2, three = 3, seven = 7 };
 
 SCENARIO("EnumValues includes defined values", "[enums]") {
   GIVEN("An EnumValues specialization covering all of a test enum") {
-    using EnumValues = PF::Util::EnumValues<
-        TestEnum, TestEnum::zero, TestEnum::two, TestEnum::three, TestEnum::seven>;
+    using EnumValues = PF::Util::
+        EnumValues<TestEnum, TestEnum::zero, TestEnum::two, TestEnum::three, TestEnum::seven>;
 
     WHEN("EnumValues is queried with an underlying value of the test enum") {
       std::array<uint8_t, 4> values{{0, 2, 3, 7}};
@@ -72,8 +67,8 @@ SCENARIO("EnumValues excludes undefined values", "[enums]") {
   }
 
   GIVEN("An EnumValues specialization covering all of a test enum") {
-    using EnumValues = PF::Util::EnumValues<
-        TestEnum, TestEnum::zero, TestEnum::two, TestEnum::three, TestEnum::seven>;
+    using EnumValues = PF::Util::
+        EnumValues<TestEnum, TestEnum::zero, TestEnum::two, TestEnum::three, TestEnum::seven>;
 
     WHEN("EnumValues is queried with any value other than an underlying value of the test enum") {
       std::array<uint8_t, 4> values{{0, 2, 3, 7}};
@@ -91,7 +86,9 @@ SCENARIO("EnumValues excludes undefined values", "[enums]") {
   GIVEN("An EnumValues specialization covering part of a test enum") {
     using EnumValues = PF::Util::EnumValues<TestEnum, TestEnum::zero, TestEnum::two>;
 
-    WHEN("EnumValues is queried with an underlying value of the test enum not covered by EnumValues") {
+    WHEN(
+        "EnumValues is queried with an underlying value of the test enum not covered by "
+        "EnumValues") {
       std::array<uint8_t, 2> values{{3, 7}};
 
       for (uint8_t value : values) {

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/Enums.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/Enums.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020, the Pez Globo team and the Pufferfish project contributors
+ *
+ * Enums.cpp
+ *
+ *  Created on: July 14, 2020
+ *      Author: Ethan Li
+ *
+ * Unit tests to confirm behavior of enums utilities
+ *
+ */
+#include <algorithm>
+#include <limits>
+
+#include "Pufferfish/Util/Enums.h"
+
+#include "catch2/catch.hpp"
+
+namespace PF = Pufferfish;
+
+enum class TestEnum : uint8_t {
+  zero = 0,
+  two = 2,
+  three = 3,
+  seven = 7
+};
+
+SCENARIO("EnumValues includes defined values", "[enums]") {
+  GIVEN("An EnumValues specialization covering all of a test enum") {
+    using EnumValues = PF::Util::EnumValues<
+        TestEnum, TestEnum::zero, TestEnum::two, TestEnum::three, TestEnum::seven>;
+
+    WHEN("EnumValues is queried with an underlying value of the test enum") {
+      std::array<uint8_t, 4> values{{0, 2, 3, 7}};
+
+      for (uint8_t value : values) {
+        THEN("EnumValues reports that it includes that value") {
+          REQUIRE(EnumValues::includes(value));
+        }
+      }
+    }
+  }
+
+  GIVEN("An EnumValues specialization covering part of a test enum") {
+    using EnumValues = PF::Util::EnumValues<TestEnum, TestEnum::zero, TestEnum::two>;
+
+    WHEN("EnumValues is queried with an underlying value of the test enum covered by EnumValues") {
+      std::array<uint8_t, 2> values{{0, 2}};
+
+      for (uint8_t value : values) {
+        THEN("EnumValues reports that it includes that value") {
+          REQUIRE(EnumValues::includes(value));
+        }
+      }
+    }
+  }
+}
+
+SCENARIO("EnumValues excludes undefined values", "[enums]") {
+  GIVEN("An empty EnumValues specialization") {
+    using EnumValues = PF::Util::EnumValues<TestEnum>;
+
+    WHEN("EnumValues is queried with an underlying value of the test enum") {
+      std::array<uint8_t, 4> values{{0, 2, 3, 7}};
+
+      for (uint8_t value : values) {
+        THEN("EnumValues reports that it does not include that value") {
+          REQUIRE(!EnumValues::includes(value));
+        }
+      }
+    }
+  }
+
+  GIVEN("An EnumValues specialization covering all of a test enum") {
+    using EnumValues = PF::Util::EnumValues<
+        TestEnum, TestEnum::zero, TestEnum::two, TestEnum::three, TestEnum::seven>;
+
+    WHEN("EnumValues is queried with any value other than an underlying value of the test enum") {
+      std::array<uint8_t, 4> values{{0, 2, 3, 7}};
+
+      for (size_t i = 0; i < std::numeric_limits<uint8_t>::max(); ++i) {
+        if (std::find(values.begin(), values.end(), i) == std::end(values)) {
+          THEN("EnumValues reports that it does not include that value") {
+            REQUIRE(!EnumValues::includes(i));
+          }
+        }
+      }
+    }
+  }
+
+  GIVEN("An EnumValues specialization covering part of a test enum") {
+    using EnumValues = PF::Util::EnumValues<TestEnum, TestEnum::zero, TestEnum::two>;
+
+    WHEN("EnumValues is queried with an underlying value of the test enum not covered by EnumValues") {
+      std::array<uint8_t, 2> values{{3, 7}};
+
+      for (uint8_t value : values) {
+        THEN("EnumValues reports that it does not include that value") {
+          REQUIRE(!EnumValues::includes(value));
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR resolves #278 by:

- Defining a new `Util::EnumValues` variadic class template which provides a recursive constexpr function to check whether the integer provided as input is the underlying value of one of the enum values provided as a template parameter to the `Util::EnumValues` template specialization. To use this, specialize `Util::EnumValues` with an enum type and the enum values from that enum type (e.g. `using MyEnumValues = Util::EnumValues<MyEnum, MyEnum::first_value, MyEnum::second_value, MyEnum::third_value>`), and then call the `Util::EnumValues::includes(integer)` method (e.g. `if (MyEnumValues::includes(5)) {...}`). This way, the comparison of the integer against the list of enum values is statically expanded by the compiler - no need to create and dynamically iterate through a data structure or worry about bounds safety.
- Defining some basic unit tests for `Util::EnumValues`.
- Making `Protocols::Message` take a `Util::EnumValues` template specialization as a template parameter, so that the `Message::parse` can call the `EnumValues` specialization's `includes` method.
- Defining a `Application::MessageTypeValues` template specialization of `Util::EnumValues` which must be given all enum values of `MessageTypes`, and updating the `Driver::Serial::Backend::BackendReceiver::BackendMessage` template specialization to use `Application::MessageTypeValues`.
- Fixing an off-by-one error in `Protocols::Message::parse` in checking whether a message type code is within the bounds of `pb_message_descriptors`