### PR TITLE
FiO2 & flow alarms

### DIFF
--- a/backend/ventserver/protocols/protobuf/mcu_pb.py
+++ b/backend/ventserver/protocols/protobuf/mcu_pb.py
@@ -21,14 +21,14 @@ class LogEventCode(betterproto.Enum):
     """Log Events"""
 
     # Patient
-    fio2_too_low = 0
-    fio2_too_high = 1
-    spo2_too_low = 2
-    spo2_too_high = 3
-    rr_too_low = 4
-    rr_too_high = 5
-    hr_too_low = 6
-    hr_too_high = 7
+    spo2_too_low = 0
+    spo2_too_high = 1
+    hr_too_low = 2
+    hr_too_high = 3
+    fio2_too_low = 4
+    fio2_too_high = 5
+    flow_too_low = 6
+    flow_too_high = 7
     # System
     battery_low = 8
     screen_locked = 9
@@ -38,9 +38,10 @@ class LogEventCode(betterproto.Enum):
     fio2_setting_changed = 12
     flow_setting_changed = 13
     # Alarm Limits
-    fio2_alarm_limits_changed = 14
-    spo2_alarm_limits_changed = 15
-    hr_alarm_limits_changed = 16
+    spo2_alarm_limits_changed = 14
+    hr_alarm_limits_changed = 15
+    fio2_alarm_limits_changed = 16
+    flow_alarm_limits_changed = 17
 
 
 class LogEventType(betterproto.Enum):

--- a/backend/ventserver/protocols/protobuf/mcu_pb.py
+++ b/backend/ventserver/protocols/protobuf/mcu_pb.py
@@ -21,14 +21,14 @@ class LogEventCode(betterproto.Enum):
     """Log Events"""
 
     # Patient
-    spo2_too_low = 0
-    spo2_too_high = 1
-    hr_too_low = 2
-    hr_too_high = 3
-    fio2_too_low = 4
-    fio2_too_high = 5
-    flow_too_low = 6
-    flow_too_high = 7
+    fio2_too_low = 0
+    fio2_too_high = 1
+    flow_too_low = 2
+    flow_too_high = 3
+    spo2_too_low = 4
+    spo2_too_high = 5
+    hr_too_low = 6
+    hr_too_high = 7
     # System
     battery_low = 8
     screen_locked = 9
@@ -38,10 +38,10 @@ class LogEventCode(betterproto.Enum):
     fio2_setting_changed = 12
     flow_setting_changed = 13
     # Alarm Limits
-    spo2_alarm_limits_changed = 14
-    hr_alarm_limits_changed = 15
-    fio2_alarm_limits_changed = 16
-    flow_alarm_limits_changed = 17
+    fio2_alarm_limits_changed = 14
+    flow_alarm_limits_changed = 15
+    spo2_alarm_limits_changed = 16
+    hr_alarm_limits_changed = 17
 
 
 class LogEventType(betterproto.Enum):

--- a/backend/ventserver/protocols/protobuf/mcu_pb.py
+++ b/backend/ventserver/protocols/protobuf/mcu_pb.py
@@ -53,8 +53,8 @@ class LogEventType(betterproto.Enum):
 
 @dataclass
 class Range(betterproto.Message):
-    lower: int = betterproto.uint32_field(1)
-    upper: int = betterproto.uint32_field(2)
+    lower: int = betterproto.int32_field(1)
+    upper: int = betterproto.int32_field(2)
 
 
 @dataclass

--- a/backend/ventserver/simulation/alarm_limits.py
+++ b/backend/ventserver/simulation/alarm_limits.py
@@ -54,6 +54,7 @@ def service_limits_range(
 class Service:
     """Base class for the AlarmLimits/AlarmLimitsRequest service."""
 
+    FIO2_TOLERANCE = 2  # % FiO2
     FIO2_MIN = 21  # % FiO2
     FIO2_MAX = 100  # % FiO2
     SPO2_MIN = 0  # % SpO2
@@ -70,6 +71,14 @@ class Service:
             log_manager: log.Manager
     ) -> None:
         """Update the alarm limits."""
+        fio2_range = mcu_pb.Range(
+            lower=int(parameters.fio2 - self.FIO2_TOLERANCE),
+            upper=int(parameters.fio2 + self.FIO2_TOLERANCE)
+        )
+        service_limits_range(
+            fio2_range, response.fio2, self.FIO2_MIN, self.FIO2_MAX,
+            mcu_pb.LogEventCode.fio2_alarm_limits_changed, log_manager
+        )
         service_limits_range(
             request.spo2, response.spo2, self.SPO2_MIN, self.SPO2_MAX,
             mcu_pb.LogEventCode.spo2_alarm_limits_changed, log_manager
@@ -87,7 +96,6 @@ class PCAC(Service):
 class HFNC(Service):
     """Alarm limits servicing for HFNC mode."""
 
-    FIO2_TOLERANCE = 2  # % FiO2
     FLOW_TOLERANCE = 2  # L/min
     FLOW_MIN = 0  # L/min
     FLOW_MAX = 80  # L/min
@@ -99,14 +107,6 @@ class HFNC(Service):
     ) -> None:
         """Update the alarm limits."""
         super().transform(parameters, request, response, log_manager)
