### PR TITLE
Refactor COBS interface and add unit test cases

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
@@ -63,7 +63,7 @@ class BackendReceiver {
     available = 0,
     waiting,
     invalid_frame_length,
-    invalid_frame_decoding,
+    invalid_frame_encoding,
     invalid_crcelement_parse,
     invalid_crcelement_crc,
     invalid_datagram_parse,

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
@@ -63,7 +63,7 @@ class BackendReceiver {
     available = 0,
     waiting,
     invalid_frame_length,
-    invalid_cobs_decoding,
+    invalid_frame_decoding,
     invalid_crcelement_parse,
     invalid_crcelement_crc,
     invalid_datagram_parse,
@@ -105,7 +105,7 @@ class BackendSender {
     invalid_message_encoding,
     invalid_datagram_length,
     invalid_crcelement_length,
-    invalid_cobs_encoding,
+    invalid_frame_encoding,
     invalid_frame_length,
     invalid_return_code
   };

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
@@ -63,6 +63,7 @@ class BackendReceiver {
     available = 0,
     waiting,
     invalid_frame_length,
+    invalid_cobs_decoding,
     invalid_crcelement_parse,
     invalid_crcelement_crc,
     invalid_datagram_parse,
@@ -104,6 +105,7 @@ class BackendSender {
     invalid_message_encoding,
     invalid_datagram_length,
     invalid_crcelement_length,
+    invalid_cobs_encoding,
     invalid_frame_length,
     invalid_return_code
   };

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
@@ -154,7 +154,7 @@ Backend::Status Backend::input(uint8_t new_byte) {
     case BackendReceiver::OutputStatus::available:
       break;
     case BackendReceiver::OutputStatus::invalid_frame_length:
-    case BackendReceiver::OutputStatus::invalid_frame_decoding:
+    case BackendReceiver::OutputStatus::invalid_frame_encoding:
     case BackendReceiver::OutputStatus::invalid_crcelement_parse:
     case BackendReceiver::OutputStatus::invalid_crcelement_crc:
     case BackendReceiver::OutputStatus::invalid_datagram_parse:

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
@@ -38,6 +38,8 @@ BackendReceiver::OutputStatus BackendReceiver::output(BackendMessage &output_mes
       return OutputStatus::waiting;
     case FrameProps::OutputStatus::invalid_length:
       return OutputStatus::invalid_frame_length;
+    case FrameProps::OutputStatus::invalid_cobs:
+      return OutputStatus::invalid_cobs_decoding;
     case FrameProps::OutputStatus::ok:
       break;
   }
@@ -120,6 +122,8 @@ BackendSender::Status BackendSender::transform(
   switch (frame_.transform(temp_buffer3, output_buffer)) {
     case FrameProps::OutputStatus::invalid_length:
       return Status::invalid_frame_length;
+    case FrameProps::OutputStatus::invalid_cobs:
+      return Status::invalid_cobs_encoding;
     case FrameProps::OutputStatus::ok:
       break;
     default:
@@ -150,6 +154,7 @@ Backend::Status Backend::input(uint8_t new_byte) {
     case BackendReceiver::OutputStatus::available:
       break;
     case BackendReceiver::OutputStatus::invalid_frame_length:
+    case BackendReceiver::OutputStatus::invalid_cobs_decoding:
     case BackendReceiver::OutputStatus::invalid_crcelement_parse:
     case BackendReceiver::OutputStatus::invalid_crcelement_crc:
     case BackendReceiver::OutputStatus::invalid_datagram_parse:
@@ -209,6 +214,7 @@ Backend::Status Backend::output(FrameProps::ChunkBuffer &output_buffer) {
     case BackendSender::Status::invalid_datagram_length:
     case BackendSender::Status::invalid_crcelement_length:
     case BackendSender::Status::invalid_frame_length:
+    case BackendSender::Status::invalid_cobs_encoding:
     case BackendSender::Status::invalid_return_code:
       // TODO(lietk12): handle error cases first
       return Status::invalid;

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
@@ -39,7 +39,7 @@ BackendReceiver::OutputStatus BackendReceiver::output(BackendMessage &output_mes
     case FrameProps::OutputStatus::invalid_length:
       return OutputStatus::invalid_frame_length;
     case FrameProps::OutputStatus::invalid_cobs:
-      return OutputStatus::invalid_frame_decoding;
+      return OutputStatus::invalid_frame_encoding;
     case FrameProps::OutputStatus::ok:
       break;
   }

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
@@ -39,7 +39,7 @@ BackendReceiver::OutputStatus BackendReceiver::output(BackendMessage &output_mes
     case FrameProps::OutputStatus::invalid_length:
       return OutputStatus::invalid_frame_length;
     case FrameProps::OutputStatus::invalid_cobs:
-      return OutputStatus::invalid_cobs_decoding;
+      return OutputStatus::invalid_frame_decoding;
     case FrameProps::OutputStatus::ok:
       break;
   }
@@ -123,7 +123,7 @@ BackendSender::Status BackendSender::transform(
     case FrameProps::OutputStatus::invalid_length:
       return Status::invalid_frame_length;
     case FrameProps::OutputStatus::invalid_cobs:
-      return Status::invalid_cobs_encoding;
+      return Status::invalid_frame_encoding;
     case FrameProps::OutputStatus::ok:
       break;
     default:
@@ -154,7 +154,7 @@ Backend::Status Backend::input(uint8_t new_byte) {
     case BackendReceiver::OutputStatus::available:
       break;
     case BackendReceiver::OutputStatus::invalid_frame_length:
-    case BackendReceiver::OutputStatus::invalid_cobs_decoding:
+    case BackendReceiver::OutputStatus::invalid_frame_decoding:
     case BackendReceiver::OutputStatus::invalid_crcelement_parse:
     case BackendReceiver::OutputStatus::invalid_crcelement_crc:
     case BackendReceiver::OutputStatus::invalid_datagram_parse:
@@ -214,7 +214,7 @@ Backend::Status Backend::output(FrameProps::ChunkBuffer &output_buffer) {
     case BackendSender::Status::invalid_datagram_length:
     case BackendSender::Status::invalid_crcelement_length:
     case BackendSender::Status::invalid_frame_length:
-    case BackendSender::Status::invalid_cobs_encoding:
+    case BackendSender::Status::invalid_frame_encoding:
     case BackendSender::Status::invalid_return_code:
       // TODO(lietk12): handle error cases first
       return Status::invalid;

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Frames.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Frames.h
@@ -24,7 +24,7 @@ struct FrameProps {
   using PayloadBuffer = Util::ByteVector<payload_max_size>;
 
   enum class InputStatus { ok = 0, output_ready, invalid_length, input_overwritten };
-  using OutputStatus = Protocols::ChunkOutputStatus;
+  enum class OutputStatus { ok = 0, waiting, invalid_length, invalid_cobs };
 };
 
 using FrameChunkSplitter = Protocols::ChunkSplitter<FrameProps::encoded_max_size>;
@@ -35,7 +35,7 @@ class COBSDecoder {
   COBSDecoder() = default;
 
   template <size_t input_size, size_t output_size>
-  FrameProps::OutputStatus transform(
+  IndexStatus transform(
       const Util::ByteVector<input_size> &input_buffer,
       Util::ByteVector<output_size> &output_buffer) const;
 };
@@ -46,7 +46,7 @@ class COBSEncoder {
   COBSEncoder() = default;
 
   template <size_t input_size, size_t output_size>
-  FrameProps::OutputStatus transform(
+  IndexStatus transform(
       const Util::ByteVector<input_size> &input_buffer,
       Util::ByteVector<output_size> &output_buffer) const;
 };

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Frames.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Frames.tpp
@@ -23,13 +23,10 @@ IndexStatus COBSDecoder::transform(
       Util::ByteVector<input_size>::max_size() <= FrameProps::encoded_max_size,
       "COBSDecoder unavailable as the input buffer size is too large");
   static_assert(
-      Util::ByteVector<output_size>::max_size() <= FrameProps::payload_max_size,
-      "COBSDecoder unavailable as the output buffer size is too large");
+      Util::ByteVector<output_size>::max_size() >= FrameProps::payload_max_size,
+      "COBSDecoder unavailable as the output buffer size is too small");
 
-  if (Util::decode_cobs(input_buffer, output_buffer) != IndexStatus::ok) {
-    return IndexStatus::out_of_bounds;
-  }
-  return IndexStatus::ok;
+  return Util::decode_cobs(input_buffer, output_buffer);
 }
 
 // COBSEncoder
@@ -39,18 +36,13 @@ IndexStatus COBSEncoder::transform(
     const Util::ByteVector<input_size> &input_buffer,
     Util::ByteVector<output_size> &output_buffer) const {
   static_assert(
-      Util::ByteVector<input_size>::max_size() <= FrameProps::encoded_max_size,
-      "COBSDecoder unavailable as the input buffer size is too large");
+      Util::ByteVector<input_size>::max_size() <= FrameProps::payload_max_size,
+      "COBSEncoder unavailable as the input buffer size is too large");
+  static_assert(
+      Util::ByteVector<output_size>::max_size() >= FrameProps::encoded_max_size,
+      "COBSEncoder unavailable as the output buffer size is too small");
 
-  size_t encoded_size = Util::get_encoded_cobs_buffer_size(input_buffer.size());
-  if (output_buffer.max_size() < encoded_size) {
-    return IndexStatus::out_of_bounds;
-  }
-
-  if (Util::encode_cobs(input_buffer, output_buffer) != IndexStatus::ok) {
-    return IndexStatus::out_of_bounds;
-  }
-  return IndexStatus::ok;
+  return Util::encode_cobs(input_buffer, output_buffer);
 }
 
 }  // namespace Pufferfish::Driver::Serial::Backend

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.h
@@ -61,6 +61,7 @@ IndexStatus encode_cobs(
 /// \brief Decode a COBS-encoded buffer.
 /// \param encodedBuffer A ByteVector to the \p encodedBuffer to decode.
 /// \param decodedBuffer The target ByteVector for the decoded bytes.
+/// The decoded buffer is resized to fit the decoded data, returns out_of_bounds otherwise
 /// \returns IndexStatus as ok/out_of_bounds
 template <size_t input_size, size_t output_size>
 IndexStatus decode_cobs(

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.h
@@ -51,21 +51,16 @@ namespace Pufferfish::Util {
 
 /// \brief Encode a byte buffer with the COBS encoder.
 /// \param buffer A ByteVector to the unencoded buffer to encode.
-/// \param size  The number of bytes in the \p buffer.
 /// \param encodedBuffer The ByteVector for the encoded bytes.
-/// \returns The number of bytes written to the \p encodedBuffer.
-/// \warning The encodedBuffer must have at least getEncodedBufferSize()
-///          allocated.
+/// \returns IndexStatus as ok/out_of_bounds
 template <size_t input_size, size_t output_size>
 IndexStatus encode_cobs(
     const Util::ByteVector<input_size> &buffer, Util::ByteVector<output_size> &encoded_buffer);
 
 /// \brief Decode a COBS-encoded buffer.
 /// \param encodedBuffer A ByteVector to the \p encodedBuffer to decode.
-/// \param size The number of bytes in the \p encodedBuffer.
 /// \param decodedBuffer The target ByteVector for the decoded bytes.
-/// \returns The number of bytes written to the \p decodedBuffer.
-/// \warning decodedBuffer must have a minimum capacity of size.
+/// \returns IndexStatus as ok/out_of_bounds
 template <size_t input_size, size_t output_size>
 IndexStatus decode_cobs(
     const Util::ByteVector<input_size> &encoded_buffer,
@@ -74,7 +69,7 @@ IndexStatus decode_cobs(
 /// \brief Get the maximum encoded buffer size for an unencoded buffer size.
 /// \param unencodedBufferSize The size of the buffer to be encoded.
 /// \returns the maximum size of the required encoded buffer.
-inline size_t get_encoded_cobs_buffer_size(size_t unencoded_buffer_size);
+constexpr size_t get_encoded_cobs_buffer_size(size_t unencoded_buffer_size);
 
 }  // namespace Pufferfish::Util
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.h
@@ -52,6 +52,7 @@ namespace Pufferfish::Util {
 /// \brief Encode a byte buffer with the COBS encoder.
 /// \param buffer A ByteVector to the unencoded buffer to encode.
 /// \param encodedBuffer The ByteVector for the encoded bytes.
+/// The encoded buffer is resized to fit the encoded data, returns out_of_bounds otherwise
 /// \returns IndexStatus as ok/out_of_bounds
 template <size_t input_size, size_t output_size>
 IndexStatus encode_cobs(

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.h
@@ -30,6 +30,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "Pufferfish/Util/Vector.h"
 namespace Pufferfish::Util {
 
 /// \brief A Consistent Overhead Byte Stuffing (COBS) Encoder.
@@ -49,25 +50,32 @@ namespace Pufferfish::Util {
 /// \sa http://www.jacquesf.com/2011/03/consistent-overhead-byte-stuffing
 
 /// \brief Encode a byte buffer with the COBS encoder.
-/// \param buffer A pointer to the unencoded buffer to encode.
+/// \param buffer A ByteVector to the unencoded buffer to encode.
 /// \param size  The number of bytes in the \p buffer.
-/// \param encodedBuffer The buffer for the encoded bytes.
+/// \param encodedBuffer The ByteVector for the encoded bytes.
 /// \returns The number of bytes written to the \p encodedBuffer.
 /// \warning The encodedBuffer must have at least getEncodedBufferSize()
 ///          allocated.
-size_t encode_cobs(const uint8_t *buffer, size_t size, uint8_t *encoded_buffer);
+template <size_t input_size, size_t output_size>
+IndexStatus encode_cobs(
+    const Util::ByteVector<input_size> &buffer, Util::ByteVector<output_size> &encoded_buffer);
 
 /// \brief Decode a COBS-encoded buffer.
-/// \param encodedBuffer A pointer to the \p encodedBuffer to decode.
+/// \param encodedBuffer A ByteVector to the \p encodedBuffer to decode.
 /// \param size The number of bytes in the \p encodedBuffer.
-/// \param decodedBuffer The target buffer for the decoded bytes.
+/// \param decodedBuffer The target ByteVector for the decoded bytes.
 /// \returns The number of bytes written to the \p decodedBuffer.
 /// \warning decodedBuffer must have a minimum capacity of size.
-size_t decode_cobs(const uint8_t *encoded_buffer, size_t size, uint8_t *decoded_buffer);
+template <size_t input_size, size_t output_size>
+IndexStatus decode_cobs(
+    const Util::ByteVector<input_size> &encoded_buffer,
+    Util::ByteVector<output_size> &decoded_buffer);
 
 /// \brief Get the maximum encoded buffer size for an unencoded buffer size.
 /// \param unencodedBufferSize The size of the buffer to be encoded.
 /// \returns the maximum size of the required encoded buffer.
-size_t get_encoded_cobs_buffer_size(size_t unencoded_buffer_size);
+inline size_t get_encoded_cobs_buffer_size(size_t unencoded_buffer_size);
 
 }  // namespace Pufferfish::Util
+
+#include "COBS.tpp"

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.tpp
@@ -39,9 +39,9 @@ IndexStatus encode_cobs(
   size_t code_index = 0;
   uint8_t code = 1;
 
-  if (encoded_buffer.empty()) {
-    encoded_buffer.resize(get_encoded_cobs_buffer_size(buffer.size()));
-  }
+  if (encoded_buffer.resize(get_encoded_cobs_buffer_size(buffer.size())) != IndexStatus::ok) {
+    return IndexStatus::out_of_bounds;
+  };
 
   while (read_index < buffer.size()) {
     if (buffer[read_index] == 0) {

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.tpp
@@ -40,7 +40,7 @@ IndexStatus encode_cobs(
   uint8_t code = 1;
 
   if (encoded_buffer.empty()) {
-    encoded_buffer.resize(buffer.size() + 1);
+    encoded_buffer.resize(get_encoded_cobs_buffer_size(buffer.size()));
   }
 
   while (read_index < buffer.size()) {
@@ -98,7 +98,7 @@ IndexStatus decode_cobs(
   return IndexStatus::ok;
 }
 
-inline size_t get_encoded_cobs_buffer_size(size_t unencoded_buffer_size) {
+constexpr size_t get_encoded_cobs_buffer_size(size_t unencoded_buffer_size) {
   return unencoded_buffer_size + unencoded_buffer_size / max_block_size + 1;
 }
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.tpp
@@ -31,13 +31,19 @@ namespace Pufferfish::Util {
 
 static const size_t max_block_size = 254;
 
-size_t encode_cobs(const uint8_t *buffer, size_t size, uint8_t *encoded_buffer) {
+template <size_t input_size, size_t output_size>
+IndexStatus encode_cobs(
+    const Util::ByteVector<input_size> &buffer, Util::ByteVector<output_size> &encoded_buffer) {
   size_t read_index = 0;
   size_t write_index = 1;
   size_t code_index = 0;
   uint8_t code = 1;
 
-  while (read_index < size) {
+  if (encoded_buffer.empty()) {
+    encoded_buffer.resize(buffer.size() + 1);
+  }
+
+  while (read_index < buffer.size()) {
     if (buffer[read_index] == 0) {
       encoded_buffer[code_index] = code;
       code = 1;
@@ -57,39 +63,42 @@ size_t encode_cobs(const uint8_t *buffer, size_t size, uint8_t *encoded_buffer) 
 
   encoded_buffer[code_index] = code;
 
-  return write_index;
+  return IndexStatus::ok;
 }
 
-size_t decode_cobs(const uint8_t *encoded_buffer, size_t size, uint8_t *decoded_buffer) {
-  if (size == 0) {
-    return 0;
+template <size_t input_size, size_t output_size>
+IndexStatus decode_cobs(
+    const Util::ByteVector<input_size> &encoded_buffer,
+    Util::ByteVector<output_size> &decoded_buffer) {
+  if (encoded_buffer.empty()) {
+    return IndexStatus::out_of_bounds;
   }
 
   size_t read_index = 0;
-  size_t write_index = 0;
 
-  while (read_index < size) {
+  while (read_index < encoded_buffer.size()) {
     uint8_t code = encoded_buffer[read_index];
 
-    if (read_index + code > size && code != 1) {
-      return 0;
+    if (read_index + code > encoded_buffer.size() && code != 1) {
+      return IndexStatus::out_of_bounds;
     }
 
     read_index++;
 
     for (uint8_t i = 1; i < code; i++) {
-      decoded_buffer[write_index++] = encoded_buffer[read_index++];
+      uint8_t byte = encoded_buffer[read_index++];
+      decoded_buffer.push_back(byte);
     }
 
-    if (code != max_block_size + 1 && read_index != size) {
-      decoded_buffer[write_index++] = '\0';
+    if (code != max_block_size + 1 && read_index != encoded_buffer.size()) {
+      decoded_buffer.push_back(0x00);
     }
   }
 
-  return write_index;
+  return IndexStatus::ok;
 }
 
-size_t get_encoded_cobs_buffer_size(size_t unencoded_buffer_size) {
+inline size_t get_encoded_cobs_buffer_size(size_t unencoded_buffer_size) {
   return unencoded_buffer_size + unencoded_buffer_size / max_block_size + 1;
 }
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Util/COBS.tpp
@@ -76,6 +76,7 @@ IndexStatus decode_cobs(
 
   size_t read_index = 0;
 
+  decoded_buffer.resize(0);
   while (read_index < encoded_buffer.size()) {
     uint8_t code = encoded_buffer[read_index];
 

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/COBS.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/COBS.cpp
@@ -86,7 +86,7 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
 
     WHEN(
         "The cobs::encode function is called on a buffer that contains these bytes '0x11 0x22 0x00 "
-        "0x33' and a output_buffer filled with 2-bytes is passed") {
+        "0x33' and a output_buffer paritally filled with 2-bytes is passed") {
       auto body = std::string("\x11\x22\x00\x33"s);
       PF::Util::convert_string_to_byte_vector(body, input_buffer);
       push_status = encoded_buffer.push_back(0x01);
@@ -105,7 +105,7 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
 
     WHEN(
         "The cobs::encode function is called on a buffer that contains these bytes "
-        "'\x74\x27\xab\xfb' and a output_buffer filled with 10-bytes is passed") {
+        "'\x74\x27\xab\xfb' and a output_buffer partially filled with 10-bytes is passed") {
       auto body = std::string("\x74\x27\xab\xfb"s);
       PF::Util::convert_string_to_byte_vector(body, input_buffer);
       auto data = std::string("\x02\x25\x00\x00\xF0\x41\x35\x00\x00\xAA"s);
@@ -457,7 +457,8 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
 
     WHEN(
         "The COBS::decode function is called on a buffer containing these bytes "
-        "'\x03\x9f\x8c\x01\x03\x21\xe8' and decoded buffer filled with 3-bytes is passed") {
+        "'\x03\x9f\x8c\x01\x03\x21\xe8' and a decoded buffer partially filled with 3-bytes is "
+        "passed") {
       auto body = std::string("\x03\x9f\x8c\x01\x03\x21\xe8"s);
       PF::Util::convert_string_to_byte_vector(body, input_buffer);
       auto data = std::string("\x01\x02\x03"s);

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/COBS.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/COBS.cpp
@@ -56,6 +56,7 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
 
     WHEN("The cobs::encode function is called on a buffer that contains these bytes '0x00 0x00'") {
       push_status = input_buffer.push_back(0x00);
+      REQUIRE(push_status == PF::IndexStatus::ok);
       push_status = input_buffer.push_back(0x00);
       REQUIRE(push_status == PF::IndexStatus::ok);
 
@@ -73,6 +74,25 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
         "0x33'") {
       auto body = std::string("\x11\x22\x00\x33"s);
       PF::Util::convert_string_to_byte_vector(body, input_buffer);
+
+      auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
+
+      THEN("The encode_cobs function reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The encoded buffer is as expected '\x03\x11\x22\x02\x33'") {
+        auto expected = std::string("\x03\x11\x22\x02\x33"s);
+        REQUIRE(encoded_buffer == expected);
+      }
+    }
+
+    WHEN(
+        "The cobs::encode function is called on a buffer that contains these bytes '0x11 0x22 0x00 "
+        "0x33' and a non-empty output_buffer is passed") {
+      auto body = std::string("\x11\x22\x00\x33"s);
+      PF::Util::convert_string_to_byte_vector(body, input_buffer);
+      push_status = encoded_buffer.push_back(0x01);
+      REQUIRE(push_status == PF::IndexStatus::ok);
+      push_status = encoded_buffer.push_back(0x02);
+      REQUIRE(push_status == PF::IndexStatus::ok);
 
       auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
 
@@ -350,6 +370,7 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
       PF::Util::ByteVector<decoded_buffer_size> decoded_buffer;
       uint8_t val = 10;
       push_status = input_buffer.push_back(0xff);
+      REQUIRE(push_status == PF::IndexStatus::ok);
       for (size_t i = 0; i < 253; i++) {
         push_status = input_buffer.push_back(val);
         REQUIRE(push_status == PF::IndexStatus::ok);
@@ -513,6 +534,7 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
         "The COBS::decode function is called on a 254-byte buffer filled with the manual encoding "
         "of a 253 non-null-byte payload") {
       push_status = input_buffer.push_back(0xfe);
+      REQUIRE(push_status == PF::IndexStatus::ok);
       for (size_t i = 0; i < 253; i++) {
         uint8_t val = 10;
         push_status = input_buffer.push_back(val);
@@ -537,6 +559,7 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
       PF::Util::ByteVector<buffer_size> input_buffer;
       PF::Util::ByteVector<decoded_buffer_size> decoded_buffer;
       push_status = input_buffer.push_back(0xff);
+      REQUIRE(push_status == PF::IndexStatus::ok);
       for (size_t i = 0; i < 253; i++) {
         uint8_t val = 10;
         push_status = input_buffer.push_back(val);
@@ -565,6 +588,7 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
       PF::Util::ByteVector<decoded_buffer_size> decoded_buffer;
       uint8_t val = 10;
       push_status = input_buffer.push_back(0xff);
+      REQUIRE(push_status == PF::IndexStatus::ok);
       for (size_t i = 0; i < 254; i++) {
         push_status = input_buffer.push_back(val);
         REQUIRE(push_status == PF::IndexStatus::ok);

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/COBS.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/COBS.cpp
@@ -25,6 +25,7 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
     constexpr size_t encoded_buffer_size = 257UL;
     PF::Util::ByteVector<buffer_size> input_buffer;
     PF::Util::ByteVector<encoded_buffer_size> encoded_buffer;
+    PF::IndexStatus push_status;
 
     WHEN("The encoded byte vector is too small to hold the encoded data") {
       constexpr size_t encoded_buffer_size = 4UL;
@@ -41,7 +42,8 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
     }
 
     WHEN("The cobs::encode function is called on a null byte") {
-      input_buffer.push_back(0x00);
+      push_status = input_buffer.push_back(0x00);
+      REQUIRE(push_status == PF::IndexStatus::ok);
 
       auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
 
@@ -53,8 +55,9 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
     }
 
     WHEN("The cobs::encode function is called on a buffer that contains these bytes '0x00 0x00'") {
-      input_buffer.push_back(0x00);
-      input_buffer.push_back(0x00);
+      push_status = input_buffer.push_back(0x00);
+      push_status = input_buffer.push_back(0x00);
+      REQUIRE(push_status == PF::IndexStatus::ok);
 
       auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
 
@@ -155,7 +158,8 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
         "0xf7 0xab' ") {
       auto data = PF::Util::make_array<uint8_t>(0x6e, 0xd7, 0xf1, 0x00, 0xf7, 0xab);
       for (auto& bytes : data) {
-        input_buffer.push_back(bytes);
+        push_status = input_buffer.push_back(bytes);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
 
       auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
@@ -170,7 +174,8 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
     WHEN("The cobs::encode function is called on a 253 byte buffer") {
       for (size_t i = 0; i < 253; i++) {
         uint8_t val = 10;
-        input_buffer.push_back(val);
+        push_status = input_buffer.push_back(val);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
 
       auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
@@ -188,9 +193,11 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
         "byte") {
       for (size_t i = 0; i < 252; i++) {
         uint8_t val = 10;
-        input_buffer.push_back(val);
+        push_status = input_buffer.push_back(val);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
-      input_buffer.push_back(0);
+      push_status = input_buffer.push_back(0);
+      REQUIRE(push_status == PF::IndexStatus::ok);
 
       auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
       THEN("The encode_cobs function reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
@@ -206,7 +213,8 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
     WHEN("The cobs::encode function is called on a 254 byte buffer with no null bytes") {
       for (size_t i = 0; i < 254; i++) {
         uint8_t val = 10;
-        input_buffer.push_back(val);
+        push_status = input_buffer.push_back(val);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
 
       auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
@@ -223,7 +231,8 @@ SCENARIO("The Util encode_cobs function correctly encodes buffers", "[COBS]") {
     WHEN("The cobs::encode function is called on a 255 byte buffer with no null bytes") {
       for (size_t i = 0; i < 255; i++) {
         uint8_t val = 10;
-        input_buffer.push_back(val);
+        push_status = input_buffer.push_back(val);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
 
       auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
@@ -246,9 +255,11 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
     constexpr size_t decoded_buffer_size = 254UL;
     PF::Util::ByteVector<buffer_size> input_buffer;
     PF::Util::ByteVector<decoded_buffer_size> decoded_buffer;
+    PF::IndexStatus push_status;
 
     WHEN("The COBS::decode function is called on a buffer containing '0x01' as the only byte") {
-      input_buffer.push_back(0x01);
+      push_status = input_buffer.push_back(0x01);
+      REQUIRE(push_status == PF::IndexStatus::ok);
       auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
 
       THEN("The decode_cobs function reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
@@ -256,7 +267,8 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
     }
 
     WHEN("The COBS::decode function is called on a buffer containing '0x03' as the only byte") {
-      input_buffer.push_back(0x03);
+      push_status = input_buffer.push_back(0x03);
+      REQUIRE(push_status == PF::IndexStatus::ok);
       auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
 
       THEN("The decode_cobs function reports out_of_bounds status") {
@@ -270,7 +282,8 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
         "0x03' ") {
       auto data = PF::Util::make_array<uint8_t>(0x05, 0x02, 0x03);
       for (auto& bytes : data) {
-        input_buffer.push_back(bytes);
+        push_status = input_buffer.push_back(bytes);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
 
       auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
@@ -286,7 +299,8 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
         "0xff' ") {
       auto data = PF::Util::make_array<uint8_t>(0x05, 0x02, 0xff);
       for (auto& bytes : data) {
-        input_buffer.push_back(bytes);
+        push_status = input_buffer.push_back(bytes);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
 
       auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
@@ -302,7 +316,8 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
         "0xff' ") {
       auto data = PF::Util::make_array<uint8_t>(0x02, 0x02, 0xff);
       for (auto& bytes : data) {
-        input_buffer.push_back(bytes);
+        push_status = input_buffer.push_back(bytes);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
 
       auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
@@ -324,6 +339,42 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
         REQUIRE(status == PF::IndexStatus::out_of_bounds);
       }
       THEN("The decoded buffer is empty") { REQUIRE(decoded_buffer.empty() == true); }
+    }
+
+    WHEN(
+        "The COBS::decode function is called on a 257-byte buffer filled with the manual encoding "
+        "of a 255 non-null-byte payload with a bad null header byte") {
+      constexpr size_t buffer_size = 257UL;
+      constexpr size_t decoded_buffer_size = 255UL;
+      PF::Util::ByteVector<buffer_size> input_buffer;
+      PF::Util::ByteVector<decoded_buffer_size> decoded_buffer;
+      uint8_t val = 10;
+      push_status = input_buffer.push_back(0xff);
+      for (size_t i = 0; i < 253; i++) {
+        push_status = input_buffer.push_back(val);
+        REQUIRE(push_status == PF::IndexStatus::ok);
+      }
+      push_status = input_buffer.push_back(0x02);
+      REQUIRE(push_status == PF::IndexStatus::ok);
+      push_status = input_buffer.push_back(val);
+      REQUIRE(push_status == PF::IndexStatus::ok);
+      push_status = input_buffer.push_back(val);
+      REQUIRE(push_status == PF::IndexStatus::ok);
+
+      auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
+
+      THEN("The decode_cobs function reports ok status") {
+        REQUIRE(status == PF::IndexStatus::out_of_bounds);
+      }
+      THEN(
+          "The decoded buffer has expected sequence of 255 bytes as '0xff 0x71 0xcf ......0x02 "
+          "0xa2 0xd2' ") {
+        for (size_t i = 0; i < 253; i++) {
+          uint8_t val = 10;
+          REQUIRE(decoded_buffer.operator[](i) == val);
+        }
+        REQUIRE(decoded_buffer.operator[](253) == 0x02);
+      }
     }
 
     WHEN("The COBS::decode function is called on a buffer containing these bytes '\x01\x01'") {
@@ -445,7 +496,8 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
         "0xb8, 0x03, 0xbe, 0xce'") {
       auto data = PF::Util::make_array<uint8_t>(0x03, 0x9c, 0xb8, 0x03, 0xbe, 0xce);
       for (auto& bytes : data) {
-        input_buffer.push_back(bytes);
+        push_status = input_buffer.push_back(bytes);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
 
       auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
@@ -458,12 +510,13 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
     }
 
     WHEN(
-        "The COBS::decode function is called on a encoded buffer of capacity 254 bytes filled with "
-        "data whose original buffer was of capacity 253 with no null bytes") {
-      input_buffer.push_back(0xfe);
+        "The COBS::decode function is called on a 254-byte buffer filled with the manual encoding "
+        "of a 253 non-null-byte payload") {
+      push_status = input_buffer.push_back(0xfe);
       for (size_t i = 0; i < 253; i++) {
         uint8_t val = 10;
-        input_buffer.push_back(val);
+        push_status = input_buffer.push_back(val);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
       auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
 
@@ -477,18 +530,20 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
     }
 
     WHEN(
-        "The COBS::decode function is called on a encoded buffer of capacity 256 bytes filled with "
-        "data whose original buffer was of capacity 254 with null byte at the end") {
+        "The COBS::decode function is called on a 256-byte buffer filled with the manual encoding "
+        "of a 254 byte payload with null byte at the end") {
       constexpr size_t buffer_size = 256UL;
       constexpr size_t decoded_buffer_size = 254UL;
       PF::Util::ByteVector<buffer_size> input_buffer;
       PF::Util::ByteVector<decoded_buffer_size> decoded_buffer;
-      input_buffer.push_back(0xff);
+      push_status = input_buffer.push_back(0xff);
       for (size_t i = 0; i < 253; i++) {
         uint8_t val = 10;
-        input_buffer.push_back(val);
+        push_status = input_buffer.push_back(val);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
-      input_buffer.push_back(0x01);
+      push_status = input_buffer.push_back(0x01);
+      REQUIRE(push_status == PF::IndexStatus::ok);
       auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
 
       THEN("The decode_cobs function reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
@@ -502,20 +557,22 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
     }
 
     WHEN(
-        "The COBS::decode function is called on a encoded buffer of capacity 257 bytes whose "
-        "original buffer was of capacity 255 with no null bytes") {
+        "The COBS::decode function is called on a 257-byte buffer filled with the manual encoding "
+        "of a 255 non-null-byte payload") {
       constexpr size_t buffer_size = 257UL;
       constexpr size_t decoded_buffer_size = 255UL;
       PF::Util::ByteVector<buffer_size> input_buffer;
       PF::Util::ByteVector<decoded_buffer_size> decoded_buffer;
       uint8_t val = 10;
-      input_buffer.push_back(0xff);
+      push_status = input_buffer.push_back(0xff);
       for (size_t i = 0; i < 254; i++) {
-        input_buffer.push_back(val);
+        push_status = input_buffer.push_back(val);
+        REQUIRE(push_status == PF::IndexStatus::ok);
       }
-      input_buffer.push_back(0x02);
-      input_buffer.push_back(val);
-      input_buffer.push_back(val);
+      push_status = input_buffer.push_back(0x02);
+      REQUIRE(push_status == PF::IndexStatus::ok);
+      push_status = input_buffer.push_back(val);
+      REQUIRE(push_status == PF::IndexStatus::ok);
 
       auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
 
@@ -523,7 +580,7 @@ SCENARIO("The Util decode_cobs function correctly decodes encoded buffers", "[CO
       THEN(
           "The decoded buffer has expected sequence of 255 bytes as '0xff 0x71 0xcf ......0x02 "
           "0xa2 0xd2' ") {
-        for (size_t i = 0; i < 254; i++) {
+        for (size_t i = 0; i < 255; i++) {
           uint8_t val = 10;
           REQUIRE(decoded_buffer.operator[](i) == val);
         }

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/COBS.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/COBS.cpp
@@ -241,7 +241,7 @@ SCENARIO("The Util encode_cobs method correctly encodes buffers", "[COBS]") {
         for (size_t i = 1; i < 254; i++) {
           REQUIRE(encoded_buffer.operator[](i) == 10);
         }
-        // REQUIRE(encoded_buffer.operator[](256) == 1);
+        REQUIRE(encoded_buffer.operator[](255) == 1);
       }
     }
 
@@ -258,8 +258,8 @@ SCENARIO("The Util encode_cobs method correctly encodes buffers", "[COBS]") {
         for (size_t i = 1; i < 254; i++) {
           REQUIRE(encoded_buffer.operator[](i) == 10);
         }
-        // REQUIRE(encoded_buffer.operator[](256) == 2);
-        // REQUIRE(encoded_buffer.operator[](257) == 10);
+        REQUIRE(encoded_buffer.operator[](255) == 2);
+        REQUIRE(encoded_buffer.operator[](256) == 10);
       }
     }
   }

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/COBS.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/COBS.cpp
@@ -1,0 +1,266 @@
+
+/*
+ * Copyright 2020, the Pez Globo team and the Pufferfish project contributors
+ *
+ * COBS.cpp
+ *
+ *  Created on: Nov 24, 2020
+ *      Author: Rohan Purohit
+ *
+ * Unit tests to confirm behavior of COBS Util
+ *
+ */
+#include "Pufferfish/Util/COBS.h"
+
+#include <iostream>
+
+#include "Pufferfish/Test/Util.h"
+#include "Pufferfish/Util/Array.h"
+#include "catch2/catch.hpp"
+
+namespace PF = Pufferfish;
+using namespace std::string_literals;
+
+SCENARIO("The Util decode_cobs method correctly decodes encoded buffers", "[COBS]") {
+  GIVEN("The Util COBS::decode function") {
+    constexpr size_t buffer_size = 255UL;
+    constexpr size_t decoded_buffer_size = 254UL;
+    PF::Util::ByteVector<buffer_size> input_buffer;
+    PF::Util::ByteVector<decoded_buffer_size> decoded_buffer;
+
+    WHEN("The COBS::decode method is called on a buffer containing '0x01' as the only byte") {
+      input_buffer.push_back(0x01);
+      auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
+
+      THEN("The decode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      // THEN("The decoded buffer is empty") { REQUIRE(decoded_buffer.empty() == true); }
+    }
+
+    WHEN("The COBS::decode method is called on a buffer containing '0x03' as the only byte") {
+      input_buffer.push_back(0x03);
+      auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
+
+      THEN("The decode_cobs method reports out_of_bounds status") {
+        REQUIRE(status == PF::IndexStatus::out_of_bounds);
+      }
+      THEN("The decoded buffer is empty") { REQUIRE(decoded_buffer.empty() == true); }
+    }
+
+    WHEN(
+        "The COBS::decode method is called on a buffer that contains these bytes '0x05 0x02 "
+        "0x03' ") {
+      auto data = PF::Util::make_array<uint8_t>(0x05, 0x02, 0x03);
+      for (auto& bytes : data) {
+        input_buffer.push_back(bytes);
+      }
+
+      auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
+
+      THEN("The decode_cobs method reports out_of_bounds status") {
+        REQUIRE(status == PF::IndexStatus::out_of_bounds);
+      }
+      THEN("The decoded buffer is empty") { REQUIRE(decoded_buffer.empty() == true); }
+    }
+
+    WHEN(
+        "The COBS::decode method is called on a buffer that contains these bytes '0x03, 0x9c, "
+        "0xb8, 0x03, 0xbe, 0xce'") {
+      auto data = PF::Util::make_array<uint8_t>(0x03, 0x9c, 0xb8, 0x03, 0xbe, 0xce);
+      for (auto& bytes : data) {
+        input_buffer.push_back(bytes);
+      }
+
+      auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
+
+      THEN("The decode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The decoded buffer is as expected '0x9c 0xb8 0x00 0xbe 0xce' ") {
+        auto expected = std::string("\x9c\xb8\x00\xbe\xce"s);
+        REQUIRE(decoded_buffer == expected);
+      }
+    }
+
+    WHEN(
+        "The COBS::decode method is called on a encoded buffer of capacity 254 bytes filled with "
+        "data whose original buffer was of capacity 253 with no null bytes") {
+      input_buffer.push_back(0xfe);
+      for (size_t i = 0; i < 253; i++) {
+        uint8_t val = 10;
+        input_buffer.push_back(val);
+      }
+      auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
+
+      THEN("The decode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The decoded buffer has expected sequence of 254 bytes") {
+        for (size_t i = 0; i < 253; i++) {
+          uint8_t val = 10;
+          REQUIRE(decoded_buffer.operator[](i) == val);
+        }
+      }
+    }
+
+    WHEN(
+        "The COBS::decode method is called on a encoded buffer of capacity 256 bytes filled with "
+        "data whose original buffer was of capacity 254 with null byte at the end") {
+      input_buffer.push_back(0xff);
+      for (size_t i = 0; i < 253; i++) {
+        uint8_t val = 10;
+        input_buffer.push_back(val);
+      }
+      input_buffer.push_back(0x01);
+      auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
+
+      THEN("The decode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The decoded buffer has expected sequence of 254 bytes with last byte as null byte") {
+        for (size_t i = 0; i < 253; i++) {
+          uint8_t val = 10;
+          REQUIRE(decoded_buffer.operator[](i) == val);
+        }
+        REQUIRE(decoded_buffer.operator[](254) == 0);
+      }
+    }
+
+    WHEN(
+        "The COBS::decode method is called on a encoded buffer of capacity 257 bytes whose "
+        "original buffer was of capacity 255 with no null bytes") {
+      uint8_t val = 10;
+      input_buffer.push_back(0xff);
+      for (size_t i = 0; i < 253; i++) {
+        input_buffer.push_back(val);
+      }
+      input_buffer.push_back(0x02);
+      input_buffer.push_back(val);
+      input_buffer.push_back(val);
+      auto status = PF::Util::decode_cobs(input_buffer, decoded_buffer);
+
+      THEN("The decode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN(
+          "The decoded buffer has expected sequence of 255 bytes as '0xff 0x71 0xcf ......0x02 "
+          "0xa2 0xd2' ") {
+        for (size_t i = 0; i < 253; i++) {
+          uint8_t val = 10;
+          REQUIRE(decoded_buffer.operator[](i) == val);
+        }
+      }
+    }
+  }
+}
+
+SCENARIO("The Util encode_cobs method correctly encodes buffers", "[COBS]") {
+  GIVEN("The Util COBS::encode function") {
+    constexpr size_t buffer_size = 256UL;
+    constexpr size_t encoded_buffer_size = 257UL;
+    PF::Util::ByteVector<buffer_size> input_buffer;
+    PF::Util::ByteVector<encoded_buffer_size> encoded_buffer;
+
+    WHEN("The cobs::encode is called on a null byte") {
+      input_buffer.push_back(0x00);
+
+      auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
+
+      THEN("The encode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The encoded buffer is as expected '\x01\x01' ") {
+        auto expected = std::string("\x01\x01"s);
+        REQUIRE(encoded_buffer == expected);
+      }
+    }
+
+    WHEN("The cobs::encode is called on a buffer that contains these bytes '0x00 0x00'") {
+      input_buffer.push_back(0x00);
+      input_buffer.push_back(0x00);
+
+      auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
+
+      THEN("The encode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The encoded buffer is as expected '\x01\x01\x01' ") {
+        auto expected = std::string("\x01\x01\x01"s);
+        REQUIRE(encoded_buffer == expected);
+      }
+    }
+
+    WHEN(
+        "The cobs::encode is called on a buffer that contains these bytes '0x6e 0xd7 0xf1 0x00 "
+        "0xf7 0xab' ") {
+      auto data = PF::Util::make_array<uint8_t>(0x6e, 0xd7, 0xf1, 0x00, 0xf7, 0xab);
+      for (auto& bytes : data) {
+        input_buffer.push_back(bytes);
+      }
+
+      auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
+
+      THEN("The encode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The encoded buffer is as expected '\x04\x6e\xd7\xf1\x03\xf7\xab' ") {
+        auto expected = std::string("\x04\x6e\xd7\xf1\x03\xf7\xab"s);
+        REQUIRE(encoded_buffer == expected);
+      }
+    }
+
+    WHEN("The cobs::encode is called on a 253 byte buffer") {
+      for (size_t i = 0; i < 253; i++) {
+        uint8_t val = 10;
+        input_buffer.push_back(val);
+      }
+
+      auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
+      THEN("The encode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xfe") {
+        REQUIRE(encoded_buffer.operator[](0) == 0xfe);
+        for (size_t i = 1; i < 253; i++) {
+          REQUIRE(encoded_buffer.operator[](i) == 10);
+        }
+      }
+    }
+
+    WHEN("The cobs::encode is called on a 254 bytes buffer with last byte as a null byte") {
+      for (size_t i = 0; i < 252; i++) {
+        uint8_t val = 10;
+        input_buffer.push_back(val);
+      }
+      input_buffer.push_back(0);
+
+      auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
+      THEN("The encode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xfd") {
+        REQUIRE(encoded_buffer.operator[](0) == 0xfd);
+        for (size_t i = 1; i < 253; i++) {
+          REQUIRE(encoded_buffer.operator[](i) == 10);
+        }
+        REQUIRE(encoded_buffer.operator[](253) == 1);
+      }
+    }
+
+    WHEN("The cobs::encode is called on a 254 byte buffer with no null bytes") {
+      for (size_t i = 0; i < 254; i++) {
+        uint8_t val = 10;
+        input_buffer.push_back(val);
+      }
+
+      auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
+      THEN("The encode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xff") {
+        REQUIRE(encoded_buffer.operator[](0) == 0xff);
+        for (size_t i = 1; i < 254; i++) {
+          REQUIRE(encoded_buffer.operator[](i) == 10);
+        }
+        // REQUIRE(encoded_buffer.operator[](256) == 1);
+      }
+    }
+
+    WHEN("The cobs::encode is called on a 255 byte buffer with no null bytes") {
+      for (size_t i = 0; i < 255; i++) {
+        uint8_t val = 10;
+        input_buffer.push_back(val);
+      }
+
+      auto status = PF::Util::encode_cobs(input_buffer, encoded_buffer);
+      THEN("The encode_cobs method reports ok status") { REQUIRE(status == PF::IndexStatus::ok); }
+      THEN("The encoded buffer has an expected sequence of 257 bytes with first byte as 0xff") {
+        REQUIRE(encoded_buffer.operator[](0) == 0xff);
+        for (size_t i = 1; i < 254; i++) {
+          REQUIRE(encoded_buffer.operator[](i) == 10);
+        }
+        // REQUIRE(encoded_buffer.operator[](256) == 2);
+        // REQUIRE(encoded_buffer.operator[](257) == 10);
+      }
+    }
+  }
+}

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
@@ -85,6 +85,10 @@ Scenario: The cobs::decode function correctly decodes encoded buffers
     THEN("The decode_cobs function reports out_of_bounds status")
     THEN("The decoded buffer is empty")
 
+  WHEN("The COBS::decode function is called on a 257-byte buffer filled with the manual encoding of a 255 non-null-byte payload with a bad null header byte at the 255th byte position")
+    THEN("The decode_cobs function reports out_of_bounds status")
+    THEN("The decoded buffer has expected sequence of 255 bytes with \x02 at the end")
+
   WHEN("The COBS::decode function is called on a buffer containing these bytes '\x01\x01'")
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer is as expected '0x00'")
@@ -121,14 +125,14 @@ Scenario: The cobs::decode function correctly decodes encoded buffers
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer is as expected '\x9c\xb8\x00\xbe\xce' ")
 
-  WHEN("The COBS::decode function is called on a encoded buffer of capacity 254 bytes whose original buffer was of capacity 253 with no null bytes")
+  WHEN("The COBS::decode function is called on a 254-byte buffer filled with the manual encoding of a 253 non-null-byte payload")
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer has expected sequence of 253 bytes")
 
-  WHEN("The COBS::decode function is called on a encoded buffer of capacity 256 bytes whose original buffer was of capacity 254 with null byte at the end")   
+  WHEN("The COBS::decode function is called on a 256-byte buffer filled with the manual encoding of a 254 byte payload with null byte at the end")
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer has expected sequence of 254 bytes with last byte as null byte")    
 
-  WHEN("The COBS::decode function is called on a encoded buffer of capacity 257 bytes whose original buffer was of capacity 255 with no null bytes") 
+  WHEN("The COBS::decode function is called on a 257-byte buffer filled with the manual encoding of a 255 non-null-byte payload")
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer has expected sequence of 255 bytes as '0xff 0x71 0xcf ......0x02 0xa2 0xd2')

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
@@ -18,9 +18,13 @@ Scenario: The Util encode_cobs function correctly encodes buffers
     THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x03\x11\x22\x02\x33'")
 
-  WHEN("The cobs::encode function is called on a buffer that contains these bytes '0x11 0x22 0x00 0x33' and a non-empty output_buffer is passed")
+  WHEN("The cobs::encode function is called on a buffer that contains these bytes '0x11 0x22 0x00 0x33' and a output_buffer filled with 2-bytes is passed")
     THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x03\x11\x22\x02\x33'")
+
+  WHEN("The cobs::encode function is called on a buffer that contains these bytes '\x74\x27\xab\xfb' and a output_buffer filled with 10-bytes is passed")
+    THEN("The encode_cobs function reports ok status")
+    THEN("The encoded buffer is as expected '\x05\x74\x27\xab\xfb'")      
 
   WHEN("The cobs::encode function is called on a buffer that contains these bytes '\x11\x22\x33\x44'")
     THEN("The encode_cobs function reports ok status")
@@ -104,6 +108,10 @@ Scenario: The cobs::decode function correctly decodes encoded buffers
   WHEN("The COBS::decode function is called on a buffer containing these bytes '\x03\x11\x22\x02\x33'")
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer is as expected '0x11 0x22 0x00 0x33'")
+
+  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x03\x9f\x8c\x01\x03\x21\xe8' and decoded buffer filled with 3-bytes is passed")
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is as expected '0x9f 0x8c 0x00 0x00 0x21 0xe8'")
 
   WHEN("The COBS::decode function is called on a buffer containing these bytes '\x05\x11\x22\x33\x44'")
     THEN("The decode_cobs function reports ok status")

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
@@ -16,7 +16,11 @@ Scenario: The Util encode_cobs function correctly encodes buffers
 
   WHEN("The cobs::encode function is called on a buffer that contains these bytes '0x11 0x22 0x00 0x33'")
     THEN("The encode_cobs function reports ok status")
-    THEN("The encoded buffer is as expected '\x03\x11\x22\x02\x33'") {
+    THEN("The encoded buffer is as expected '\x03\x11\x22\x02\x33'")
+
+  WHEN("The cobs::encode function is called on a buffer that contains these bytes '0x11 0x22 0x00 0x33' and a non-empty output_buffer is passed")
+    THEN("The encode_cobs function reports ok status")
+    THEN("The encoded buffer is as expected '\x03\x11\x22\x02\x33'")
 
   WHEN("The cobs::encode function is called on a buffer that contains these bytes '\x11\x22\x33\x44'")
     THEN("The encode_cobs function reports ok status")
@@ -81,7 +85,7 @@ Scenario: The cobs::decode function correctly decodes encoded buffers
   WHEN("The COBS::decode function is called on a buffer that contains these bytes '0x02 0x02 0xff' ")    
     THEN("The decode_cobs function reports out_of_bounds status")
 
-  WHEN("The decoded buffer is too small to hold the decoded data") {
+  WHEN("The decoded buffer is too small to hold the decoded data")
     THEN("The decode_cobs function reports out_of_bounds status")
     THEN("The decoded buffer is empty")
 
@@ -93,7 +97,7 @@ Scenario: The cobs::decode function correctly decodes encoded buffers
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer is as expected '0x00'")
 
-  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x01\x01\x01'") {    
+  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x01\x01\x01'")    
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer is as expected '0x00 0x00'")
 
@@ -105,7 +109,7 @@ Scenario: The cobs::decode function correctly decodes encoded buffers
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer is as expected '\x11\x22\x33\x44'")            
 
-  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x02x'") {
+  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x02x'")
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer is as expected 'x' ")
 

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
@@ -3,31 +3,31 @@ Scenario: The cobs::decode method correctly decodes encoded buffers
  GIVEN("The Util COBS::decode function")
 
    WHEN("The COBS::decode method is called on a buffer containing '0x01' as the only byte")
-    THEN("The decoded size is 0")
+    THEN("The decode_cobs method reports ok status")
     THEN("The decoded buffer is emppty")
 
    WHEN("The COBS::decode method is called on a buffer containing '0x03' as the only byte")      
-    THEN("The decoded size is 0")
+    THEN("The decode_cobs method reports out_of_bounds status")
     THEN("The decoded buffer is emppty")
      
    WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x05 0x02 0x03' ")    
-    THEN("The decoded size is 0")
+    THEN("The decode_cobs method reports out_of_bounds status")
     THEN("The decoded buffer is emppty")
 
    WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x03, 0x9c, 0xb8, 0x03, 0xbe, 0xce'")
-    THEN("The decoded size is 5")
+    THEN("The decode_cobs method reports ok status")
     THEN("The decoded buffer is as expected '\x9c\xb8\x00\xbe\xce' ")
 
    WHEN("The COBS::decode method is called on a encoded buffer of capacity 254 bytes whose original buffer was of capacity 253 with no null bytes")
-    THEN("The decoded size is 253")   
+    THEN("The decode_cobs method reports ok status")
     THEN("The decoded buffer has expected sequence of 253 bytes")
 
    WHEN("The COBS::decode method is called on a encoded buffer of capacity 256 bytes whose original buffer was of capacity 254 with null byte at the end")   
-    THEN("The decoded size is 254")    
+    THEN("The decode_cobs method reports ok status")
     THEN("The decoded buffer has expected sequence of 254 bytes with last byte as null byte")    
 
    WHEN("The COBS::decode method is called on a encoded buffer of capacity 257 bytes whose original buffer was of capacity 255 with no null bytes") 
-    THEN("The decoded size is 255")
+    THEN("The decode_cobs method reports ok status")
     THEN("The decoded buffer has expected sequence of 255 bytes as '0xff 0x71 0xcf ......0x02 0xa2 0xd2')
 
 Scenario: The Util encode_cobs method correctly encodes buffers

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
@@ -18,11 +18,11 @@ Scenario: The Util encode_cobs function correctly encodes buffers
     THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x03\x11\x22\x02\x33'")
 
-  WHEN("The cobs::encode function is called on a buffer that contains these bytes '0x11 0x22 0x00 0x33' and a output_buffer filled with 2-bytes is passed")
+  WHEN("The cobs::encode function is called on a buffer that contains these bytes '0x11 0x22 0x00 0x33' and a output_buffer partially filled with 2-bytes is passed")
     THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x03\x11\x22\x02\x33'")
 
-  WHEN("The cobs::encode function is called on a buffer that contains these bytes '\x74\x27\xab\xfb' and a output_buffer filled with 10-bytes is passed")
+  WHEN("The cobs::encode function is called on a buffer that contains these bytes '\x74\x27\xab\xfb' and a output_buffer partially filled with 10-bytes is passed")
     THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x05\x74\x27\xab\xfb'")      
 
@@ -109,7 +109,7 @@ Scenario: The cobs::decode function correctly decodes encoded buffers
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer is as expected '0x11 0x22 0x00 0x33'")
 
-  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x03\x9f\x8c\x01\x03\x21\xe8' and decoded buffer filled with 3-bytes is passed")
+  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x03\x9f\x8c\x01\x03\x21\xe8' and a decoded buffer partially filled with 3-bytes is passed")
     THEN("The decode_cobs function reports ok status")
     THEN("The decoded buffer is as expected '0x9f 0x8c 0x00 0x00 0x21 0xe8'")
 

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
@@ -2,31 +2,71 @@ Scenario: The cobs::decode method correctly decodes encoded buffers
 
  GIVEN("The Util COBS::decode function")
 
-   WHEN("The COBS::decode method is called on a buffer containing '0x01' as the only byte")
+  WHEN("The COBS::decode method is called on a buffer containing '0x01' as the only byte")
     THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is emppty")
+    THEN("The decoded buffer is empty")    
 
-   WHEN("The COBS::decode method is called on a buffer containing '0x03' as the only byte")      
+  WHEN("The COBS::decode method is called on a buffer containing '0x03' as the only byte")      
     THEN("The decode_cobs method reports out_of_bounds status")
-    THEN("The decoded buffer is emppty")
+    THEN("The decoded buffer is empty")
      
-   WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x05 0x02 0x03' ")    
+  WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x05 0x02 0x03' ")    
     THEN("The decode_cobs method reports out_of_bounds status")
-    THEN("The decoded buffer is emppty")
+    THEN("The decoded buffer is empty")
 
-   WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x03, 0x9c, 0xb8, 0x03, 0xbe, 0xce'")
+  WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x05 0x02 0xff' ")    
+    THEN("The decode_cobs method reports out_of_bounds status")
+    THEN("The decoded buffer is empty")
+
+  WHEN("The decoded buffer is too small to hold the decoded data") {
+    THEN("The decode_cobs method reports out_of_bounds status")
+    THEN("The decoded buffer is empty")
+
+  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x01\x01'")
+    THEN("The decode_cobs method reports ok status")
+    THEN("The decoded buffer is as expected '0x00'")
+
+  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x01\x01\x01'") {    
+    THEN("The decode_cobs method reports ok status")
+    THEN("The decoded buffer is as expected '0x00 0x00'")
+
+  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x03\x11\x22\x02\x33'")
+    THEN("The decode_cobs method reports ok status")
+    THEN("The decoded buffer is as expected '0x11 0x22 0x00 0x33'")
+
+  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x05\x11\x22\x33\x44'")
+    THEN("The decode_cobs method reports ok status")
+    THEN("The decoded buffer is as expected '\x11\x22\x33\x44'")            
+
+  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x02x'") {
+    THEN("The decode_cobs method reports ok status")
+    THEN("The decoded buffer is as expected 'x' ")
+
+  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x03xy'")    
+    THEN("The decode_cobs method reports ok status")
+    THEN("The decoded buffer is as expected 'xy' ")
+
+  WHEN("The COBS::decode method is called on a buffer containing the bytestring '\x0cHello World'")
+    THEN("The decode_cobs method reports ok status")
+    THEN("The decoded buffer is as expected 'Hello World'")
+
+  WHEN("The COBS::decode method is called on a buffer containing a encoded sensor measurements message payload")
+    THEN("The decode_cobs method reports ok status")
+    THEN("The decoded buffer is as expected")
+
+  WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x03, 0x9c, 0xb8, 0x03, 0xbe, 0xce'")
     THEN("The decode_cobs method reports ok status")
     THEN("The decoded buffer is as expected '\x9c\xb8\x00\xbe\xce' ")
 
-   WHEN("The COBS::decode method is called on a encoded buffer of capacity 254 bytes whose original buffer was of capacity 253 with no null bytes")
+  WHEN("The COBS::decode method is called on a encoded buffer of capacity 254 bytes whose original buffer was of capacity 253 with no null bytes")
     THEN("The decode_cobs method reports ok status")
     THEN("The decoded buffer has expected sequence of 253 bytes")
 
-   WHEN("The COBS::decode method is called on a encoded buffer of capacity 256 bytes whose original buffer was of capacity 254 with null byte at the end")   
+  WHEN("The COBS::decode method is called on a encoded buffer of capacity 256 bytes whose original buffer was of capacity 254 with null byte at the end")   
     THEN("The decode_cobs method reports ok status")
     THEN("The decoded buffer has expected sequence of 254 bytes with last byte as null byte")    
 
-   WHEN("The COBS::decode method is called on a encoded buffer of capacity 257 bytes whose original buffer was of capacity 255 with no null bytes") 
+  WHEN("The COBS::decode method is called on a encoded buffer of capacity 257 bytes whose original buffer was of capacity 255 with no null bytes") 
     THEN("The decode_cobs method reports ok status")
     THEN("The decoded buffer has expected sequence of 255 bytes as '0xff 0x71 0xcf ......0x02 0xa2 0xd2')
 
@@ -34,30 +74,58 @@ Scenario: The Util encode_cobs method correctly encodes buffers
 
   GIVEN("The Util COBS::encode function")
 
-    WHEN("The cobs::encode is called on a null byte")
-      THEN("The encode_cobs method reports ok status")
-      THEN("The encoded buffer is as expected '\x01\x01' ")
+  WHEN("The encoded byte vector is too small to hold the encoded data")
+    THEN("The encode_cobs method reports out_of_bounds status")
+    THEN("The encoded buffer is empty")
 
-    WHEN("The cobs::encode is called on a buffer that contains these bytes '0x00 0x00'")
-      THEN("The encode_cobs method reports ok status")
-      THEN("The encoded buffer is as expected '\x01\x01\x01' ")
+  WHEN("The cobs::encode is called on a null byte")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer is as expected '\x01\x01' ")
 
-    WHEN("The cobs::encode is called on a buffer that contains these bytes '0x6e 0xd7 0xf1 0x00 0xf7 0xab' ")
-      THEN("The encode_cobs method reports ok status")
-      THEN("The encoded buffer is as expected '\x04\x6e\xd7\xf1\x03\xf7\xab' ")
+  WHEN("The cobs::encode is called on a buffer that contains these bytes '0x00 0x00'")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer is as expected '\x01\x01\x01' ")
 
-    WHEN("The cobs::encode is called on a 253 byte buffer")
-      THEN("The encode_cobs method reports ok status")
-      THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xfe")
+  WHEN("The cobs::encode method is called on a buffer that contains these bytes '0x11 0x22 0x00 0x33'")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer is as expected '\x03\x11\x22\x02\x33'") {
 
-    WHEN("The cobs::encode is called on a 254 bytes buffer with last byte as a null byte")
-      THEN("The encode_cobs method reports ok status")
-      THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xfd")
+  WHEN("The cobs::encode method is called on a buffer that contains these bytes '\x11\x22\x33\x44'")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer is as expected '\x05\x11\x22\x33\x44'")
 
-    WHEN("The cobs::encode is called on a 254 byte buffer with no null bytes")
-      THEN("The encode_cobs method reports ok status")
-      THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xff")
+  WHEN("The cobs::encode method is called on the char 'x'")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer is as expected '\02x'")
+  
+  WHEN("The cobs::encode method is called on the char 'xy'")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer is as expected '\03xy'")
 
-    WHEN("The cobs::encode is called on a 255 byte buffer with no null bytes")
-      THEN("The encode_cobs method reports ok status")
-      THEN("The encoded buffer has an expected sequence of 257 bytes with first byte as 0xff")
+  WHEN("The cobs::encode method is called on the string 'Hello world'")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer is as expected '\x0cHello World'")
+
+  WHEN("The cobs::encode method is called on a sensor measurements message payload")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer is as expected")
+
+  WHEN("The cobs::encode is called on a buffer that contains these bytes '0x6e 0xd7 0xf1 0x00 0xf7 0xab' ")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer is as expected '\x04\x6e\xd7\xf1\x03\xf7\xab' ")
+
+  WHEN("The cobs::encode is called on a 253 byte buffer")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xfe")
+
+  WHEN("The cobs::encode is called on a 254 bytes buffer with last byte as a null byte")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xfd")
+
+  WHEN("The cobs::encode is called on a 254 byte buffer with no null bytes")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xff")
+
+  WHEN("The cobs::encode is called on a 255 byte buffer with no null bytes")
+    THEN("The encode_cobs method reports ok status")
+    THEN("The encoded buffer has an expected sequence of 257 bytes with first byte as 0xff")

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
@@ -1,131 +1,134 @@
-Scenario: The cobs::decode method correctly decodes encoded buffers
-
- GIVEN("The Util COBS::decode function")
-
-  WHEN("The COBS::decode method is called on a buffer containing '0x01' as the only byte")
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is empty")    
-
-  WHEN("The COBS::decode method is called on a buffer containing '0x03' as the only byte")      
-    THEN("The decode_cobs method reports out_of_bounds status")
-    THEN("The decoded buffer is empty")
-     
-  WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x05 0x02 0x03' ")    
-    THEN("The decode_cobs method reports out_of_bounds status")
-    THEN("The decoded buffer is empty")
-
-  WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x05 0x02 0xff' ")    
-    THEN("The decode_cobs method reports out_of_bounds status")
-    THEN("The decoded buffer is empty")
-
-  WHEN("The decoded buffer is too small to hold the decoded data") {
-    THEN("The decode_cobs method reports out_of_bounds status")
-    THEN("The decoded buffer is empty")
-
-  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x01\x01'")
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is as expected '0x00'")
-
-  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x01\x01\x01'") {    
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is as expected '0x00 0x00'")
-
-  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x03\x11\x22\x02\x33'")
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is as expected '0x11 0x22 0x00 0x33'")
-
-  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x05\x11\x22\x33\x44'")
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is as expected '\x11\x22\x33\x44'")            
-
-  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x02x'") {
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is as expected 'x' ")
-
-  WHEN("The COBS::decode method is called on a buffer containing these bytes '\x03xy'")    
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is as expected 'xy' ")
-
-  WHEN("The COBS::decode method is called on a buffer containing the bytestring '\x0cHello World'")
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is as expected 'Hello World'")
-
-  WHEN("The COBS::decode method is called on a buffer containing a encoded sensor measurements message payload")
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is as expected")
-
-  WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x03, 0x9c, 0xb8, 0x03, 0xbe, 0xce'")
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer is as expected '\x9c\xb8\x00\xbe\xce' ")
-
-  WHEN("The COBS::decode method is called on a encoded buffer of capacity 254 bytes whose original buffer was of capacity 253 with no null bytes")
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer has expected sequence of 253 bytes")
-
-  WHEN("The COBS::decode method is called on a encoded buffer of capacity 256 bytes whose original buffer was of capacity 254 with null byte at the end")   
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer has expected sequence of 254 bytes with last byte as null byte")    
-
-  WHEN("The COBS::decode method is called on a encoded buffer of capacity 257 bytes whose original buffer was of capacity 255 with no null bytes") 
-    THEN("The decode_cobs method reports ok status")
-    THEN("The decoded buffer has expected sequence of 255 bytes as '0xff 0x71 0xcf ......0x02 0xa2 0xd2')
-
-Scenario: The Util encode_cobs method correctly encodes buffers
+Scenario: The Util encode_cobs function correctly encodes buffers
 
   GIVEN("The Util COBS::encode function")
 
   WHEN("The encoded byte vector is too small to hold the encoded data")
-    THEN("The encode_cobs method reports out_of_bounds status")
+    THEN("The encode_cobs function reports out_of_bounds status")
     THEN("The encoded buffer is empty")
 
   WHEN("The cobs::encode is called on a null byte")
-    THEN("The encode_cobs method reports ok status")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x01\x01' ")
 
   WHEN("The cobs::encode is called on a buffer that contains these bytes '0x00 0x00'")
-    THEN("The encode_cobs method reports ok status")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x01\x01\x01' ")
 
-  WHEN("The cobs::encode method is called on a buffer that contains these bytes '0x11 0x22 0x00 0x33'")
-    THEN("The encode_cobs method reports ok status")
+  WHEN("The cobs::encode function is called on a buffer that contains these bytes '0x11 0x22 0x00 0x33'")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x03\x11\x22\x02\x33'") {
 
-  WHEN("The cobs::encode method is called on a buffer that contains these bytes '\x11\x22\x33\x44'")
-    THEN("The encode_cobs method reports ok status")
+  WHEN("The cobs::encode function is called on a buffer that contains these bytes '\x11\x22\x33\x44'")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x05\x11\x22\x33\x44'")
 
-  WHEN("The cobs::encode method is called on the char 'x'")
-    THEN("The encode_cobs method reports ok status")
+  WHEN("The cobs::encode function is called on the char 'x'")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\02x'")
   
-  WHEN("The cobs::encode method is called on the char 'xy'")
-    THEN("The encode_cobs method reports ok status")
+  WHEN("The cobs::encode function is called on the char 'xy'")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\03xy'")
 
-  WHEN("The cobs::encode method is called on the string 'Hello world'")
-    THEN("The encode_cobs method reports ok status")
+  WHEN("The cobs::encode function is called on the string 'Hello world'")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x0cHello World'")
 
-  WHEN("The cobs::encode method is called on a sensor measurements message payload")
-    THEN("The encode_cobs method reports ok status")
+  WHEN("The cobs::encode function is called on a sensor measurements message payload")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected")
 
   WHEN("The cobs::encode is called on a buffer that contains these bytes '0x6e 0xd7 0xf1 0x00 0xf7 0xab' ")
-    THEN("The encode_cobs method reports ok status")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer is as expected '\x04\x6e\xd7\xf1\x03\xf7\xab' ")
 
   WHEN("The cobs::encode is called on a 253 byte buffer")
-    THEN("The encode_cobs method reports ok status")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xfe")
 
   WHEN("The cobs::encode is called on a 254 bytes buffer with last byte as a null byte")
-    THEN("The encode_cobs method reports ok status")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xfd")
 
   WHEN("The cobs::encode is called on a 254 byte buffer with no null bytes")
-    THEN("The encode_cobs method reports ok status")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xff")
 
   WHEN("The cobs::encode is called on a 255 byte buffer with no null bytes")
-    THEN("The encode_cobs method reports ok status")
+    THEN("The encode_cobs function reports ok status")
     THEN("The encoded buffer has an expected sequence of 257 bytes with first byte as 0xff")
+
+Scenario: The cobs::decode function correctly decodes encoded buffers
+
+ GIVEN("The Util COBS::decode function")
+
+  WHEN("The COBS::decode function is called on a buffer containing '0x01' as the only byte")
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is empty")    
+
+  WHEN("The COBS::decode function is called on a buffer containing '0x03' as the only byte")      
+    THEN("The decode_cobs function reports out_of_bounds status")
+    THEN("The decoded buffer is empty")
+     
+  WHEN("The COBS::decode function is called on a buffer that contains these bytes '0x05 0x02 0x03' ")    
+    THEN("The decode_cobs function reports out_of_bounds status")
+    THEN("The decoded buffer is empty")
+
+  WHEN("The COBS::decode function is called on a buffer that contains these bytes '0x05 0x02 0xff' ")    
+    THEN("The decode_cobs function reports out_of_bounds status")
+    THEN("The decoded buffer is empty")
+
+  WHEN("The COBS::decode function is called on a buffer that contains these bytes '0x02 0x02 0xff' ")    
+    THEN("The decode_cobs function reports out_of_bounds status")
+
+  WHEN("The decoded buffer is too small to hold the decoded data") {
+    THEN("The decode_cobs function reports out_of_bounds status")
+    THEN("The decoded buffer is empty")
+
+  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x01\x01'")
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is as expected '0x00'")
+
+  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x01\x01\x01'") {    
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is as expected '0x00 0x00'")
+
+  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x03\x11\x22\x02\x33'")
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is as expected '0x11 0x22 0x00 0x33'")
+
+  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x05\x11\x22\x33\x44'")
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is as expected '\x11\x22\x33\x44'")            
+
+  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x02x'") {
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is as expected 'x' ")
+
+  WHEN("The COBS::decode function is called on a buffer containing these bytes '\x03xy'")    
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is as expected 'xy' ")
+
+  WHEN("The COBS::decode function is called on a buffer containing the bytestring '\x0cHello World'")
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is as expected 'Hello World'")
+
+  WHEN("The COBS::decode function is called on a buffer containing a encoded sensor measurements message payload")
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is as expected")
+
+  WHEN("The COBS::decode function is called on a buffer that contains these bytes '0x03, 0x9c, 0xb8, 0x03, 0xbe, 0xce'")
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer is as expected '\x9c\xb8\x00\xbe\xce' ")
+
+  WHEN("The COBS::decode function is called on a encoded buffer of capacity 254 bytes whose original buffer was of capacity 253 with no null bytes")
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer has expected sequence of 253 bytes")
+
+  WHEN("The COBS::decode function is called on a encoded buffer of capacity 256 bytes whose original buffer was of capacity 254 with null byte at the end")   
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer has expected sequence of 254 bytes with last byte as null byte")    
+
+  WHEN("The COBS::decode function is called on a encoded buffer of capacity 257 bytes whose original buffer was of capacity 255 with no null bytes") 
+    THEN("The decode_cobs function reports ok status")
+    THEN("The decoded buffer has expected sequence of 255 bytes as '0xff 0x71 0xcf ......0x02 0xa2 0xd2')

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Util/cobs.txt
@@ -1,0 +1,63 @@
+Scenario: The cobs::decode method correctly decodes encoded buffers
+
+ GIVEN("The Util COBS::decode function")
+
+   WHEN("The COBS::decode method is called on a buffer containing '0x01' as the only byte")
+    THEN("The decoded size is 0")
+    THEN("The decoded buffer is emppty")
+
+   WHEN("The COBS::decode method is called on a buffer containing '0x03' as the only byte")      
+    THEN("The decoded size is 0")
+    THEN("The decoded buffer is emppty")
+     
+   WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x05 0x02 0x03' ")    
+    THEN("The decoded size is 0")
+    THEN("The decoded buffer is emppty")
+
+   WHEN("The COBS::decode method is called on a buffer that contains these bytes '0x03, 0x9c, 0xb8, 0x03, 0xbe, 0xce'")
+    THEN("The decoded size is 5")
+    THEN("The decoded buffer is as expected '\x9c\xb8\x00\xbe\xce' ")
+
+   WHEN("The COBS::decode method is called on a encoded buffer of capacity 254 bytes whose original buffer was of capacity 253 with no null bytes")
+    THEN("The decoded size is 253")   
+    THEN("The decoded buffer has expected sequence of 253 bytes")
+
+   WHEN("The COBS::decode method is called on a encoded buffer of capacity 256 bytes whose original buffer was of capacity 254 with null byte at the end")   
+    THEN("The decoded size is 254")    
+    THEN("The decoded buffer has expected sequence of 254 bytes with last byte as null byte")    
+
+   WHEN("The COBS::decode method is called on a encoded buffer of capacity 257 bytes whose original buffer was of capacity 255 with no null bytes") 
+    THEN("The decoded size is 255")
+    THEN("The decoded buffer has expected sequence of 255 bytes as '0xff 0x71 0xcf ......0x02 0xa2 0xd2')
+
+Scenario: The Util encode_cobs method correctly encodes buffers
+
+  GIVEN("The Util COBS::encode function")
+
+    WHEN("The cobs::encode is called on a null byte")
+      THEN("The encode_cobs method reports ok status")
+      THEN("The encoded buffer is as expected '\x01\x01' ")
+
+    WHEN("The cobs::encode is called on a buffer that contains these bytes '0x00 0x00'")
+      THEN("The encode_cobs method reports ok status")
+      THEN("The encoded buffer is as expected '\x01\x01\x01' ")
+
+    WHEN("The cobs::encode is called on a buffer that contains these bytes '0x6e 0xd7 0xf1 0x00 0xf7 0xab' ")
+      THEN("The encode_cobs method reports ok status")
+      THEN("The encoded buffer is as expected '\x04\x6e\xd7\xf1\x03\xf7\xab' ")
+
+    WHEN("The cobs::encode is called on a 253 byte buffer")
+      THEN("The encode_cobs method reports ok status")
+      THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xfe")
+
+    WHEN("The cobs::encode is called on a 254 bytes buffer with last byte as a null byte")
+      THEN("The encode_cobs method reports ok status")
+      THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xfd")
+
+    WHEN("The cobs::encode is called on a 254 byte buffer with no null bytes")
+      THEN("The encode_cobs method reports ok status")
+      THEN("The encoded buffer has an expected sequence of 254 bytes with first byte as 0xff")
+
+    WHEN("The cobs::encode is called on a 255 byte buffer with no null bytes")
+      THEN("The encode_cobs method reports ok status")
+      THEN("The encoded buffer has an expected sequence of 257 bytes with first byte as 0xff")


### PR DESCRIPTION
This PR: 
Updates the COBS interface:

- pass ByteVectors instead of pointers to buffers.
- return IndexStatus code instead of decode and encode sizes.
- return early if buffer is empty while decoding
- return early if resize is not possible for output encoded buffer while encoding

Updates to COBSDecoder and COBSencoder classes:
- use static asserts to check for input and output sizes ( we are doing this to avoid writing test cases )
- return IndexStatus instead of FrameProps::OutputStatus

Add test cases for Util encode_cobs and decode_cobs