### PR TITLE
Fixed parse_network_order argument issue

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/I2C/SFM3019/Device.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/I2C/SFM3019/Device.cpp
@@ -58,11 +58,11 @@ I2CDeviceStatus Device::read_conversion_factors(ConversionFactors &conversion) {
   }
 
   conversion.scale_factor =
-      HAL::ntoh(Util::parse_network_order<uint16_t>(buffer.data(), buffer.size()));
+      HAL::ntoh(Util::parse_network_order<uint16_t>(buffer.data(), sizeof(uint16_t)));
   conversion.offset = HAL::ntoh(
-      Util::parse_network_order<uint16_t>(buffer.data() + sizeof(uint16_t), buffer.size()));
+      Util::parse_network_order<uint16_t>(buffer.data() + sizeof(uint16_t), sizeof(uint16_t)));
   conversion.flow_unit = HAL::ntoh(
-      Util::parse_network_order<uint16_t>(buffer.data() + 2 * sizeof(uint16_t), buffer.size()));
+      Util::parse_network_order<uint16_t>(buffer.data() + 2 * sizeof(uint16_t), sizeof(uint16_t)));
   return I2CDeviceStatus::ok;
 }
 


### PR DESCRIPTION
The second parameter to parse_network_order() in Device.cpp should be 2 bytes (sizeof(uint16_t)) and not the buffer.size(). The latter will cause a buffer overflow error.