-        fio2_range = mcu_pb.Range(
-            lower=int(parameters.fio2 - self.FIO2_TOLERANCE),
-            upper=int(parameters.fio2 + self.FIO2_TOLERANCE)
-        )
-        service_limits_range(
-            fio2_range, response.fio2, self.FIO2_MIN, self.FIO2_MAX,
-            mcu_pb.LogEventCode.fio2_alarm_limits_changed, log_manager
-        )
         flow_range = mcu_pb.Range(
             lower=int(parameters.flow - self.FLOW_TOLERANCE),
             upper=int(parameters.flow + self.FLOW_TOLERANCE)

--- a/backend/ventserver/simulation/alarm_limits.py
+++ b/backend/ventserver/simulation/alarm_limits.py
@@ -62,24 +62,22 @@ def service_limits_range(
 class Service:
     """Base class for the AlarmLimits/AlarmLimitsRequest service."""
 
-    FIO2_MIN = 21
-    FIO2_MAX = 100
-    SPO2_MIN = 0
-    SPO2_MAX = 100
-    HR_MIN = 0
-    HR_MAX = 200
+    FIO2_MIN = 21  # % FiO2
+    FIO2_MAX = 100  # % FiO2
+    SPO2_MIN = 0  # % SpO2
+    SPO2_MAX = 100  # % SpO2
+    HR_MIN = 0  # bpm
+    HR_MAX = 200  # bpm
 
     # Update methods
 
     def transform(
-            self, request: mcu_pb.AlarmLimitsRequest,
-            response: mcu_pb.AlarmLimits, log_manager: log.Manager
+            self,
+            parameters: mcu_pb.Parameters,  # pylint: disable=unused-argument
+            request: mcu_pb.AlarmLimitsRequest, response: mcu_pb.AlarmLimits,
+            log_manager: log.Manager
     ) -> None:
         """Update the alarm limits."""
-        service_limits_range(
-            request.fio2, response.fio2, self.FIO2_MIN, self.FIO2_MAX,
-            mcu_pb.LogEventCode.fio2_alarm_limits_changed, log_manager
-        )
         service_limits_range(
             request.spo2, response.spo2, self.SPO2_MIN, self.SPO2_MAX,
             mcu_pb.LogEventCode.spo2_alarm_limits_changed, log_manager
@@ -96,6 +94,35 @@ class PCAC(Service):
 
 class HFNC(Service):
     """Alarm limits servicing for HFNC mode."""
+
+    FIO2_TOLERANCE = 2  # % FiO2
+    FLOW_TOLERANCE = 2  # L/min
+    FLOW_MIN = 0  # L/min
+    FLOW_MAX = 80  # L/min
+
+    def transform(
+            self, parameters: mcu_pb.Parameters,
+            request: mcu_pb.AlarmLimitsRequest, response: mcu_pb.AlarmLimits,
+            log_manager: log.Manager
+    ) -> None:
+        """Update the alarm limits."""
+        super().transform(parameters, request, response, log_manager)
+        fio2_range = mcu_pb.Range(
+            lower=int(parameters.fio2 - self.FIO2_TOLERANCE),
+            upper=int(parameters.fio2 + self.FIO2_TOLERANCE)
+        )
+        service_limits_range(
+            fio2_range, response.fio2, self.FIO2_MIN, self.FIO2_MAX,
+            mcu_pb.LogEventCode.fio2_alarm_limits_changed, log_manager
+        )
+        flow_range = mcu_pb.Range(
+            lower=int(parameters.flow - self.FLOW_TOLERANCE),
+            upper=int(parameters.flow + self.FLOW_TOLERANCE)
+        )
+        service_limits_range(
+            flow_range, response.flow, self.FLOW_MIN, self.FLOW_MAX,
+            mcu_pb.LogEventCode.flow_alarm_limits_changed, log_manager
+        )
 
 
 # Aggregation
@@ -132,4 +159,6 @@ class Services:
             return
 
         log_manager.update_clock(current_time)
-        self._active_service.transform(request, response, log_manager)
+        self._active_service.transform(
+            parameters, request, response, log_manager
+        )

--- a/backend/ventserver/simulation/alarm_limits.py
+++ b/backend/ventserver/simulation/alarm_limits.py
@@ -16,20 +16,13 @@ from ventserver.simulation import log
 # Update Functions
 
 def transform_limits_range(
-        floor: int, ceiling: int, requested_min: int, requested_max: int,
-        current_min: int, current_max: int
+        floor: int, ceiling: int, requested_min: int, requested_max: int
 ) -> Tuple[int, int]:
-    """Return requested if between floor and ceiling, or else return current."""
-    if current_min > current_max:
-        (current_min, current_max) = (current_max, current_min)
+    """Return requested, clamped between floor and ceiling."""
     if requested_min > requested_max:
         (requested_min, requested_max) = (requested_max, requested_min)
-    if not floor <= current_min <= current_max <= ceiling:
-        requested_min = min(ceiling, max(floor, requested_min))
-        requested_max = min(ceiling, max(floor, requested_max))
-    if not floor <= requested_min <= requested_max <= ceiling:
-        return (current_min, current_max)
-
+    requested_min = min(ceiling, max(floor, requested_min))
+    requested_max = min(ceiling, max(floor, requested_max))
     return (requested_min, requested_max)
 
 
@@ -40,8 +33,7 @@ def service_limits_range(
     """Handle the request's alarm limits range."""
     old_response = dataclasses.replace(response)
     (response.lower, response.upper) = transform_limits_range(
-        floor, ceiling, request.lower, request.upper,
-        response.lower, response.upper
+        floor, ceiling, request.lower, request.upper
     )
     if (
             old_response.lower == response.lower and

--- a/backend/ventserver/simulation/alarms.py
+++ b/backend/ventserver/simulation/alarms.py
@@ -98,6 +98,14 @@ class Service:
             mcu_pb.LogEventCode.hr_too_high,
             log_manager
         )
+        self.transform_parameter_alarms(
+            alarm_limits.fio2.lower, alarm_limits.fio2.upper,
+            sensor_measurements.fio2,
+            mcu_pb.LogEventCode.fio2_too_low,
+            mcu_pb.LogEventCode.fio2_too_high,
+            log_manager
+        )
+
         self._manager.transform_active_log_event_ids(active_log_events)
 
     # Update methods
@@ -157,14 +165,6 @@ class HFNC(Service):
         )
         if not parameters.ventilating:
             return
-
-        self.transform_parameter_alarms(
-            alarm_limits.fio2.lower, alarm_limits.fio2.upper,
-            sensor_measurements.fio2,
-            mcu_pb.LogEventCode.fio2_too_low,
-            mcu_pb.LogEventCode.fio2_too_high,
-            log_manager
-        )
         self.transform_parameter_alarms(
             alarm_limits.flow.lower, alarm_limits.flow.upper,
             sensor_measurements.flow,

--- a/backend/ventserver/simulation/alarms.py
+++ b/backend/ventserver/simulation/alarms.py
@@ -58,14 +58,14 @@ class Service:
     """Base class for a breathing circuit simulator."""
 
     ALARM_CODES = {
-        mcu_pb.LogEventCode.spo2_too_low,
-        mcu_pb.LogEventCode.spo2_too_high,
-        mcu_pb.LogEventCode.hr_too_low,
-        mcu_pb.LogEventCode.hr_too_high,
         mcu_pb.LogEventCode.fio2_too_low,
         mcu_pb.LogEventCode.fio2_too_high,
         mcu_pb.LogEventCode.flow_too_low,
         mcu_pb.LogEventCode.flow_too_high,
+        mcu_pb.LogEventCode.spo2_too_low,
+        mcu_pb.LogEventCode.spo2_too_high,
+        mcu_pb.LogEventCode.hr_too_low,
+        mcu_pb.LogEventCode.hr_too_high,
     }
 
     _manager: Manager = attr.ib(factory=Manager)
@@ -85,6 +85,13 @@ class Service:
             return
 
         self.transform_parameter_alarms(
+            alarm_limits.fio2.lower, alarm_limits.fio2.upper,
+            sensor_measurements.fio2,
+            mcu_pb.LogEventCode.fio2_too_low,
+            mcu_pb.LogEventCode.fio2_too_high,
+            log_manager
+        )
+        self.transform_parameter_alarms(
             alarm_limits.spo2.lower, alarm_limits.spo2.upper,
             sensor_measurements.spo2,
             mcu_pb.LogEventCode.spo2_too_low,
@@ -96,13 +103,6 @@ class Service:
             sensor_measurements.hr,
             mcu_pb.LogEventCode.hr_too_low,
             mcu_pb.LogEventCode.hr_too_high,
-            log_manager
-        )
-        self.transform_parameter_alarms(
-            alarm_limits.fio2.lower, alarm_limits.fio2.upper,
-            sensor_measurements.fio2,
-            mcu_pb.LogEventCode.fio2_too_low,
-            mcu_pb.LogEventCode.fio2_too_high,
             log_manager
         )
 

--- a/backend/ventserver/simulation/alarms.py
+++ b/backend/ventserver/simulation/alarms.py
@@ -58,14 +58,14 @@ class Service:
     """Base class for a breathing circuit simulator."""
 
     ALARM_CODES = {
-        mcu_pb.LogEventCode.fio2_too_low,
-        mcu_pb.LogEventCode.fio2_too_high,
         mcu_pb.LogEventCode.spo2_too_low,
         mcu_pb.LogEventCode.spo2_too_high,
-        mcu_pb.LogEventCode.rr_too_low,
-        mcu_pb.LogEventCode.rr_too_high,
         mcu_pb.LogEventCode.hr_too_low,
         mcu_pb.LogEventCode.hr_too_high,
+        mcu_pb.LogEventCode.fio2_too_low,
+        mcu_pb.LogEventCode.fio2_too_high,
+        mcu_pb.LogEventCode.flow_too_low,
+        mcu_pb.LogEventCode.flow_too_high,
     }
 
     _manager: Manager = attr.ib(factory=Manager)
@@ -142,6 +142,37 @@ class PCAC(Service):
 @attr.s
 class HFNC(Service):
     """Breathing circuit simulator in HFNC mode."""
+
+    def transform(
+            self, parameters: mcu_pb.Parameters,
+            alarm_limits: mcu_pb.AlarmLimits,
+            sensor_measurements: mcu_pb.SensorMeasurements,
+            active_log_events: mcu_pb.ActiveLogEvents,
+            log_manager: log.Manager
+    ) -> None:
+        """Update the simulation."""
+        super().transform(
+            parameters, alarm_limits, sensor_measurements, active_log_events,
+            log_manager
+        )
+        if not parameters.ventilating:
+            return
+
+        self.transform_parameter_alarms(
+            alarm_limits.fio2.lower, alarm_limits.fio2.upper,
+            sensor_measurements.fio2,
+            mcu_pb.LogEventCode.fio2_too_low,
+            mcu_pb.LogEventCode.fio2_too_high,
+            log_manager
+        )
+        self.transform_parameter_alarms(
+            alarm_limits.flow.lower, alarm_limits.flow.upper,
+            sensor_measurements.flow,
+            mcu_pb.LogEventCode.flow_too_low,
+            mcu_pb.LogEventCode.flow_too_high,
+            log_manager
+        )
+        self._manager.transform_active_log_event_ids(active_log_events)
 
 
 # Aggregation

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
@@ -21,24 +21,24 @@ typedef enum _VentilationMode {
 } VentilationMode;
 
 typedef enum _LogEventCode {
-    LogEventCode_spo2_too_low = 0,
-    LogEventCode_spo2_too_high = 1,
-    LogEventCode_hr_too_low = 2,
-    LogEventCode_hr_too_high = 3,
-    LogEventCode_fio2_too_low = 4,
-    LogEventCode_fio2_too_high = 5,
-    LogEventCode_flow_too_low = 6,
-    LogEventCode_flow_too_high = 7,
+    LogEventCode_fio2_too_low = 0,
+    LogEventCode_fio2_too_high = 1,
+    LogEventCode_flow_too_low = 2,
+    LogEventCode_flow_too_high = 3,
+    LogEventCode_spo2_too_low = 4,
+    LogEventCode_spo2_too_high = 5,
+    LogEventCode_hr_too_low = 6,
+    LogEventCode_hr_too_high = 7,
     LogEventCode_battery_low = 8,
     LogEventCode_screen_locked = 9,
     LogEventCode_ventilation_operation_changed = 10,
     LogEventCode_ventilation_mode_changed = 11,
     LogEventCode_fio2_setting_changed = 12,
     LogEventCode_flow_setting_changed = 13,
-    LogEventCode_spo2_alarm_limits_changed = 14,
-    LogEventCode_hr_alarm_limits_changed = 15,
-    LogEventCode_fio2_alarm_limits_changed = 16,
-    LogEventCode_flow_alarm_limits_changed = 17
+    LogEventCode_fio2_alarm_limits_changed = 14,
+    LogEventCode_flow_alarm_limits_changed = 15,
+    LogEventCode_spo2_alarm_limits_changed = 16,
+    LogEventCode_hr_alarm_limits_changed = 17
 } LogEventCode;
 
 typedef enum _LogEventType {
@@ -239,9 +239,9 @@ typedef struct _NextLogEvents {
 #define _VentilationMode_MAX VentilationMode_prvc
 #define _VentilationMode_ARRAYSIZE ((VentilationMode)(VentilationMode_prvc+1))
 
-#define _LogEventCode_MIN LogEventCode_spo2_too_low
-#define _LogEventCode_MAX LogEventCode_flow_alarm_limits_changed
-#define _LogEventCode_ARRAYSIZE ((LogEventCode)(LogEventCode_flow_alarm_limits_changed+1))
+#define _LogEventCode_MIN LogEventCode_fio2_too_low
+#define _LogEventCode_MAX LogEventCode_hr_alarm_limits_changed
+#define _LogEventCode_ARRAYSIZE ((LogEventCode)(LogEventCode_hr_alarm_limits_changed+1))
 
 #define _LogEventType_MIN LogEventType_patient
 #define _LogEventType_MAX LogEventType_alarm_limits

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
@@ -121,8 +121,8 @@ typedef struct _Ping {
 } Ping;
 
 typedef struct _Range {
-    uint32_t lower;
-    uint32_t upper;
+    int32_t lower;
+    int32_t upper;
 } Range;
 
 typedef struct _ScreenStatus {
@@ -391,8 +391,8 @@ extern "C" {
 
 /* Struct field encoding specification for nanopb */
 #define Range_FIELDLIST(X, a) \
-X(a, STATIC,   SINGULAR, UINT32,   lower,             1) \
-X(a, STATIC,   SINGULAR, UINT32,   upper,             2)
+X(a, STATIC,   SINGULAR, INT32,    lower,             1) \
+X(a, STATIC,   SINGULAR, INT32,    upper,             2)
 #define Range_CALLBACK NULL
 #define Range_DEFAULT NULL
 
@@ -627,18 +627,18 @@ extern const pb_msgdesc_t AlarmMuteRequest_msg;
 #define AlarmMuteRequest_fields &AlarmMuteRequest_msg
 
 /* Maximum encoded size of messages (where known) */
-#define Range_size                               12
-#define AlarmLimits_size                         207
-#define AlarmLimitsRequest_size                  207
+#define Range_size                               22
+#define AlarmLimits_size                         347
+#define AlarmLimitsRequest_size                  347
 #define SensorMeasurements_size                  47
 #define CycleMeasurements_size                   41
 #define Parameters_size                          50
 #define ParametersRequest_size                   50
 #define Ping_size                                17
 #define Announcement_size                        77
-#define LogEvent_size                            93
+#define LogEvent_size                            123
 #define ExpectedLogEvent_size                    6
-#define NextLogEvents_size                       208
+#define NextLogEvents_size                       268
 #define ActiveLogEvents_size                     192
 #define BatteryPower_size                        8
 #define ScreenStatus_size                        2

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
@@ -21,23 +21,24 @@ typedef enum _VentilationMode {
 } VentilationMode;
 
 typedef enum _LogEventCode {
-    LogEventCode_fio2_too_low = 0,
-    LogEventCode_fio2_too_high = 1,
-    LogEventCode_spo2_too_low = 2,
-    LogEventCode_spo2_too_high = 3,
-    LogEventCode_rr_too_low = 4,
-    LogEventCode_rr_too_high = 5,
-    LogEventCode_hr_too_low = 6,
-    LogEventCode_hr_too_high = 7,
+    LogEventCode_spo2_too_low = 0,
+    LogEventCode_spo2_too_high = 1,
+    LogEventCode_hr_too_low = 2,
+    LogEventCode_hr_too_high = 3,
+    LogEventCode_fio2_too_low = 4,
+    LogEventCode_fio2_too_high = 5,
+    LogEventCode_flow_too_low = 6,
+    LogEventCode_flow_too_high = 7,
     LogEventCode_battery_low = 8,
     LogEventCode_screen_locked = 9,
     LogEventCode_ventilation_operation_changed = 10,
     LogEventCode_ventilation_mode_changed = 11,
     LogEventCode_fio2_setting_changed = 12,
     LogEventCode_flow_setting_changed = 13,
-    LogEventCode_fio2_alarm_limits_changed = 14,
-    LogEventCode_spo2_alarm_limits_changed = 15,
-    LogEventCode_hr_alarm_limits_changed = 16
+    LogEventCode_spo2_alarm_limits_changed = 14,
+    LogEventCode_hr_alarm_limits_changed = 15,
+    LogEventCode_fio2_alarm_limits_changed = 16,
+    LogEventCode_flow_alarm_limits_changed = 17
 } LogEventCode;
 
 typedef enum _LogEventType {
@@ -238,9 +239,9 @@ typedef struct _NextLogEvents {
 #define _VentilationMode_MAX VentilationMode_prvc
 #define _VentilationMode_ARRAYSIZE ((VentilationMode)(VentilationMode_prvc+1))
 
-#define _LogEventCode_MIN LogEventCode_fio2_too_low
-#define _LogEventCode_MAX LogEventCode_hr_alarm_limits_changed
-#define _LogEventCode_ARRAYSIZE ((LogEventCode)(LogEventCode_hr_alarm_limits_changed+1))
+#define _LogEventCode_MIN LogEventCode_spo2_too_low
+#define _LogEventCode_MAX LogEventCode_flow_alarm_limits_changed
+#define _LogEventCode_ARRAYSIZE ((LogEventCode)(LogEventCode_flow_alarm_limits_changed+1))
 
 #define _LogEventType_MIN LogEventType_patient
 #define _LogEventType_MAX LogEventType_alarm_limits

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/AlarmLimitsService.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/AlarmLimitsService.h
@@ -27,11 +27,18 @@ void service_limits_range(
 
 class AlarmLimitsService {
  public:
+  static const uint8_t fio2_tolerance = 2;       // % FiO2
+  static constexpr Range allowed_fio2{21, 100};  // % SpO2
   static constexpr Range allowed_spo2{21, 100};  // % SpO2
   static constexpr Range allowed_hr{0, 200};     // bpm
-  static constexpr Range allowed_fio2{21, 100};  // % SpO2
-  static const uint8_t fio2_tolerance = 2;       // % FiO2
 
+  virtual void transform(
+      const Parameters &parameters,
+      const AlarmLimitsRequest &alarm_limits_request,
+      AlarmLimits &alarm_limits,
+      Application::LogEventsManager &log_manager);
+
+ private:
   static void service_fio2(
       const Parameters &parameters,
       AlarmLimits &response,
@@ -44,25 +51,13 @@ class AlarmLimitsService {
       const AlarmLimitsRequest &request,
       AlarmLimits &response,
       Application::LogEventsManager &log_manager);
-
-  virtual void transform(
-      const Parameters &parameters,
-      const AlarmLimitsRequest &alarm_limits_request,
-      AlarmLimits &alarm_limits,
-      Application::LogEventsManager &log_manager) = 0;
 };
 
-class PCACAlarmLimits : public AlarmLimitsService {
- public:
-  void transform(
-      const Parameters &parameters,
-      const AlarmLimitsRequest &alarm_limits_request,
-      AlarmLimits &alarm_limits,
-      Application::LogEventsManager &log_manager) override;
-};
+class PCACAlarmLimits : public AlarmLimitsService {};
 
 class HFNCAlarmLimits : public AlarmLimitsService {
  public:
+  static const uint8_t flow_tolerance = 2;  // L/min
   static constexpr Range allowed_flow{0, 80};  // L/min
 
   void transform(
@@ -72,7 +67,6 @@ class HFNCAlarmLimits : public AlarmLimitsService {
       Application::LogEventsManager &log_manager) override;
 
  private:
-  static const uint8_t flow_tolerance = 2;  // L/min
 
   static void service_flow(
       const Parameters &parameters,

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/AlarmLimitsService.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/AlarmLimitsService.h
@@ -17,7 +17,7 @@
 
 namespace Pufferfish::Driver::BreathingCircuit {
 
-Range transform_limits_range(uint32_t floor, uint32_t ceiling, Range request);
+Range transform_limits_range(int32_t floor, int32_t ceiling, Range request);
 void service_limits_range(
     Range request,
     Range &response,
@@ -27,7 +27,7 @@ void service_limits_range(
 
 class AlarmLimitsService {
  public:
-  static const uint8_t fio2_tolerance = 2;       // % FiO2
+  static const int8_t fio2_tolerance = 2;        // % FiO2
   static constexpr Range allowed_fio2{21, 100};  // % SpO2
   static constexpr Range allowed_spo2{21, 100};  // % SpO2
   static constexpr Range allowed_hr{0, 200};     // bpm
@@ -57,8 +57,8 @@ class PCACAlarmLimits : public AlarmLimitsService {};
 
 class HFNCAlarmLimits : public AlarmLimitsService {
  public:
-  static const uint8_t flow_tolerance = 2;  // L/min
-  static constexpr Range allowed_flow{0, 80};  // L/min
+  static const int8_t flow_tolerance = 2;                    // L/min
+  static constexpr Range allowed_flow{-flow_tolerance, 80};  // L/min
 
   void transform(
       const Parameters &parameters,
@@ -67,7 +67,6 @@ class HFNCAlarmLimits : public AlarmLimitsService {
       Application::LogEventsManager &log_manager) override;
 
  private:
-
   static void service_flow(
       const Parameters &parameters,
       AlarmLimits &response,

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Alarms.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/Alarms.h
@@ -20,14 +20,14 @@ namespace Pufferfish::Driver::BreathingCircuit {
 
 // All alarm codes need to be registered in the following array:
 static constexpr auto alarm_codes = Util::make_array<LogEventCode>(
-    LogEventCode::LogEventCode_fio2_too_low,
-    LogEventCode::LogEventCode_fio2_too_high,
     LogEventCode::LogEventCode_spo2_too_low,
     LogEventCode::LogEventCode_spo2_too_high,
-    LogEventCode::LogEventCode_rr_too_low,
-    LogEventCode::LogEventCode_rr_too_high,
     LogEventCode::LogEventCode_hr_too_low,
-    LogEventCode::LogEventCode_hr_too_high);
+    LogEventCode::LogEventCode_hr_too_high,
+    LogEventCode::LogEventCode_fio2_too_low,
+    LogEventCode::LogEventCode_fio2_too_high,
+    LogEventCode::LogEventCode_flow_too_low,
+    LogEventCode::LogEventCode_flow_too_high);
 
 class AlarmsManager {
  public:
@@ -51,7 +51,7 @@ class AlarmsService {
       LogEventCode too_high_code,
       AlarmsManager &alarms_manager);
 
-  static void transform(
+  virtual void transform(
       const Parameters &parameters,
       const AlarmLimits &alarm_limits,
       const SensorMeasurements &sensor_measurements,
@@ -63,7 +63,15 @@ class AlarmsService {
 
 class PCACAlarms : public AlarmsService {};
 
-class HFNCAlarms : public AlarmsService {};
+class HFNCAlarms : public AlarmsService {
+ public:
+  void transform(
+      const Parameters &parameters,
+      const AlarmLimits &alarm_limits,
+      const SensorMeasurements &sensor_measurements,
+      ActiveLogEvents &active_log_events,
+      AlarmsManager &alarms_manager) override;
+};
 
 class AlarmsServices {
  public:

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/AlarmLimitsService.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/AlarmLimitsService.cpp
@@ -13,7 +13,7 @@ namespace Pufferfish::Driver::BreathingCircuit {
 
 // Update functions
 
-Range transform_limits_range(uint32_t floor, uint32_t ceiling, Range request) {
+Range transform_limits_range(int32_t floor, int32_t ceiling, Range request) {
   if (request.lower > request.upper) {
     std::swap(request.lower, request.upper);
   }
@@ -159,7 +159,7 @@ void make_state_initializers(Application::StateSegment &request_segment, AlarmLi
   response.fio2.upper = response.fio2.lower + AlarmLimitsService::fio2_tolerance;
   response.has_flow = true;
   response.flow.lower = HFNCAlarmLimits::allowed_flow.lower;
-  response.flow.upper = response.flow.lower + HFNCAlarmLimits::flow_tolerance;
+  response.flow.upper = response.flow.lower + 2 * HFNCAlarmLimits::flow_tolerance;
   response.has_spo2 = true;
   response.spo2 = AlarmLimitsService::allowed_spo2;
   response.has_hr = true;

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/AlarmLimitsService.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/AlarmLimitsService.cpp
@@ -13,24 +13,13 @@ namespace Pufferfish::Driver::BreathingCircuit {
 
 // Update functions
 
-Range transform_limits_range(uint32_t floor, uint32_t ceiling, Range request, Range current) {
-  if (current.lower > current.upper) {
-    std::swap(current.lower, current.upper);
-  }
+Range transform_limits_range(uint32_t floor, uint32_t ceiling, Range request) {
   if (request.lower > request.upper) {
     std::swap(request.lower, request.upper);
   }
-  if (!Util::within(current.lower, floor, current.upper) ||
-      !Util::within(current.upper, current.lower, ceiling)) {
-    request.lower = Util::clamp(request.lower, floor, ceiling);
-    request.upper = Util::clamp(request.upper, floor, ceiling);
-  }
-  if (Util::within(request.lower, floor, request.upper) &&
-      Util::within(request.upper, request.lower, ceiling)) {
-    return request;
-  }
-
-  return current;
+  request.lower = Util::clamp(request.lower, floor, ceiling);
+  request.upper = Util::clamp(request.upper, floor, ceiling);
+  return request;
 }
 
 void service_limits_range(
@@ -41,7 +30,7 @@ void service_limits_range(
     Application::LogEventsManager &log_manager) {
   Range old_response;
   old_response = response;
-  response = transform_limits_range(allowed.lower, allowed.upper, request, response);
+  response = transform_limits_range(allowed.lower, allowed.upper, request);
   if (old_response.lower == response.lower && old_response.upper == response.upper) {
     return;
   }
@@ -59,11 +48,14 @@ void service_limits_range(
 // AlarmLimitsService
 
 void AlarmLimitsService::service_fio2(
-    const AlarmLimitsRequest &request,
+    const Parameters &parameters,
     AlarmLimits &response,
     Application::LogEventsManager &log_manager) {
+  Range fio2_range{};
+  fio2_range.lower = parameters.fio2 - fio2_tolerance;
+  fio2_range.upper = parameters.fio2 + fio2_tolerance;
   service_limits_range(
-      request.fio2,
+      fio2_range,
       response.fio2,
       allowed_fio2,
       LogEventCode::LogEventCode_fio2_alarm_limits_changed,
@@ -100,23 +92,42 @@ void AlarmLimitsService::service_hr(
 // PCAC AlarmLimits
 
 void PCACAlarmLimits::transform(
+    const Parameters &parameters,
     const AlarmLimitsRequest &alarm_limits_request,
     AlarmLimits &alarm_limits,
     Application::LogEventsManager &log_manager) {
-  service_fio2(alarm_limits_request, alarm_limits, log_manager);
   service_spo2(alarm_limits_request, alarm_limits, log_manager);
   service_hr(alarm_limits_request, alarm_limits, log_manager);
+  service_fio2(parameters, alarm_limits, log_manager);
 }
 
 // HFNC AlarmLimits
 
 void HFNCAlarmLimits::transform(
+    const Parameters &parameters,
     const AlarmLimitsRequest &alarm_limits_request,
     AlarmLimits &alarm_limits,
     Application::LogEventsManager &log_manager) {
-  service_fio2(alarm_limits_request, alarm_limits, log_manager);
   service_spo2(alarm_limits_request, alarm_limits, log_manager);
   service_hr(alarm_limits_request, alarm_limits, log_manager);
+  service_fio2(parameters, alarm_limits, log_manager);
+  service_flow(parameters, alarm_limits, log_manager);
+}
+
+void HFNCAlarmLimits::service_flow(
+    const Parameters &parameters,
+    AlarmLimits &response,
+    Application::LogEventsManager &log_manager) {
+  Range flow_range{};
+  flow_range.lower = parameters.flow - fio2_tolerance;
+  flow_range.upper = parameters.flow + fio2_tolerance;
+  service_limits_range(
+      flow_range,
+      response.flow,
+      allowed_flow,
+      LogEventCode::LogEventCode_flow_alarm_limits_changed,
+      log_manager);
+  response.has_flow = true;
 }
 
 // AlarmLimitsServices
@@ -141,26 +152,30 @@ void AlarmLimitsServices::transform(
     return;
   }
 
-  active_service_->transform(alarm_limits_request, alarm_limits, log_manager);
+  active_service_->transform(parameters, alarm_limits_request, alarm_limits, log_manager);
 }
 
 // Initializers
 
 void make_state_initializers(Application::StateSegment &request_segment, AlarmLimits &response) {
-  response.has_fio2 = true;
-  response.fio2 = allowed_fio2;
   response.has_spo2 = true;
   response.spo2 = AlarmLimitsService::allowed_spo2;
   response.has_hr = true;
   response.hr = AlarmLimitsService::allowed_hr;
+  response.has_fio2 = true;
+  response.fio2 = allowed_fio2;
+  response.has_flow = true;
+  response.flow = HFNCAlarmLimits::allowed_flow;
 
   AlarmLimitsRequest request{};
-  request.has_fio2 = true;
-  request.fio2 = response.fio2;
   request.has_spo2 = true;
   request.spo2 = response.spo2;
   request.has_hr = true;
   request.hr = response.hr;
+  request.has_fio2 = true;
+  request.fio2 = response.fio2;
+  request.has_flow = true;
+  request.flow = response.flow;
   request_segment.set(request);
 }
 

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Alarms.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/Alarms.cpp
@@ -76,7 +76,7 @@ void AlarmsService::transform(
     ActiveLogEvents &active_log_events,
     AlarmsManager &alarms_manager) {
   if (!parameters.ventilating) {
-    // TODO(lietk12): deactivate all breathing circuit alarms
+    deactivate_alarms(active_log_events, alarms_manager);
     return;
   }
 
@@ -92,6 +92,12 @@ void AlarmsService::transform(
       LogEventCode::LogEventCode_hr_too_low,
       LogEventCode::LogEventCode_hr_too_high,
       alarms_manager);
+  check_parameter(
+      alarm_limits.fio2,
+      sensor_measurements.fio2,
+      LogEventCode::LogEventCode_fio2_too_low,
+      LogEventCode::LogEventCode_fio2_too_high,
+      alarms_manager);
 
   alarms_manager.transform(active_log_events);
 }
@@ -101,6 +107,30 @@ void AlarmsService::deactivate_alarms(
   for (size_t i = 0; i < alarm_codes.max_size(); ++i) {
     alarms_manager.deactivate_alarm(alarm_codes[i]);
   }
+  alarms_manager.transform(active_log_events);
+}
+
+// HFNCAlarms
+
+void HFNCAlarms::transform(
+    const Parameters &parameters,
+    const AlarmLimits &alarm_limits,
+    const SensorMeasurements &sensor_measurements,
+    ActiveLogEvents &active_log_events,
+    AlarmsManager &alarms_manager) {
+  AlarmsService::transform(
+      parameters, alarm_limits, sensor_measurements, active_log_events, alarms_manager);
+  if (!parameters.ventilating) {
+    return;
+  }
+
+  check_parameter(
+      alarm_limits.flow,
+      sensor_measurements.flow,
+      LogEventCode::LogEventCode_flow_too_low,
+      LogEventCode::LogEventCode_flow_too_high,
+      alarms_manager);
+
   alarms_manager.transform(active_log_events);
 }
 

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/ParametersService.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/ParametersService.cpp
@@ -142,8 +142,8 @@ void HFNCParameters::transform(
   }
 
   service_ventilating(parameters_request.ventilating, parameters.ventilating, log_manager);
-  service_flow(parameters_request.flow, parameters.flow, log_manager);
   service_fio2(parameters_request.fio2, parameters.fio2, log_manager);
+  service_flow(parameters_request.flow, parameters.flow, log_manager);
 }
 
 bool HFNCParameters::mode_active(const Parameters &parameters) const {

--- a/frontend/src/modules/info/units.ts
+++ b/frontend/src/modules/info/units.ts
@@ -1,5 +1,5 @@
 // Rates
-export const BMIN = 'b/min';
+// export const BMIN = 'b/min';
 export const BPM = 'BPM';
 export const LMIN = 'L/min';
 // Pressure

--- a/frontend/src/modules/info/units.ts
+++ b/frontend/src/modules/info/units.ts
@@ -1,5 +1,5 @@
 // Rates
-// export const BMIN = 'b/min';
+export const BMIN = 'b/min';
 export const BPM = 'BPM';
 export const LMIN = 'L/min';
 // Pressure

--- a/frontend/src/modules/logs/EventType.tsx
+++ b/frontend/src/modules/logs/EventType.tsx
@@ -45,6 +45,34 @@ export const getEventDetails = (event: LogEvent, eventType: EventType): string =
 export const getEventType = (code: LogEventCode): EventType => {
   switch (code) {
     // Patient
+    case LogEventCode.spo2_too_low:
+      return {
+        type: LogEventType.patient,
+        label: 'SpO2 is too low',
+        stateKey: 'spo2',
+        unit: PERCENT,
+      };
+    case LogEventCode.spo2_too_high:
+      return {
+        type: LogEventType.patient,
+        label: 'SpO2 is too high',
+        stateKey: 'spo2',
+        unit: PERCENT,
+      };
+    case LogEventCode.hr_too_low:
+      return {
+        type: LogEventType.patient,
+        label: 'Heart Rate is too low',
+        stateKey: 'hr',
+        unit: BPM,
+      };
+    case LogEventCode.hr_too_high:
+      return {
+        type: LogEventType.patient,
+        label: 'Heart Rate is too high',
+        stateKey: 'hr',
+        unit: BPM,
+      };
     case LogEventCode.fio2_too_low:
       return {
         type: LogEventType.patient,
@@ -61,47 +89,19 @@ export const getEventType = (code: LogEventCode): EventType => {
         stateKey: 'fio2',
         unit: PERCENT,
       };
-    case LogEventCode.spo2_too_low:
+    case LogEventCode.flow_too_low:
       return {
         type: LogEventType.patient,
-        label: 'SpO2 is too low',
-        stateKey: 'spo2',
-        unit: PERCENT,
+        label: 'Flow Rate is too low',
+        stateKey: 'flow',
+        unit: LMIN,
       };
-    case LogEventCode.spo2_too_high:
+    case LogEventCode.flow_too_high:
       return {
         type: LogEventType.patient,
-        label: 'SpO2 is too high',
-        stateKey: 'spo2',
-        unit: PERCENT,
-      };
-    case LogEventCode.rr_too_low:
-      return {
-        type: LogEventType.patient,
-        label: 'Respiratory Rate is too low',
-        stateKey: 'rr',
-        unit: BMIN,
-      };
-    case LogEventCode.rr_too_high:
-      return {
-        type: LogEventType.patient,
-        label: 'Respiratory Rate is too high',
-        stateKey: 'rr',
-        unit: BMIN,
-      };
-    case LogEventCode.hr_too_low:
-      return {
-        type: LogEventType.patient,
-        label: 'Heart Rate is too low',
-        stateKey: 'hr',
-        unit: BPM,
-      };
-    case LogEventCode.hr_too_high:
-      return {
-        type: LogEventType.patient,
-        label: 'Heart Rate is too high',
-        stateKey: 'hr',
-        unit: BPM,
+        label: 'Flow Rate is too high',
+        stateKey: 'flow',
+        unit: LMIN,
       };
     // System
     case BACKEND_CONNECTION_LOST_CODE:
@@ -152,13 +152,6 @@ export const getEventType = (code: LogEventCode): EventType => {
         unit: LMIN,
       };
     // Alarm Limits
-    case LogEventCode.fio2_alarm_limits_changed:
-      return {
-        type: LogEventType.alarm_limits,
-        label: 'FiO2 limits changed',
-        stateKey: 'FiO2',
-        unit: PERCENT,
-      };
     case LogEventCode.spo2_alarm_limits_changed:
       return {
         type: LogEventType.alarm_limits,
@@ -172,6 +165,20 @@ export const getEventType = (code: LogEventCode): EventType => {
         label: 'Heart Rate limits changed',
         stateKey: 'HR',
         unit: BPM,
+      };
+    case LogEventCode.fio2_alarm_limits_changed:
+      return {
+        type: LogEventType.alarm_limits,
+        label: 'FiO2 limits changed',
+        stateKey: 'FiO2',
+        unit: PERCENT,
+      };
+    case LogEventCode.flow_alarm_limits_changed:
+      return {
+        type: LogEventType.alarm_limits,
+        label: 'Flow limits changed',
+        stateKey: 'Flow',
+        unit: PERCENT,
       };
     default:
       return { type: LogEventType.system, label: '', unit: '' };

--- a/frontend/src/modules/logs/EventType.tsx
+++ b/frontend/src/modules/logs/EventType.tsx
@@ -1,6 +1,6 @@
 import { LogEvent, LogEventCode, LogEventType } from '../../store/controller/proto/mcu_pb';
 import { BACKEND_CONNECTION_LOST_CODE } from '../../store/controller/types';
-import { PERCENT, BMIN, BPM, LMIN } from '../info/units';
+import { PERCENT, BPM, LMIN } from '../info/units';
 
 export interface EventType {
   type: LogEventType;
@@ -45,6 +45,22 @@ export const getEventDetails = (event: LogEvent, eventType: EventType): string =
 export const getEventType = (code: LogEventCode): EventType => {
   switch (code) {
     // Patient
+    case LogEventCode.fio2_too_low:
+      return {
+        type: LogEventType.patient,
+        label: 'FiO2 is too low',
+        head: 'FiO2',
+        stateKey: 'fio2',
+        unit: PERCENT,
+      };
+    case LogEventCode.fio2_too_high:
+      return {
+        type: LogEventType.patient,
+        label: 'FiO2 is too high',
+        head: 'FiO2',
+        stateKey: 'fio2',
+        unit: PERCENT,
+      };
     case LogEventCode.spo2_too_low:
       return {
         type: LogEventType.patient,
@@ -72,22 +88,6 @@ export const getEventType = (code: LogEventCode): EventType => {
         label: 'Heart Rate is too high',
         stateKey: 'hr',
         unit: BPM,
-      };
-    case LogEventCode.fio2_too_low:
-      return {
-        type: LogEventType.patient,
-        label: 'FiO2 is too low',
-        head: 'FiO2',
-        stateKey: 'fio2',
-        unit: PERCENT,
-      };
-    case LogEventCode.fio2_too_high:
-      return {
-        type: LogEventType.patient,
-        label: 'FiO2 is too high',
-        head: 'FiO2',
-        stateKey: 'fio2',
-        unit: PERCENT,
       };
     case LogEventCode.flow_too_low:
       return {
@@ -152,20 +152,6 @@ export const getEventType = (code: LogEventCode): EventType => {
         unit: LMIN,
       };
     // Alarm Limits
-    case LogEventCode.spo2_alarm_limits_changed:
-      return {
-        type: LogEventType.alarm_limits,
-        label: 'SpO2 limits changed',
-        stateKey: 'SpO2',
-        unit: PERCENT,
-      };
-    case LogEventCode.hr_alarm_limits_changed:
-      return {
-        type: LogEventType.alarm_limits,
-        label: 'Heart Rate limits changed',
-        stateKey: 'HR',
-        unit: BPM,
-      };
     case LogEventCode.fio2_alarm_limits_changed:
       return {
         type: LogEventType.alarm_limits,
@@ -179,6 +165,20 @@ export const getEventType = (code: LogEventCode): EventType => {
         label: 'Flow limits changed',
         stateKey: 'Flow',
         unit: PERCENT,
+      };
+    case LogEventCode.spo2_alarm_limits_changed:
+      return {
+        type: LogEventType.alarm_limits,
+        label: 'SpO2 limits changed',
+        stateKey: 'SpO2',
+        unit: PERCENT,
+      };
+    case LogEventCode.hr_alarm_limits_changed:
+      return {
+        type: LogEventType.alarm_limits,
+        label: 'Heart Rate limits changed',
+        stateKey: 'HR',
+        unit: BPM,
       };
     default:
       return { type: LogEventType.system, label: '', unit: '' };

--- a/frontend/src/store/controller/proto/mcu_pb.ts
+++ b/frontend/src/store/controller/proto/mcu_pb.ts
@@ -398,10 +398,10 @@ const baseRange: object = { lower: 0, upper: 0 };
 export const Range = {
   encode(message: Range, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.lower !== 0) {
-      writer.uint32(8).uint32(message.lower);
+      writer.uint32(8).int32(message.lower);
     }
     if (message.upper !== 0) {
-      writer.uint32(16).uint32(message.upper);
+      writer.uint32(16).int32(message.upper);
     }
     return writer;
   },
@@ -414,10 +414,10 @@ export const Range = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.lower = reader.uint32();
+          message.lower = reader.int32();
           break;
         case 2:
-          message.upper = reader.uint32();
+          message.upper = reader.int32();
           break;
         default:
           reader.skipType(tag & 7);

--- a/frontend/src/store/controller/proto/mcu_pb.ts
+++ b/frontend/src/store/controller/proto/mcu_pb.ts
@@ -68,15 +68,15 @@ export function ventilationModeToJSON(object: VentilationMode): string {
 
 /** Log Events */
 export enum LogEventCode {
-  /** fio2_too_low - Patient */
-  fio2_too_low = 0,
-  fio2_too_high = 1,
-  spo2_too_low = 2,
-  spo2_too_high = 3,
-  rr_too_low = 4,
-  rr_too_high = 5,
-  hr_too_low = 6,
-  hr_too_high = 7,
+  /** spo2_too_low - Patient */
+  spo2_too_low = 0,
+  spo2_too_high = 1,
+  hr_too_low = 2,
+  hr_too_high = 3,
+  fio2_too_low = 4,
+  fio2_too_high = 5,
+  flow_too_low = 6,
+  flow_too_high = 7,
   /** battery_low - System */
   battery_low = 8,
   screen_locked = 9,
@@ -85,39 +85,40 @@ export enum LogEventCode {
   ventilation_mode_changed = 11,
   fio2_setting_changed = 12,
   flow_setting_changed = 13,
-  /** fio2_alarm_limits_changed - Alarm Limits */
-  fio2_alarm_limits_changed = 14,
-  spo2_alarm_limits_changed = 15,
-  hr_alarm_limits_changed = 16,
+  /** spo2_alarm_limits_changed - Alarm Limits */
+  spo2_alarm_limits_changed = 14,
+  hr_alarm_limits_changed = 15,
+  fio2_alarm_limits_changed = 16,
+  flow_alarm_limits_changed = 17,
   UNRECOGNIZED = -1,
 }
 
 export function logEventCodeFromJSON(object: any): LogEventCode {
   switch (object) {
     case 0:
-    case "fio2_too_low":
-      return LogEventCode.fio2_too_low;
-    case 1:
-    case "fio2_too_high":
-      return LogEventCode.fio2_too_high;
-    case 2:
     case "spo2_too_low":
       return LogEventCode.spo2_too_low;
-    case 3:
+    case 1:
     case "spo2_too_high":
       return LogEventCode.spo2_too_high;
-    case 4:
-    case "rr_too_low":
-      return LogEventCode.rr_too_low;
-    case 5:
-    case "rr_too_high":
-      return LogEventCode.rr_too_high;
-    case 6:
+    case 2:
     case "hr_too_low":
       return LogEventCode.hr_too_low;
-    case 7:
+    case 3:
     case "hr_too_high":
       return LogEventCode.hr_too_high;
+    case 4:
+    case "fio2_too_low":
+      return LogEventCode.fio2_too_low;
+    case 5:
+    case "fio2_too_high":
+      return LogEventCode.fio2_too_high;
+    case 6:
+    case "flow_too_low":
+      return LogEventCode.flow_too_low;
+    case 7:
+    case "flow_too_high":
+      return LogEventCode.flow_too_high;
     case 8:
     case "battery_low":
       return LogEventCode.battery_low;
@@ -137,14 +138,17 @@ export function logEventCodeFromJSON(object: any): LogEventCode {
     case "flow_setting_changed":
       return LogEventCode.flow_setting_changed;
     case 14:
-    case "fio2_alarm_limits_changed":
-      return LogEventCode.fio2_alarm_limits_changed;
-    case 15:
     case "spo2_alarm_limits_changed":
       return LogEventCode.spo2_alarm_limits_changed;
-    case 16:
+    case 15:
     case "hr_alarm_limits_changed":
       return LogEventCode.hr_alarm_limits_changed;
+    case 16:
+    case "fio2_alarm_limits_changed":
+      return LogEventCode.fio2_alarm_limits_changed;
+    case 17:
+    case "flow_alarm_limits_changed":
+      return LogEventCode.flow_alarm_limits_changed;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -154,22 +158,22 @@ export function logEventCodeFromJSON(object: any): LogEventCode {
 
 export function logEventCodeToJSON(object: LogEventCode): string {
   switch (object) {
-    case LogEventCode.fio2_too_low:
-      return "fio2_too_low";
-    case LogEventCode.fio2_too_high:
-      return "fio2_too_high";
     case LogEventCode.spo2_too_low:
       return "spo2_too_low";
     case LogEventCode.spo2_too_high:
       return "spo2_too_high";
-    case LogEventCode.rr_too_low:
-      return "rr_too_low";
-    case LogEventCode.rr_too_high:
-      return "rr_too_high";
     case LogEventCode.hr_too_low:
       return "hr_too_low";
     case LogEventCode.hr_too_high:
       return "hr_too_high";
+    case LogEventCode.fio2_too_low:
+      return "fio2_too_low";
+    case LogEventCode.fio2_too_high:
+      return "fio2_too_high";
+    case LogEventCode.flow_too_low:
+      return "flow_too_low";
+    case LogEventCode.flow_too_high:
+      return "flow_too_high";
     case LogEventCode.battery_low:
       return "battery_low";
     case LogEventCode.screen_locked:
@@ -182,12 +186,14 @@ export function logEventCodeToJSON(object: LogEventCode): string {
       return "fio2_setting_changed";
     case LogEventCode.flow_setting_changed:
       return "flow_setting_changed";
-    case LogEventCode.fio2_alarm_limits_changed:
-      return "fio2_alarm_limits_changed";
     case LogEventCode.spo2_alarm_limits_changed:
       return "spo2_alarm_limits_changed";
     case LogEventCode.hr_alarm_limits_changed:
       return "hr_alarm_limits_changed";
+    case LogEventCode.fio2_alarm_limits_changed:
+      return "fio2_alarm_limits_changed";
+    case LogEventCode.flow_alarm_limits_changed:
+      return "flow_alarm_limits_changed";
     default:
       return "UNKNOWN";
   }

--- a/frontend/src/store/controller/proto/mcu_pb.ts
+++ b/frontend/src/store/controller/proto/mcu_pb.ts
@@ -68,15 +68,15 @@ export function ventilationModeToJSON(object: VentilationMode): string {
 
 /** Log Events */
 export enum LogEventCode {
-  /** spo2_too_low - Patient */
-  spo2_too_low = 0,
-  spo2_too_high = 1,
-  hr_too_low = 2,
-  hr_too_high = 3,
-  fio2_too_low = 4,
-  fio2_too_high = 5,
-  flow_too_low = 6,
-  flow_too_high = 7,
+  /** fio2_too_low - Patient */
+  fio2_too_low = 0,
+  fio2_too_high = 1,
+  flow_too_low = 2,
+  flow_too_high = 3,
+  spo2_too_low = 4,
+  spo2_too_high = 5,
+  hr_too_low = 6,
+  hr_too_high = 7,
   /** battery_low - System */
   battery_low = 8,
   screen_locked = 9,
@@ -85,40 +85,40 @@ export enum LogEventCode {
   ventilation_mode_changed = 11,
   fio2_setting_changed = 12,
   flow_setting_changed = 13,
-  /** spo2_alarm_limits_changed - Alarm Limits */
-  spo2_alarm_limits_changed = 14,
-  hr_alarm_limits_changed = 15,
-  fio2_alarm_limits_changed = 16,
-  flow_alarm_limits_changed = 17,
+  /** fio2_alarm_limits_changed - Alarm Limits */
+  fio2_alarm_limits_changed = 14,
+  flow_alarm_limits_changed = 15,
+  spo2_alarm_limits_changed = 16,
+  hr_alarm_limits_changed = 17,
   UNRECOGNIZED = -1,
 }
 
 export function logEventCodeFromJSON(object: any): LogEventCode {
   switch (object) {
     case 0:
-    case "spo2_too_low":
-      return LogEventCode.spo2_too_low;
-    case 1:
-    case "spo2_too_high":
-      return LogEventCode.spo2_too_high;
-    case 2:
-    case "hr_too_low":
-      return LogEventCode.hr_too_low;
-    case 3:
-    case "hr_too_high":
-      return LogEventCode.hr_too_high;
-    case 4:
     case "fio2_too_low":
       return LogEventCode.fio2_too_low;
-    case 5:
+    case 1:
     case "fio2_too_high":
       return LogEventCode.fio2_too_high;
-    case 6:
+    case 2:
     case "flow_too_low":
       return LogEventCode.flow_too_low;
-    case 7:
+    case 3:
     case "flow_too_high":
       return LogEventCode.flow_too_high;
+    case 4:
+    case "spo2_too_low":
+      return LogEventCode.spo2_too_low;
+    case 5:
+    case "spo2_too_high":
+      return LogEventCode.spo2_too_high;
+    case 6:
+    case "hr_too_low":
+      return LogEventCode.hr_too_low;
+    case 7:
+    case "hr_too_high":
+      return LogEventCode.hr_too_high;
     case 8:
     case "battery_low":
       return LogEventCode.battery_low;
@@ -138,17 +138,17 @@ export function logEventCodeFromJSON(object: any): LogEventCode {
     case "flow_setting_changed":
       return LogEventCode.flow_setting_changed;
     case 14:
-    case "spo2_alarm_limits_changed":
-      return LogEventCode.spo2_alarm_limits_changed;
-    case 15:
-    case "hr_alarm_limits_changed":
-      return LogEventCode.hr_alarm_limits_changed;
-    case 16:
     case "fio2_alarm_limits_changed":
       return LogEventCode.fio2_alarm_limits_changed;
-    case 17:
+    case 15:
     case "flow_alarm_limits_changed":
       return LogEventCode.flow_alarm_limits_changed;
+    case 16:
+    case "spo2_alarm_limits_changed":
+      return LogEventCode.spo2_alarm_limits_changed;
+    case 17:
+    case "hr_alarm_limits_changed":
+      return LogEventCode.hr_alarm_limits_changed;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -158,14 +158,6 @@ export function logEventCodeFromJSON(object: any): LogEventCode {
 
 export function logEventCodeToJSON(object: LogEventCode): string {
   switch (object) {
-    case LogEventCode.spo2_too_low:
-      return "spo2_too_low";
-    case LogEventCode.spo2_too_high:
-      return "spo2_too_high";
-    case LogEventCode.hr_too_low:
-      return "hr_too_low";
-    case LogEventCode.hr_too_high:
-      return "hr_too_high";
     case LogEventCode.fio2_too_low:
       return "fio2_too_low";
     case LogEventCode.fio2_too_high:
@@ -174,6 +166,14 @@ export function logEventCodeToJSON(object: LogEventCode): string {
       return "flow_too_low";
     case LogEventCode.flow_too_high:
       return "flow_too_high";
+    case LogEventCode.spo2_too_low:
+      return "spo2_too_low";
+    case LogEventCode.spo2_too_high:
+      return "spo2_too_high";
+    case LogEventCode.hr_too_low:
+      return "hr_too_low";
+    case LogEventCode.hr_too_high:
+      return "hr_too_high";
     case LogEventCode.battery_low:
       return "battery_low";
     case LogEventCode.screen_locked:
@@ -186,14 +186,14 @@ export function logEventCodeToJSON(object: LogEventCode): string {
       return "fio2_setting_changed";
     case LogEventCode.flow_setting_changed:
       return "flow_setting_changed";
-    case LogEventCode.spo2_alarm_limits_changed:
-      return "spo2_alarm_limits_changed";
-    case LogEventCode.hr_alarm_limits_changed:
-      return "hr_alarm_limits_changed";
     case LogEventCode.fio2_alarm_limits_changed:
       return "fio2_alarm_limits_changed";
     case LogEventCode.flow_alarm_limits_changed:
       return "flow_alarm_limits_changed";
+    case LogEventCode.spo2_alarm_limits_changed:
+      return "spo2_alarm_limits_changed";
+    case LogEventCode.hr_alarm_limits_changed:
+      return "hr_alarm_limits_changed";
     default:
       return "UNKNOWN";
   }

--- a/frontend/src/store/controller/reducers/components.ts
+++ b/frontend/src/store/controller/reducers/components.ts
@@ -88,11 +88,8 @@ export const parametersRequestStanbyReducer = (
   state: { parameters: ParametersRequest } = {
     parameters: ParametersRequest.fromJSON({
       mode: VentilationMode.hfnc,
-      pip: 30,
-      peep: 0,
-      rr: 30,
-      ie: 1.0,
-      fio2: 21.0,
+      fio2: 80.0,
+      flow: 30,
     }),
   } as { parameters: ParametersRequest },
   action: commitAction,
@@ -170,11 +167,8 @@ export const withRequestUpdate = <T>(state: T, action: commitAction, prefix: str
 export const parametersRequestReducer = (
   state: ParametersRequest = ParametersRequest.fromJSON({
     mode: VentilationMode.hfnc,
-    pip: 30,
-    peep: 0,
-    rr: 30,
-    ie: 1.0,
     fio2: 21.0,
+    flow: 0,
     ventilating: false,
   }) as ParametersRequest,
   action: StateUpdateAction | ParameterCommitAction,

--- a/proto/mcu_pb.proto
+++ b/proto/mcu_pb.proto
@@ -113,14 +113,14 @@ message Announcement {
 // Log Events
 enum LogEventCode {
   // Patient
-  spo2_too_low = 0;
-  spo2_too_high = 1;
-  hr_too_low = 2;
-  hr_too_high = 3;
-  fio2_too_low = 4;
-  fio2_too_high = 5;
-  flow_too_low = 6;
-  flow_too_high = 7;
+  fio2_too_low = 0;
+  fio2_too_high = 1;
+  flow_too_low = 2;
+  flow_too_high = 3;
+  spo2_too_low = 4;
+  spo2_too_high = 5;
+  hr_too_low = 6;
+  hr_too_high = 7;
   // System
   battery_low = 8;
   screen_locked = 9;
@@ -130,10 +130,10 @@ enum LogEventCode {
   fio2_setting_changed = 12;
   flow_setting_changed = 13;
   // Alarm Limits
-  spo2_alarm_limits_changed = 14;
-  hr_alarm_limits_changed = 15;
-  fio2_alarm_limits_changed = 16;
-  flow_alarm_limits_changed = 17;
+  fio2_alarm_limits_changed = 14;
+  flow_alarm_limits_changed = 15;
+  spo2_alarm_limits_changed = 16;
+  hr_alarm_limits_changed = 17;
 }
 
 enum LogEventType {

--- a/proto/mcu_pb.proto
+++ b/proto/mcu_pb.proto
@@ -113,14 +113,14 @@ message Announcement {
 // Log Events
 enum LogEventCode {
   // Patient
-  fio2_too_low = 0;
-  fio2_too_high = 1;
-  spo2_too_low = 2;
-  spo2_too_high = 3;
-  rr_too_low = 4;
-  rr_too_high = 5;
-  hr_too_low = 6;
-  hr_too_high = 7;
+  spo2_too_low = 0;
+  spo2_too_high = 1;
+  hr_too_low = 2;
+  hr_too_high = 3;
+  fio2_too_low = 4;
+  fio2_too_high = 5;
+  flow_too_low = 6;
+  flow_too_high = 7;
   // System
   battery_low = 8;
   screen_locked = 9;
@@ -130,9 +130,10 @@ enum LogEventCode {
   fio2_setting_changed = 12;
   flow_setting_changed = 13;
   // Alarm Limits
-  fio2_alarm_limits_changed = 14;
-  spo2_alarm_limits_changed = 15;
-  hr_alarm_limits_changed = 16;
+  spo2_alarm_limits_changed = 14;
+  hr_alarm_limits_changed = 15;
+  fio2_alarm_limits_changed = 16;
+  flow_alarm_limits_changed = 17;
 }
 
 enum LogEventType {

--- a/proto/mcu_pb.proto
+++ b/proto/mcu_pb.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
 message Range {
-  uint32 lower = 1;
-  uint32 upper = 2;
+  int32 lower = 1;
+  int32 upper = 2;
 }
 
 message AlarmLimits {


### PR DESCRIPTION
This PR resolves #323 by having the firmware automatically set FiO2 and flow alarm limits as a tolerance window (+/- 2) around the FiO2 and flow parameters, and filling the remaining gaps for support of FiO2 and flow rate alarms.

Additional minor changes:
- Range protobuf messages now use int32 instead of uint32, to allow for negative numbers in alarm limits and ranges
- The frontend now shows more useful initial values for the FiO2 and flow rate settings on the quick start screen, reducing the number of increment/decrement button-presses needed to adjust to clinically relevant values (in the absence of the rotary encoder).