### PR TITLE
Clean up the HFNC dashboard

### DIFF
--- a/backend/ventserver/simulation/alarm_limits.py
+++ b/backend/ventserver/simulation/alarm_limits.py
@@ -97,7 +97,7 @@ class HFNC(Service):
     """Alarm limits servicing for HFNC mode."""
 
     FLOW_TOLERANCE = 2  # L/min
-    FLOW_MIN = 0  # L/min
+    FLOW_MIN = -2  # L/min
     FLOW_MAX = 80  # L/min
 
     def transform(

--- a/backend/ventserver/simulator.py
+++ b/backend/ventserver/simulator.py
@@ -85,13 +85,15 @@ def initialize_states(all_states: MutableMapping[
             all_states[segment_type] = mcu_pb.SensorMeasurements()
         elif segment_type is backend.StateSegment.ALARM_LIMITS_REQUEST:
             all_states[segment_type] = mcu_pb.AlarmLimitsRequest(
-                fio2=mcu_pb.Range(lower=21, upper=100),
+                fio2=mcu_pb.Range(lower=21, upper=23),
+                flow=mcu_pb.Range(lower=-2, upper=2),
                 spo2=mcu_pb.Range(lower=21, upper=100),
                 hr=mcu_pb.Range(lower=0, upper=200),
             )
         elif segment_type is backend.StateSegment.ALARM_LIMITS:
             all_states[segment_type] = mcu_pb.AlarmLimits(
-                fio2=mcu_pb.Range(lower=21, upper=100),
+                fio2=mcu_pb.Range(lower=21, upper=23),
+                flow=mcu_pb.Range(lower=-2, upper=2),
                 spo2=mcu_pb.Range(lower=21, upper=100),
                 hr=mcu_pb.Range(lower=0, upper=200),
             )

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -319,7 +319,7 @@ PF::Driver::Serial::Nonin::Sensor nonin_oem(nonin_oem_dev);
 // Initializables
 
 auto initializables = PF::Util::make_array<std::reference_wrapper<PF::Driver::Initializable>>(
-    sfm3019_air, sfm3019_o2, /*fdo2, */ nonin_oem);
+    sfm3019_air, sfm3019_o2, fdo2, nonin_oem);
 std::array<PF::InitializableState, initializables.size()> initialization_states;
 
 /*

--- a/frontend/src/modules/alarms/AlarmsPage.tsx
+++ b/frontend/src/modules/alarms/AlarmsPage.tsx
@@ -236,7 +236,6 @@ const alarmConfiguration = (ventilationMode: VentilationMode): Array<AlarmConfig
   switch (ventilationMode) {
     case VentilationMode.hfnc:
       return [
-        { label: 'FiO2', stateKey: 'fio2' },
         { label: 'SpO2', stateKey: 'spo2' },
         { label: 'HR', stateKey: 'hr', max: 200 },
       ];

--- a/frontend/src/modules/app/ToolBar.tsx
+++ b/frontend/src/modules/app/ToolBar.tsx
@@ -4,7 +4,10 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import { getClockTime } from '../../store/app/selectors';
-import { updateCommittedParameter } from '../../store/controller/actions';
+import {
+  updateCommittedParameter,
+  updateCommittedState,
+} from '../../store/controller/actions';
 import { VentilationMode } from '../../store/controller/proto/mcu_pb';
 import {
   getBatteryPower,
@@ -12,9 +15,10 @@ import {
   getIsVentilating,
   getParametersRequestMode,
   getParametersRequestStandby,
+  getAlarmLimitsRequestStandby,
   getPopupEventLog,
 } from '../../store/controller/selectors';
-import { BACKEND_CONNECTION_LOST_CODE } from '../../store/controller/types';
+import { BACKEND_CONNECTION_LOST_CODE, ALARM_LIMITS } from '../../store/controller/types';
 import ViewDropdown from '../dashboard/views/ViewDropdown';
 import { BackIcon } from '../icons';
 import ClockIcon from '../icons/ClockIcon';
@@ -109,6 +113,7 @@ export const ToolBar = ({
   const currentMode = useSelector(getParametersRequestMode);
   const popupEventLog = useSelector(getPopupEventLog, shallowEqual);
   const parameterRequestStandby = useSelector(getParametersRequestStandby, shallowEqual);
+  const alarmLimitsRequestStandby = useSelector(getAlarmLimitsRequestStandby, shallowEqual);
   const ventilating = useSelector(getIsVentilating);
   const [isVentilatorOn, setIsVentilatorOn] = React.useState(ventilating);
   const [label, setLabel] = useState('Start Ventilation');
@@ -134,6 +139,12 @@ export const ToolBar = ({
               flow: parameterRequestStandby.flow,
             }),
           );
+          dispatch(updateCommittedState(
+                ALARM_LIMITS, {
+                  spo2: alarmLimitsRequestStandby.spo2,
+                  hr: alarmLimitsRequestStandby.hr,
+                }
+          ));
           break;
         case VentilationMode.pc_ac:
         case VentilationMode.vc_ac:

--- a/frontend/src/modules/app/ToolBar.tsx
+++ b/frontend/src/modules/app/ToolBar.tsx
@@ -4,10 +4,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import { getClockTime } from '../../store/app/selectors';
-import {
-  updateCommittedParameter,
-  updateCommittedState,
-} from '../../store/controller/actions';
+import { updateCommittedParameter, updateCommittedState } from '../../store/controller/actions';
 import { VentilationMode } from '../../store/controller/proto/mcu_pb';
 import {
   getBatteryPower,
@@ -139,12 +136,12 @@ export const ToolBar = ({
               flow: parameterRequestStandby.flow,
             }),
           );
-          dispatch(updateCommittedState(
-                ALARM_LIMITS, {
-                  spo2: alarmLimitsRequestStandby.spo2,
-                  hr: alarmLimitsRequestStandby.hr,
-                }
-          ));
+          dispatch(
+            updateCommittedState(ALARM_LIMITS, {
+              spo2: alarmLimitsRequestStandby.spo2,
+              hr: alarmLimitsRequestStandby.hr,
+            }),
+          );
           break;
         case VentilationMode.pc_ac:
         case VentilationMode.vc_ac:

--- a/frontend/src/modules/app/ToolBar.tsx
+++ b/frontend/src/modules/app/ToolBar.tsx
@@ -161,7 +161,7 @@ export const ToolBar = ({
           break;
       }
     }
-  }, [isVentilatorOn, parameterRequestStandby, currentMode, dispatch]);
+  }, [isVentilatorOn, parameterRequestStandby, alarmLimitsRequestStandby, currentMode, dispatch]);
 
   useEffect(() => {
     if (popupEventLog && popupEventLog.code === BACKEND_CONNECTION_LOST_CODE) {

--- a/frontend/src/modules/app/UserActivity.tsx
+++ b/frontend/src/modules/app/UserActivity.tsx
@@ -57,7 +57,9 @@ export const UserActivity = (): JSX.Element => {
       history.push('/screensaver');
     }
   };
-  return <IdleTimer timeout={idleTimeout} onTimeOut={onTimeOut} />;
+  // We are temporarily disabling the screensaver
+  return <React.Fragment />;
+  // return <IdleTimer timeout={idleTimeout} onTimeOut={onTimeOut} />;
 };
 
 export default UserActivity;

--- a/frontend/src/modules/app/UserActivity.tsx
+++ b/frontend/src/modules/app/UserActivity.tsx
@@ -47,7 +47,9 @@ const IdleTimer = ({ timeout, onTimeOut }: { timeout: number; onTimeOut(): void 
 };
 
 export const UserActivity = (): JSX.Element => {
-  const [idleTimeout] = useState(10 * 60 * 1000);
+  // 10 year timeout, so that we can temporarily disable the screensaver for v0.7
+  const [idleTimeout] = useState(10 * 52 * 7 * 24 * 60 * 60 * 1000);
+  // const [idleTimeout] = useState(10 * 60 * 1000);
   const history = useHistory();
   const ventilating = useSelector(getIsVentilating);
 
@@ -57,9 +59,7 @@ export const UserActivity = (): JSX.Element => {
       history.push('/screensaver');
     }
   };
-  // We are temporarily disabling the screensaver
-  return <React.Fragment />;
-  // return <IdleTimer timeout={idleTimeout} onTimeOut={onTimeOut} />;
+  return <IdleTimer timeout={idleTimeout} onTimeOut={onTimeOut} />;
 };
 
 export default UserActivity;

--- a/frontend/src/modules/dashboard/containers/LargeValueInfo.tsx
+++ b/frontend/src/modules/dashboard/containers/LargeValueInfo.tsx
@@ -1,4 +1,4 @@
-import { Grid, makeStyles, Theme, Typography } from '@material-ui/core';
+import { Grid, makeStyles, Typography } from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { getAlarmLimitsRequest } from '../../../store/controller/selectors';
@@ -7,7 +7,7 @@ import { AlarmModal } from '../../controllers';
 import { SelectorType, ValueSelectorDisplay } from '../../displays/ValueSelectorDisplay';
 import { Range } from '../../../store/controller/proto/mcu_pb';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(() => ({
   rootParent: {
     flexDirection: 'initial',
     height: '100%',
@@ -95,7 +95,6 @@ export interface Props {
   stateKey: string;
   units?: string;
   isLive?: boolean;
-  isMain?: boolean;
   showLimits?: boolean;
   decimal?: number;
 }
@@ -128,7 +127,6 @@ const ControlValuesDisplay = ({
   label,
   stateKey,
   units = '',
-  isMain = false,
   showLimits = false,
   decimal,
 }: Props): JSX.Element => {
@@ -161,7 +159,7 @@ const ControlValuesDisplay = ({
             container
             direction="column"
             className={classes.root}
-            style={isMain ? { width: '80%', margin: '0 auto' } : {}}
+            style={{ width: '80%', margin: '0 auto' }}
           >
             <Grid
               container
@@ -236,7 +234,6 @@ const ValueInfo = ({
   label,
   stateKey,
   units = '',
-  isMain = false,
   showLimits = false,
   decimal,
 }: Props): JSX.Element => {
@@ -245,7 +242,6 @@ const ValueInfo = ({
     <Grid item xs container className={`${classes.valuesPanel} ${classes.mainContainer}`}>
       <Grid item xs className={classes.gridAreavalues1}>
         <ControlValuesDisplay
-          isMain={true}
           stateKey={stateKey}
           selector={selector}
           label={label}

--- a/frontend/src/modules/dashboard/containers/LargeValueInfo.tsx
+++ b/frontend/src/modules/dashboard/containers/LargeValueInfo.tsx
@@ -43,12 +43,12 @@ const useStyles = makeStyles(() => ({
     // border: '1px solid yellow',
   },
   valueLabel: {
-    fontSize: '6rem',
+    fontSize: '5rem',
     lineHeight: '1',
     // border: '1px solid red',
   },
   unitsLabel: {
-    fontSize: '2rem',
+    fontSize: '1.5rem',
     opacity: 0.8,
     // border: '1px solid red'
   },
@@ -170,16 +170,16 @@ const ControlValuesDisplay = ({
               wrap="nowrap"
             >
               <Grid item xs style={{ width: '100%' }}>
-                <Typography className={classes.whiteFont} style={{ fontSize: '3rem' }}>
+                <Typography className={classes.whiteFont} style={{ fontSize: '2rem' }}>
                   {label}
                 </Typography>
               </Grid>
               {showLimits && stateKey && (
                 <Grid container item xs={3} className={classes.liveContainer}>
-                  <Typography className={classes.whiteFont} style={{ fontSize: '1.5rem' }}>
+                  <Typography className={classes.whiteFont} style={{ fontSize: '1.25rem' }}>
                     {alarmLimits[stateKey].lower}
                   </Typography>
-                  <Typography className={classes.whiteFont} style={{ fontSize: '1.5rem' }}>
+                  <Typography className={classes.whiteFont} style={{ fontSize: '1.25rem' }}>
                     {alarmLimits[stateKey].upper}
                   </Typography>
                 </Grid>

--- a/frontend/src/modules/dashboard/containers/LargeValueInfo.tsx
+++ b/frontend/src/modules/dashboard/containers/LargeValueInfo.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     // border: '1px solid red'
     backgroundColor: '#010010',
     borderRadius: '8px',
-    padding: '10px',
+    padding: '2rem',
     height: '100%',
   },
   displayContainer: {
@@ -36,13 +36,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     textAlign: 'right',
     // border: '1px solid blue'
   },
-  liveBox: {
-    textAlign: 'center',
-    width: '100%',
-    fontSize: 14,
-    borderRadius: 5,
-    border: `2px solid ${theme.palette.primary.main}`,
-  },
   valueContainer: {
     justifyContent: 'flex-start',
     alignItems: 'center',
@@ -50,13 +43,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     // border: '1px solid yellow',
   },
   valueLabel: {
-    fontSize: '3.5rem',
+    fontSize: '6rem',
     lineHeight: '1',
     // border: '1px solid red',
   },
   unitsLabel: {
-    // paddingLeft: theme.spacing(1),
-    // paddingTop: theme.spacing(4),
+    fontSize: '2rem',
     opacity: 0.8,
     // border: '1px solid red'
   },
@@ -81,34 +73,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   gridAreavalues3: {
     gridArea: 'gridAreavalues3',
   },
-
-  gridRoot: {
-    width: '100%',
-    // border: '1px solid red'
-    backgroundColor: '#010010',
-    borderRadius: '8px',
-    padding: '5px 10px',
-    height: '100%',
-  },
   gridLiveContainer: {
     // display: 'flex',
     justifyContent: 'flex-end',
     height: '100%',
     // border: '1px solid blue'
     textAlign: 'right',
-  },
-
-  gridValueLabel: {
-    fontSize: '2rem',
-    lineHeight: '1',
-    // border: '1px solid red',
-  },
-  gridUnitsLabel: {
-    // paddingLeft: theme.spacing(1),
-    paddingTop: theme.spacing(3),
-    opacity: 0.8,
-    fontSize: '12px',
-    // border: '1px solid red'
   },
   whiteFont: {
     color: '#fff',
@@ -202,16 +172,16 @@ const ControlValuesDisplay = ({
               wrap="nowrap"
             >
               <Grid item xs style={{ width: '100%' }}>
-                <Typography className={classes.whiteFont} style={{ fontSize: '16px' }}>
+                <Typography className={classes.whiteFont} style={{ fontSize: '3rem' }}>
                   {label}
                 </Typography>
               </Grid>
               {showLimits && stateKey && (
                 <Grid container item xs={3} className={classes.liveContainer}>
-                  <Typography className={classes.whiteFont}>
+                  <Typography className={classes.whiteFont} style={{ fontSize: '1.5rem' }}>
                     {alarmLimits[stateKey].lower}
                   </Typography>
-                  <Typography className={classes.whiteFont}>
+                  <Typography className={classes.whiteFont} style={{ fontSize: '1.5rem' }}>
                     {alarmLimits[stateKey].upper}
                   </Typography>
                 </Grid>

--- a/frontend/src/modules/dashboard/containers/LargeValueInfo.tsx
+++ b/frontend/src/modules/dashboard/containers/LargeValueInfo.tsx
@@ -68,10 +68,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     gridTemplateAreas: `'gridAreavalues1 gridAreavalues2'
     'gridAreavalues1 gridAreavalues3'`,
   },
-  mainWithSubcontainer: {
-    gridTemplateAreas: `'gridAreavalues1 gridAreavalues2'
-    'gridAreavalues1 gridAreavalues3'`,
-  },
   mainContainer: {
     gridTemplateAreas: `'gridAreavalues1 gridAreavalues1'
     'gridAreavalues1 gridAreavalues1'`,
@@ -121,8 +117,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export interface ValueInfoProps {
   mainContainer: Props;
-  subContainer1?: Props;
-  subContainer2?: Props;
 }
 
 export interface Props {
@@ -165,7 +159,7 @@ const ControlValuesDisplay = ({
   stateKey,
   units = '',
   isMain = false,
-  showLimits = true,
+  showLimits = false,
   decimal,
 }: Props): JSX.Element => {
   const classes = useStyles();
@@ -261,160 +255,37 @@ const ControlValuesDisplay = ({
   );
 };
 
-const GridControlValuesDisplay = ({
-  selector,
-  label,
-  stateKey,
-  units = '',
-  decimal,
-}: Props): JSX.Element => {
-  const classes = useStyles();
-  const [open, setOpen] = useState(false);
-  const alarmLimits = useSelector(getAlarmLimitsRequest, shallowEqual) as Record<string, Range>;
-  const onClick = () => {
-    // setOpen(true);
-    if (stateKey) {
-      setMultiPopupOpen(true, stateKey);
-    }
-  };
-  const handleClick = ClickHandler(onClick, () => {
-    return false;
-  });
-  const updateModalStatus = (status: boolean) => {
-    setOpen(status);
-  };
-  return (
-    <div
-      style={{ outline: 'none', height: '100%' }}
-      role="button"
-      onKeyDown={() => null}
-      onClick={handleClick}
-      tabIndex={0}
-    >
-      <Grid container direction="column" className={classes.rootParent}>
-        <Grid item xs style={{ width: '100%', height: '100%' }}>
-          <Grid container direction="column" className={classes.gridRoot}>
-            <Grid container item style={{ height: '100%' }}>
-              <Grid item xs>
-                <Typography className={classes.whiteFont}>{label}</Typography>
-              </Grid>
-
-              <Grid container item xs justify="flex-start" alignItems="center" wrap="nowrap">
-                <Grid className={classes.displayContainer}>
-                  <Typography
-                    align="center"
-                    variant="h5"
-                    className={`${classes.gridValueLabel} ${classes.whiteFont}`}
-                  >
-                    <ValueSelectorDisplay decimal={decimal} selector={selector} />
-                  </Typography>
-                  {units !== '' && (
-                    <Typography
-                      align="center"
-                      variant="body1"
-                      className={`${classes.gridUnitsLabel} ${classes.whiteFont}`}
-                    >
-                      {units}
-                    </Typography>
-                  )}
-                </Grid>
-              </Grid>
-              {stateKey && (
-                <Grid item xs className={classes.gridLiveContainer}>
-                  <Typography className={classes.whiteFont}>
-                    {alarmLimits[stateKey].lower}
-                  </Typography>
-                  <Typography className={classes.whiteFont}>
-                    {alarmLimits[stateKey].upper}
-                  </Typography>
-                </Grid>
-              )}
-            </Grid>
-          </Grid>
-        </Grid>
-        {stateKey && (
-          <AlarmModal
-            updateModalStatus={updateModalStatus}
-            openModal={open}
-            disableAlarmButton={true}
-            label={label}
-            units={units}
-            stateKey={stateKey}
-            requestCommitRange={() => null}
-          />
-        )}
-      </Grid>
-    </div>
-  );
-};
 /**
  * Value Info
  *
  * Component for showing information.
  *
  */
-const ValueInfo = (props: {
-  mainContainer: Props;
-  subContainer1?: Props;
-  subContainer2?: Props;
-}): JSX.Element => {
-  const { mainContainer, subContainer1, subContainer2 } = props;
+const ValueInfo = ({
+  selector,
+  label,
+  stateKey,
+  units = '',
+  isMain = false,
+  showLimits = false,
+  decimal,
+}: Props): JSX.Element => {
   const classes = useStyles();
-  const Render = () => {
-    if (mainContainer && !subContainer1 && !subContainer2) {
-      return (
-        <Grid item xs container className={`${classes.valuesPanel} ${classes.mainContainer}`}>
-          <Grid item xs className={classes.gridAreavalues1}>
-            <ControlValuesDisplay
-              isMain={true}
-              stateKey={mainContainer.stateKey}
-              selector={mainContainer.selector}
-              label={mainContainer.label}
-              units={mainContainer.units}
-              showLimits={mainContainer.showLimits}
-              decimal={mainContainer.decimal || 0}
-            />
-          </Grid>
-        </Grid>
-      );
-    }
-    return (
-      <Grid item xs container className={`${classes.valuesPanel} ${classes.mainWithSubcontainer}`}>
-        <Grid item xs className={classes.gridAreavalues1}>
-          <ControlValuesDisplay
-            stateKey={mainContainer.stateKey}
-            selector={mainContainer.selector}
-            label={mainContainer.label}
-            units={mainContainer.units}
-            decimal={mainContainer.decimal || 0}
-          />
-        </Grid>
-        <Grid item xs className={classes.gridAreavalues2}>
-          {subContainer1 && (
-            <GridControlValuesDisplay
-              stateKey={subContainer1.stateKey}
-              selector={subContainer1.selector}
-              label={subContainer1.label}
-              units={subContainer1.units}
-              decimal={subContainer1.decimal || 0}
-            />
-          )}
-        </Grid>
-        <Grid item xs className={classes.gridAreavalues3}>
-          {subContainer2 && (
-            <GridControlValuesDisplay
-              stateKey={subContainer2.stateKey}
-              selector={subContainer2.selector}
-              label={subContainer2.label}
-              units={subContainer2.units}
-              decimal={subContainer2.decimal || 0}
-            />
-          )}
-        </Grid>
+  return (
+    <Grid item xs container className={`${classes.valuesPanel} ${classes.mainContainer}`}>
+      <Grid item xs className={classes.gridAreavalues1}>
+        <ControlValuesDisplay
+          isMain={true}
+          stateKey={stateKey}
+          selector={selector}
+          label={label}
+          units={units}
+          showLimits={showLimits}
+          decimal={decimal || 0}
+        />
       </Grid>
-    );
-  };
-  return <Render />;
+    </Grid>
+  );
 };
 
 export default ValueInfo;

--- a/frontend/src/modules/dashboard/containers/LargeValueInfo.tsx
+++ b/frontend/src/modules/dashboard/containers/LargeValueInfo.tsx
@@ -1,7 +1,7 @@
 import { Grid, makeStyles, Typography } from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
-import { getAlarmLimitsRequest } from '../../../store/controller/selectors';
+import { getAlarmLimits } from '../../../store/controller/selectors';
 import { setMultiPopupOpen } from '../../app/Service';
 import { AlarmModal } from '../../controllers';
 import { SelectorType, ValueSelectorDisplay } from '../../displays/ValueSelectorDisplay';
@@ -132,7 +132,7 @@ const ControlValuesDisplay = ({
 }: Props): JSX.Element => {
   const classes = useStyles();
   const [open, setOpen] = useState(false);
-  const alarmLimits = useSelector(getAlarmLimitsRequest, shallowEqual) as Record<string, Range>;
+  const alarmLimits = useSelector(getAlarmLimits, shallowEqual) as Record<string, Range>;
   const onClick = () => {
     // setOpen(true);
     if (stateKey) {

--- a/frontend/src/modules/dashboard/containers/ValueInfo.tsx
+++ b/frontend/src/modules/dashboard/containers/ValueInfo.tsx
@@ -1,7 +1,7 @@
 import { Grid, makeStyles, Theme, Typography } from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
-import { getAlarmLimitsRequest } from '../../../store/controller/selectors';
+import { getAlarmLimits } from '../../../store/controller/selectors';
 import { setMultiPopupOpen } from '../../app/Service';
 import { AlarmModal } from '../../controllers';
 import { SelectorType, ValueSelectorDisplay } from '../../displays/ValueSelectorDisplay';
@@ -170,7 +170,7 @@ const ControlValuesDisplay = ({
 }: Props): JSX.Element => {
   const classes = useStyles();
   const [open, setOpen] = useState(false);
-  const alarmLimits = useSelector(getAlarmLimitsRequest, shallowEqual) as Record<string, Range>;
+  const alarmLimits = useSelector(getAlarmLimits, shallowEqual) as Record<string, Range>;
   const onClick = () => {
     // setOpen(true);
     if (stateKey) {
@@ -270,7 +270,7 @@ const GridControlValuesDisplay = ({
 }: Props): JSX.Element => {
   const classes = useStyles();
   const [open, setOpen] = useState(false);
-  const alarmLimits = useSelector(getAlarmLimitsRequest, shallowEqual) as Record<string, Range>;
+  const alarmLimits = useSelector(getAlarmLimits, shallowEqual) as Record<string, Range>;
   const onClick = () => {
     // setOpen(true);
     if (stateKey) {

--- a/frontend/src/modules/dashboard/views/HFNCGraphView.tsx
+++ b/frontend/src/modules/dashboard/views/HFNCGraphView.tsx
@@ -1,0 +1,279 @@
+import { Grid, Tab, Tabs, Typography } from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import React from 'react';
+import {
+  getParametersFiO2,
+  getParametersFlow,
+  getROXIndex,
+  getSmoothedFiO2Value,
+  getSmoothedFlow,
+  getSmoothedSpO2,
+  getSmoothedHR,
+} from '../../../store/controller/selectors';
+import { a11yProps, TabPanel } from '../../controllers/TabPanel';
+import { BPM, LMIN, PERCENT } from '../../info/units';
+import { FlowGraphInfo, PawGraphInfo, VolumeGraphInfo } from '../containers';
+import ControlInfo from '../containers/ControlInfo';
+import ValueInfo from '../containers/ValueInfo';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    height: '100%',
+    width: '100%',
+  },
+  topPanel: {
+    alignItems: 'stretch',
+  },
+  topLeftPanel: {
+    borderRadius: theme.panel.borderRadius,
+    minWidth: '260px',
+    backgroundColor: theme.palette.background.paper,
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    // gridTemplateRows: '1fr 60px',
+    overflow: 'hidden',
+  },
+  graphPanel: {
+    borderRadius: theme.panel.borderRadius,
+    // marginLeft: theme.spacing(2),
+    // marginRight: theme.spacing(2),
+    padding: theme.spacing(1),
+    backgroundColor: theme.palette.background.paper,
+    display: 'grid',
+    gridTemplateRows: '1fr 30px',
+    gridGap: 15,
+  },
+  tabs: {
+    width: '100%',
+    paddingTop: theme.spacing(0),
+    paddingBottom: theme.spacing(1),
+    minHeight: 30,
+  },
+  tab: {
+    borderRadius: 8,
+    border: `2px solid ${theme.palette.primary.main}`,
+    margin: '0px 8px',
+    zIndex: 1,
+    minHeight: 0,
+    padding: 0,
+  },
+
+  selectedTab: { color: theme.palette.primary.contrastText, lineHeight: '1.4' },
+
+  tabIndicator: {
+    borderRadius: 8,
+    border: `2px solid ${theme.palette.primary.main}`,
+    background: theme.palette.primary.main,
+    // marginBottom: theme.spacing(1),
+    zIndex: 0,
+    minHeight: 30,
+  },
+  bottomPanel: {
+    // marginTop: theme.spacing(2),
+    display: 'grid',
+    // gridTemplateColumns: '1fr 100px',
+  },
+  bottomLeftPanel: {
+    minWidth: '500px',
+    // marginRight: theme.spacing(2),
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: '16px',
+    height: '100%',
+  },
+  bottomRightPanel: {
+    borderRadius: '0px 16px 16px 0px',
+    backgroundColor: '#06172e',
+    height: '100%',
+    display: 'flex',
+    fontSize: '15px',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+  },
+  bottomBorder: {
+    borderBottom: `2px dashed ${theme.palette.background.default}`,
+    height: '100%',
+  },
+  rightBorder: {
+    borderRight: `2px dashed ${theme.palette.background.default}`,
+    height: '100%',
+    '&:last-child': {
+      borderRight: 'none !important',
+    },
+  },
+  graphMainPanel: {
+    display: 'grid',
+    gridTemplateRows: '1fr 111px',
+    gridGap: 15,
+    paddingLeft: '15px',
+  },
+  buttonPosition: {
+    position: 'absolute',
+    right: '35px',
+    zIndex: 2,
+  },
+  moreValues: {
+    backgroundColor: '#06172e',
+    borderRadius: '0px 0px 16px 16px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: '15px',
+  },
+}));
+
+/**
+ * HFNCMainView
+ */
+const HFNCMainView = (): JSX.Element => {
+  const classes = useStyles();
+  const [value, setValue] = React.useState(0);
+  const handleTabChange = (event: React.ChangeEvent<Record<string, unknown>>, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+    <Grid container className={classes.root}>
+      <Grid container item xs={12} alignItems="stretch" className={classes.topPanel}>
+        <Grid item xs={4} alignItems="stretch" className={classes.topLeftPanel}>
+          <Grid container item justify="center" alignItems="stretch">
+            <ValueInfo
+              mainContainer={{
+                selector: getSmoothedSpO2,
+                label: 'SpO2',
+                stateKey: 'spo2',
+                units: PERCENT,
+              }}
+            />
+          </Grid>
+          <Grid container item justify="center" alignItems="stretch">
+            <ValueInfo
+              mainContainer={{
+                selector: getSmoothedHR,
+                label: 'HR',
+                stateKey: 'hr',
+                units: BPM,
+              }}
+            />
+          </Grid>
+          <Grid container item justify="center" alignItems="stretch">
+            <ValueInfo
+              mainContainer={{
+                selector: getROXIndex,
+                label: 'ROX Index',
+                stateKey: '',
+                decimal: 2,
+              }}
+            />
+          </Grid>
+        </Grid>
+        <Grid container item xs direction="column" className={classes.graphMainPanel} wrap="nowrap">
+          <Grid container item xs direction="column" className={classes.graphPanel} wrap="nowrap">
+            <Grid>
+              <Grid className={classes.buttonPosition}>
+                {/* <Button variant="contained" color="primary" disableElevation>
+                  <Typography variant="subtitle2" align="center">
+                    More Waveforms
+                  </Typography>
+                </Button> */}
+              </Grid>
+              <TabPanel value={value} index={0}>
+                <Grid container item xs justify="space-between" style={{ height: '100%' }}>
+                  <Grid item container style={{ height: '34%' }}>
+                    <PawGraphInfo />
+                  </Grid>
+                  <Grid item style={{ height: '0%' }} />
+                  <Grid item container style={{ height: '37%' }}>
+                    <FlowGraphInfo />
+                  </Grid>
+                  <Grid item style={{ height: '0%' }} />
+                  <Grid item container style={{ height: '33%' }}>
+                    <VolumeGraphInfo />
+                  </Grid>
+                </Grid>
+              </TabPanel>
+              <TabPanel value={value} index={1}>
+                <Grid container item xs style={{ height: '100%' }}>
+                  <Grid item xs>
+                    <Typography>PV Loops</Typography>
+                  </Grid>
+                </Grid>
+              </TabPanel>
+              <TabPanel value={value} index={2}>
+                <Grid container item xs style={{ height: '100%' }}>
+                  <Grid item xs>
+                    <Typography>Compliance</Typography>
+                  </Grid>
+                </Grid>
+              </TabPanel>
+            </Grid>
+            <Grid container item direction="row" justify="center" alignItems="center">
+              <Tabs
+                value={value}
+                onChange={handleTabChange}
+                variant="fullWidth"
+                className={classes.tabs}
+                classes={{ indicator: classes.tabIndicator }}
+              >
+                <Tab
+                  label="Waveforms"
+                  {...a11yProps(0)}
+                  className={classes.tab}
+                  classes={{ selected: classes.selectedTab }}
+                />
+                {/* NOTE: The 2 tabs below are disabled until their functionality is implemented. */}
+                <Tab
+                  label="Trends"
+                  {...a11yProps(1)}
+                  className={classes.tab}
+                  disabled
+                  classes={{ selected: classes.selectedTab }}
+                />
+                <Tab
+                  label="Loops"
+                  {...a11yProps(2)}
+                  className={classes.tab}
+                  disabled
+                  classes={{ selected: classes.selectedTab }}
+                />
+              </Tabs>
+            </Grid>
+          </Grid>
+          <Grid container item xs={12} className={classes.bottomPanel}>
+            <Grid
+              container
+              item
+              xs={12}
+              justify="center"
+              alignItems="stretch"
+              className={classes.bottomLeftPanel}
+            >
+              <Grid item xs className={classes.rightBorder}>
+                <ControlInfo
+                  selector={getSmoothedFiO2Value}
+                  label="FiO2"
+                  stateKey="fio2"
+                  units={PERCENT}
+                  committedSettingSelector={getParametersFiO2}
+                  min={21}
+                />
+              </Grid>
+              <Grid item xs className={classes.rightBorder}>
+                <ControlInfo
+                  selector={getSmoothedFlow}
+                  label="Flow Rate"
+                  stateKey="flow"
+                  units={LMIN}
+                  committedSettingSelector={getParametersFlow}
+                  max={80}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default HFNCMainView;

--- a/frontend/src/modules/dashboard/views/HFNCMainView.tsx
+++ b/frontend/src/modules/dashboard/views/HFNCMainView.tsx
@@ -1,124 +1,39 @@
-import { Grid, Tab, Tabs, Typography } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import React from 'react';
 import {
   getParametersFiO2,
   getParametersFlow,
-  getROXIndex,
   getSmoothedFiO2Value,
   getSmoothedFlow,
   getSmoothedSpO2,
   getSmoothedHR,
 } from '../../../store/controller/selectors';
-import { a11yProps, TabPanel } from '../../controllers/TabPanel';
 import { BPM, LMIN, PERCENT } from '../../info/units';
-import { FlowGraphInfo, PawGraphInfo, VolumeGraphInfo } from '../containers';
-import ControlInfo from '../containers/ControlInfo';
-import ValueInfo from '../containers/ValueInfo';
+import LargeValueInfo from '../containers/LargeValueInfo';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     height: '100%',
     width: '100%',
-  },
-  topPanel: {
     alignItems: 'stretch',
   },
-  topLeftPanel: {
+  leftPanel: {
     borderRadius: theme.panel.borderRadius,
-    minWidth: '260px',
     backgroundColor: theme.palette.background.paper,
-    display: 'grid',
-    gridTemplateColumns: '1fr',
-    // gridTemplateRows: '1fr 60px',
+    marginRight: theme.spacing(2),
     overflow: 'hidden',
   },
-  graphPanel: {
+  rightPanel: {
     borderRadius: theme.panel.borderRadius,
-    // marginLeft: theme.spacing(2),
-    // marginRight: theme.spacing(2),
-    padding: theme.spacing(1),
+    backgroundColor: theme.palette.background.paper,
+    overflow: 'hidden',
+  },
+  panelColumn: {
+    borderRadius: theme.panel.borderRadius,
     backgroundColor: theme.palette.background.paper,
     display: 'grid',
-    gridTemplateRows: '1fr 30px',
-    gridGap: 15,
-  },
-  tabs: {
-    width: '100%',
-    paddingTop: theme.spacing(0),
-    paddingBottom: theme.spacing(1),
-    minHeight: 30,
-  },
-  tab: {
-    borderRadius: 8,
-    border: `2px solid ${theme.palette.primary.main}`,
-    margin: '0px 8px',
-    zIndex: 1,
-    minHeight: 0,
-    padding: 0,
-  },
-
-  selectedTab: { color: theme.palette.primary.contrastText, lineHeight: '1.4' },
-
-  tabIndicator: {
-    borderRadius: 8,
-    border: `2px solid ${theme.palette.primary.main}`,
-    background: theme.palette.primary.main,
-    // marginBottom: theme.spacing(1),
-    zIndex: 0,
-    minHeight: 30,
-  },
-  bottomPanel: {
-    // marginTop: theme.spacing(2),
-    display: 'grid',
-    // gridTemplateColumns: '1fr 100px',
-  },
-  bottomLeftPanel: {
-    minWidth: '500px',
-    // marginRight: theme.spacing(2),
-    backgroundColor: theme.palette.background.paper,
-    borderRadius: '16px',
-    height: '100%',
-  },
-  bottomRightPanel: {
-    borderRadius: '0px 16px 16px 0px',
-    backgroundColor: '#06172e',
-    height: '100%',
-    display: 'flex',
-    fontSize: '15px',
-    alignItems: 'center',
-    justifyContent: 'center',
-    textAlign: 'center',
-  },
-  bottomBorder: {
-    borderBottom: `2px dashed ${theme.palette.background.default}`,
-    height: '100%',
-  },
-  rightBorder: {
-    borderRight: `2px dashed ${theme.palette.background.default}`,
-    height: '100%',
-    '&:last-child': {
-      borderRight: 'none !important',
-    },
-  },
-  graphMainPanel: {
-    display: 'grid',
-    gridTemplateRows: '1fr 111px',
-    gridGap: 15,
-    paddingLeft: '15px',
-  },
-  buttonPosition: {
-    position: 'absolute',
-    right: '35px',
-    zIndex: 2,
-  },
-  moreValues: {
-    backgroundColor: '#06172e',
-    borderRadius: '0px 0px 16px 16px',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontSize: '15px',
+    overflow: 'hidden',
   },
 }));
 
@@ -127,148 +42,68 @@ const useStyles = makeStyles((theme: Theme) => ({
  */
 const HFNCMainView = (): JSX.Element => {
   const classes = useStyles();
-  const [value, setValue] = React.useState(0);
-  const handleTabChange = (event: React.ChangeEvent<Record<string, unknown>>, newValue: number) => {
-    setValue(newValue);
-  };
 
   return (
-    <Grid container className={classes.root}>
-      <Grid container item xs={12} alignItems="stretch" className={classes.topPanel}>
-        <Grid item xs={4} alignItems="stretch" className={classes.topLeftPanel}>
+    <Grid container direction="row" className={classes.root}>
+      <Grid container item xs direction="row" alignItems="stretch" className={classes.leftPanel}>
+        <Grid container item xs direction="column" alignItems="stretch" className={classes.panelColumn}>
           <Grid container item justify="center" alignItems="stretch">
-            <ValueInfo
-              mainContainer={{
-                selector: getSmoothedSpO2,
-                label: 'SpO2',
-                stateKey: 'spo2',
-                units: PERCENT,
-              }}
+            <LargeValueInfo
+              selector={getSmoothedSpO2}
+              label='Measured SpO2'
+              stateKey='spo2'
+              units={PERCENT}
+              showLimits
             />
           </Grid>
           <Grid container item justify="center" alignItems="stretch">
-            <ValueInfo
-              mainContainer={{
-                selector: getSmoothedHR,
-                label: 'HR',
-                stateKey: 'hr',
-                units: BPM,
-              }}
-            />
-          </Grid>
-          <Grid container item justify="center" alignItems="stretch">
-            <ValueInfo
-              mainContainer={{
-                selector: getROXIndex,
-                label: 'ROX Index',
-                stateKey: '',
-                decimal: 2,
-              }}
+            <LargeValueInfo
+              selector={getSmoothedHR}
+              label='Measured HR'
+              stateKey='hr'
+              units={BPM}
+              showLimits
             />
           </Grid>
         </Grid>
-        <Grid container item xs direction="column" className={classes.graphMainPanel} wrap="nowrap">
-          <Grid container item xs direction="column" className={classes.graphPanel} wrap="nowrap">
-            <Grid>
-              <Grid className={classes.buttonPosition}>
-                {/* <Button variant="contained" color="primary" disableElevation>
-                  <Typography variant="subtitle2" align="center">
-                    More Waveforms
-                  </Typography>
-                </Button> */}
-              </Grid>
-              <TabPanel value={value} index={0}>
-                <Grid container item xs justify="space-between" style={{ height: '100%' }}>
-                  <Grid item container style={{ height: '34%' }}>
-                    <PawGraphInfo />
-                  </Grid>
-                  <Grid item style={{ height: '0%' }} />
-                  <Grid item container style={{ height: '37%' }}>
-                    <FlowGraphInfo />
-                  </Grid>
-                  <Grid item style={{ height: '0%' }} />
-                  <Grid item container style={{ height: '33%' }}>
-                    <VolumeGraphInfo />
-                  </Grid>
-                </Grid>
-              </TabPanel>
-              <TabPanel value={value} index={1}>
-                <Grid container item xs style={{ height: '100%' }}>
-                  <Grid item xs>
-                    <Typography>PV Loops</Typography>
-                  </Grid>
-                </Grid>
-              </TabPanel>
-              <TabPanel value={value} index={2}>
-                <Grid container item xs style={{ height: '100%' }}>
-                  <Grid item xs>
-                    <Typography>Compliance</Typography>
-                  </Grid>
-                </Grid>
-              </TabPanel>
-            </Grid>
-            <Grid container item direction="row" justify="center" alignItems="center">
-              <Tabs
-                value={value}
-                onChange={handleTabChange}
-                variant="fullWidth"
-                className={classes.tabs}
-                classes={{ indicator: classes.tabIndicator }}
-              >
-                <Tab
-                  label="Waveforms"
-                  {...a11yProps(0)}
-                  className={classes.tab}
-                  classes={{ selected: classes.selectedTab }}
-                />
-                {/* NOTE: The 2 tabs below are disabled until their functionality is implemented. */}
-                <Tab
-                  label="Trends"
-                  {...a11yProps(1)}
-                  className={classes.tab}
-                  disabled
-                  classes={{ selected: classes.selectedTab }}
-                />
-                <Tab
-                  label="Loops"
-                  {...a11yProps(2)}
-                  className={classes.tab}
-                  disabled
-                  classes={{ selected: classes.selectedTab }}
-                />
-              </Tabs>
-            </Grid>
+        <Grid container item xs direction="column" alignItems="stretch" className={classes.panelColumn}>
+          <Grid container item justify="center" alignItems="stretch">
+            <LargeValueInfo
+              selector={getSmoothedFiO2Value}
+              label='Measured FiO2'
+              stateKey='fio2'
+              units={PERCENT}
+              showLimits
+            />
           </Grid>
-          <Grid container item xs={12} className={classes.bottomPanel}>
-            <Grid
-              container
-              item
-              xs={12}
-              justify="center"
-              alignItems="stretch"
-              className={classes.bottomLeftPanel}
-            >
-              <Grid item xs className={classes.rightBorder}>
-                <ControlInfo
-                  selector={getSmoothedFiO2Value}
-                  label="FiO2"
-                  stateKey="fio2"
-                  units={PERCENT}
-                  committedSettingSelector={getParametersFiO2}
-                  min={21}
-                />
-              </Grid>
-              <Grid item xs className={classes.rightBorder}>
-                <ControlInfo
-                  selector={getSmoothedFlow}
-                  label="Flow Rate"
-                  stateKey="flow"
-                  units={LMIN}
-                  committedSettingSelector={getParametersFlow}
-                  max={80}
-                />
-              </Grid>
-            </Grid>
+          <Grid container item justify="center" alignItems="stretch">
+            <LargeValueInfo
+              selector={getSmoothedFlow}
+              label='Measured Flow'
+              stateKey='flow'
+              units={LMIN}
+              showLimits
+            />
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid container item xs={4} direction="row" className={classes.rightPanel} wrap="nowrap">
+        <Grid container item xs direction="column" alignItems="stretch" className={classes.panelColumn}>
+          <Grid container item justify="center" alignItems="stretch">
+            <LargeValueInfo
+              selector={getParametersFiO2}
+              label='FiO2 Setting'
+              stateKey='fio2'
+              units={PERCENT}
+            />
+          </Grid>
+          <Grid container item justify="center" alignItems="stretch">
+            <LargeValueInfo
+              selector={getParametersFlow}
+              label='Flow Setting'
+              stateKey='flow'
+              units={LMIN}
+            />
           </Grid>
         </Grid>
       </Grid>

--- a/frontend/src/modules/dashboard/views/HFNCMainView.tsx
+++ b/frontend/src/modules/dashboard/views/HFNCMainView.tsx
@@ -35,6 +35,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'grid',
     overflow: 'hidden',
   },
+  panelValue: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+  }
 }));
 
 /**
@@ -47,19 +51,19 @@ const HFNCMainView = (): JSX.Element => {
     <Grid container direction="row" className={classes.root}>
       <Grid container item xs direction="row" alignItems="stretch" className={classes.leftPanel}>
         <Grid container item xs direction="column" alignItems="stretch" className={classes.panelColumn}>
-          <Grid container item justify="center" alignItems="stretch">
+          <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getSmoothedSpO2}
-              label='Measured SpO2'
+              label='SpO2'
               stateKey='spo2'
               units={PERCENT}
               showLimits
             />
           </Grid>
-          <Grid container item justify="center" alignItems="stretch">
+          <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getSmoothedHR}
-              label='Measured HR'
+              label='HR'
               stateKey='hr'
               units={BPM}
               showLimits
@@ -67,19 +71,19 @@ const HFNCMainView = (): JSX.Element => {
           </Grid>
         </Grid>
         <Grid container item xs direction="column" alignItems="stretch" className={classes.panelColumn}>
-          <Grid container item justify="center" alignItems="stretch">
+          <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getSmoothedFiO2Value}
-              label='Measured FiO2'
+              label='FiO2'
               stateKey='fio2'
               units={PERCENT}
               showLimits
             />
           </Grid>
-          <Grid container item justify="center" alignItems="stretch">
+          <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getSmoothedFlow}
-              label='Measured Flow'
+              label='Flow'
               stateKey='flow'
               units={LMIN}
               showLimits
@@ -89,7 +93,7 @@ const HFNCMainView = (): JSX.Element => {
       </Grid>
       <Grid container item xs={4} direction="row" className={classes.rightPanel} wrap="nowrap">
         <Grid container item xs direction="column" alignItems="stretch" className={classes.panelColumn}>
-          <Grid container item justify="center" alignItems="stretch">
+          <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getParametersFiO2}
               label='FiO2 Setting'
@@ -97,7 +101,7 @@ const HFNCMainView = (): JSX.Element => {
               units={PERCENT}
             />
           </Grid>
-          <Grid container item justify="center" alignItems="stretch">
+          <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getParametersFlow}
               label='Flow Setting'

--- a/frontend/src/modules/dashboard/views/HFNCMainView.tsx
+++ b/frontend/src/modules/dashboard/views/HFNCMainView.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   panelValue: {
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
-  }
+  },
 }));
 
 /**
@@ -50,12 +50,19 @@ const HFNCMainView = (): JSX.Element => {
   return (
     <Grid container direction="row" className={classes.root}>
       <Grid container item xs direction="row" alignItems="stretch" className={classes.leftPanel}>
-        <Grid container item xs direction="column" alignItems="stretch" className={classes.panelColumn}>
+        <Grid
+          container
+          item
+          xs
+          direction="column"
+          alignItems="stretch"
+          className={classes.panelColumn}
+        >
           <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getSmoothedSpO2}
-              label='SpO2'
-              stateKey='spo2'
+              label="SpO2"
+              stateKey="spo2"
               units={PERCENT}
               showLimits
             />
@@ -63,19 +70,26 @@ const HFNCMainView = (): JSX.Element => {
           <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getSmoothedHR}
-              label='HR'
-              stateKey='hr'
+              label="HR"
+              stateKey="hr"
               units={BPM}
               showLimits
             />
           </Grid>
         </Grid>
-        <Grid container item xs direction="column" alignItems="stretch" className={classes.panelColumn}>
+        <Grid
+          container
+          item
+          xs
+          direction="column"
+          alignItems="stretch"
+          className={classes.panelColumn}
+        >
           <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getSmoothedFiO2Value}
-              label='FiO2'
-              stateKey='fio2'
+              label="FiO2"
+              stateKey="fio2"
               units={PERCENT}
               showLimits
             />
@@ -83,8 +97,8 @@ const HFNCMainView = (): JSX.Element => {
           <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getSmoothedFlow}
-              label='Flow'
-              stateKey='flow'
+              label="Flow"
+              stateKey="flow"
               units={LMIN}
               showLimits
             />
@@ -92,20 +106,27 @@ const HFNCMainView = (): JSX.Element => {
         </Grid>
       </Grid>
       <Grid container item xs={4} direction="row" className={classes.rightPanel} wrap="nowrap">
-        <Grid container item xs direction="column" alignItems="stretch" className={classes.panelColumn}>
+        <Grid
+          container
+          item
+          xs
+          direction="column"
+          alignItems="stretch"
+          className={classes.panelColumn}
+        >
           <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getParametersFiO2}
-              label='FiO2 Setting'
-              stateKey='fio2'
+              label="FiO2 Setting"
+              stateKey="fio2"
               units={PERCENT}
             />
           </Grid>
           <Grid container item justify="center" alignItems="stretch" className={classes.panelValue}>
             <LargeValueInfo
               selector={getParametersFlow}
-              label='Flow Setting'
-              stateKey='flow'
+              label="Flow Setting"
+              stateKey="flow"
               units={LMIN}
             />
           </Grid>

--- a/frontend/src/modules/displays/Carousel.tsx
+++ b/frontend/src/modules/displays/Carousel.tsx
@@ -9,7 +9,7 @@ const useStyles = makeStyles(() => ({
     height: '100%',
   },
   carouselFlex: {
-    maxWidth: '700px',
+    maxWidth: '750px',
     display: 'flex',
     justifyContent: 'center',
     flexDirection: 'column',
@@ -49,7 +49,7 @@ const useStyles = makeStyles(() => ({
     },
   },
   carouselArrowRight: {
-    right: '13%',
+    right: '10%',
     border: '1px solid #fff',
     width: '45px',
     height: '45px',
@@ -63,7 +63,7 @@ const useStyles = makeStyles(() => ({
     },
   },
   carouselArrowLeft: {
-    left: '13%',
+    left: '10%',
     border: '1px solid #fff',
     width: '45px',
     height: '45px',

--- a/frontend/src/modules/displays/MultiStepWizard.tsx
+++ b/frontend/src/modules/displays/MultiStepWizard.tsx
@@ -7,8 +7,8 @@ import ReplyIcon from '@material-ui/icons/Reply';
 import ModalPopup from '../controllers/ModalPopup';
 import { getcurrentStateKey, getMultiPopupOpenState, setMultiPopupOpen } from '../app/Service';
 import {
-  getSmoothedFiO2Value,
-  getSmoothedFlow,
+  getParametersFiO2,
+  getParametersFlow,
   getSmoothedSpO2,
   getSmoothedHR,
   roundValue,
@@ -137,7 +137,7 @@ const HFNCControls = (): JSX.Element => {
       <Grid container item justify="center" alignItems="stretch" direction="column">
         <ValueInfo
           mainContainer={{
-            selector: getSmoothedFiO2Value,
+            selector: getParametersFiO2,
             label: 'FiO2',
             stateKey: 'fio2',
             units: PERCENT,
@@ -145,7 +145,7 @@ const HFNCControls = (): JSX.Element => {
         />
         <ValueInfo
           mainContainer={{
-            selector: getSmoothedFlow,
+            selector: getParametersFlow,
             label: 'Flow',
             stateKey: 'flow',
             units: LMIN,

--- a/frontend/src/modules/displays/MultiStepWizard.tsx
+++ b/frontend/src/modules/displays/MultiStepWizard.tsx
@@ -7,10 +7,10 @@ import ReplyIcon from '@material-ui/icons/Reply';
 import ModalPopup from '../controllers/ModalPopup';
 import { getcurrentStateKey, getMultiPopupOpenState, setMultiPopupOpen } from '../app/Service';
 import {
-  getCycleMeasurementsRR,
-  getSensorMeasurementsSpO2,
   getSmoothedFiO2Value,
   getSmoothedFlow,
+  getSmoothedSpO2,
+  getSmoothedHR,
   roundValue,
 } from '../../store/controller/selectors';
 import { SetValueContent } from '../controllers/ValueModal';
@@ -119,18 +119,18 @@ const HFNCControls = (): JSX.Element => {
       >
         <ValueInfo
           mainContainer={{
-            selector: getCycleMeasurementsRR,
-            label: 'HR',
-            stateKey: 'hr',
-            units: BPM,
+            selector: getSmoothedSpO2,
+            label: 'SpO2',
+            stateKey: 'spo2',
+            units: PERCENT,
           }}
         />
         <ValueInfo
           mainContainer={{
-            selector: getSensorMeasurementsSpO2,
-            label: 'SpO2',
-            stateKey: 'spo2',
-            units: PERCENT,
+            selector: getSmoothedHR,
+            label: 'HR',
+            stateKey: 'hr',
+            units: BPM,
           }}
         />
       </Grid>
@@ -146,7 +146,7 @@ const HFNCControls = (): JSX.Element => {
         <ValueInfo
           mainContainer={{
             selector: getSmoothedFlow,
-            label: 'Flow Rate',
+            label: 'Flow',
             stateKey: 'flow',
             units: LMIN,
           }}

--- a/frontend/src/modules/landing-page/LandingPage.tsx
+++ b/frontend/src/modules/landing-page/LandingPage.tsx
@@ -7,7 +7,7 @@ const useStyles = makeStyles(() => ({
   slideHead: {
     margin: '0px',
     textAlign: 'left',
-    marginBottom: '10px',
+    marginBottom: '2.5rem',
 
     '& ul': {
       padding: '0px 20px',
@@ -22,8 +22,13 @@ const useStyles = makeStyles(() => ({
     backgroundColor: '#042139',
     padding: '20px',
     borderRadius: '10px',
-    minHeight: '235px',
+    minHeight: '275px',
   },
+  slideText: {
+    textAlign: 'left',
+    fontWeight: 'normal',
+    fontSize: '1.5rem',
+  }
 }));
 
 export const LandingPage = (): JSX.Element => {
@@ -36,39 +41,73 @@ export const LandingPage = (): JSX.Element => {
         position: 'relative',
       }}
     >
-      <Carousel
-        slides={[
-          <div>
-            <h1 className={classes.slideHead}>Invasive Modes</h1>
-            <Grid item xs direction="row" container className={classes.slideContent}>
-              <Grid item xs className={classes.slideHead}>
-                <h4>Pressure Controlled</h4>
-                <ul>
-                  <li>PC-AC</li>
-                  <li>PSV</li>
-                  <li>PC-SIMV</li>
-                  <li>Bi-level</li>
-                </ul>
-              </Grid>
-              <Grid item xs className={classes.slideHead}>
-                <h4>Volume Controlled</h4>
-                <ul>
-                  <li>VC-AC</li>
-                  <li>VC-SIMV</li>
-                </ul>
-              </Grid>
-              <Grid item xs className={classes.slideHead}>
-                <h4>Miscellaneous</h4>
-                <ul>
-                  <li>PRVC</li>
-                </ul>
-              </Grid>
+      <Carousel slides={[
+        /*<div>
+          <h1 className={classes.slideHead}>Invasive Modes</h1>
+          <Grid item xs direction="row" container className={classes.slideContent}>
+            <Grid item xs className={classes.slideHead}>
+              <h4>Pressure Controlled</h4>
+              <ul>
+                <li>PC-AC</li>
+                <li>PSV</li>
+                <li>PC-SIMV</li>
+                <li>Bi-level</li>
+              </ul>
             </Grid>
-          </div>,
-          <div />,
-          <div />,
-        ]}
-      />
+            <Grid item xs className={classes.slideHead}>
+              <h4>Volume Controlled</h4>
+              <ul>
+                <li>VC-AC</li>
+                <li>VC-SIMV</li>
+              </ul>
+            </Grid>
+            <Grid item xs className={classes.slideHead}>
+              <h4>Miscellaneous</h4>
+              <ul>
+                <li>PRVC</li>
+              </ul>
+            </Grid>
+          </Grid>
+        </div>,*/
+        <div>
+          <h1 className={classes.slideHead}>Emergency Use Notice</h1>
+          <Grid item xs direction="row" container className={classes.slideContent}>
+            <Grid item xs className={classes.slideText}>
+              <p>
+                This Pufferfish ventilator is running a test version of software
+                with known problems, limitations, and missing safety measures. For this
+                reason, any person connected to this ventilator should always be
+                supervised by someone trained in what to do if a problem occurs.
+              </p>
+              <p>
+                This ventilator provides oxygen therapy and may be considered for
+                use if no safer alternatives are available. It should not be used
+                outside of extreme crisis situations.
+              </p>
+            </Grid>
+          </Grid>
+        </div>,
+        <div>
+          <h1 className={classes.slideHead}>Capabilities</h1>
+          <Grid item xs direction="row" container className={classes.slideContent}>
+            <Grid item xs className={classes.slideText}>
+              <p>
+                This version of software provides a visual alarm when the oxygen
+                supply runs out, and it allows adjusting FiO2 and flow rate. Because
+                alarms do not generate sounds, the ventilator must always be watched
+                in case of alarms.
+              </p>
+              <p>
+                This ventilator has a small internal battery in case of power outage.
+                Because the current version of software does not have any way to
+                read the charge level of the battery, it will shut off without
+                warning if it runs out of power. Thus, the ventilator should never be
+                disconnected from its power source.
+              </p>
+            </Grid>
+          </Grid>
+        </div>,
+      ]} />
     </div>
   );
 };

--- a/frontend/src/modules/landing-page/LandingPage.tsx
+++ b/frontend/src/modules/landing-page/LandingPage.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(() => ({
     textAlign: 'left',
     fontWeight: 'normal',
     fontSize: '1.5rem',
-  }
+  },
 }));
 
 export const LandingPage = (): JSX.Element => {
@@ -41,8 +41,9 @@ export const LandingPage = (): JSX.Element => {
         position: 'relative',
       }}
     >
-      <Carousel slides={[
-        /*<div>
+      <Carousel
+        slides={[
+          /* <div>
           <h1 className={classes.slideHead}>Invasive Modes</h1>
           <Grid item xs direction="row" container className={classes.slideContent}>
             <Grid item xs className={classes.slideHead}>
@@ -68,46 +69,45 @@ export const LandingPage = (): JSX.Element => {
               </ul>
             </Grid>
           </Grid>
-        </div>,*/
-        <div>
-          <h1 className={classes.slideHead}>Emergency Use Notice</h1>
-          <Grid item xs direction="row" container className={classes.slideContent}>
-            <Grid item xs className={classes.slideText}>
-              <p>
-                This Pufferfish ventilator is running a test version of software
-                with known problems, limitations, and missing safety measures. For this
-                reason, any person connected to this ventilator should always be
-                supervised by someone trained in what to do if a problem occurs.
-              </p>
-              <p>
-                This ventilator provides oxygen therapy and may be considered for
-                use if no safer alternatives are available. It should not be used
-                outside of extreme crisis situations.
-              </p>
+        </div>, */
+          <div>
+            <h1 className={classes.slideHead}>Emergency Use Notice</h1>
+            <Grid item xs direction="row" container className={classes.slideContent}>
+              <Grid item xs className={classes.slideText}>
+                <p>
+                  This Pufferfish ventilator is running a test version of software with known
+                  problems, limitations, and missing safety measures. For this reason, any person
+                  connected to this ventilator should always be supervised by someone trained in
+                  what to do if a problem occurs.
+                </p>
+                <p>
+                  This ventilator provides oxygen therapy and may be considered for use if no safer
+                  alternatives are available. It should not be used outside of extreme crisis
+                  situations.
+                </p>
+              </Grid>
             </Grid>
-          </Grid>
-        </div>,
-        <div>
-          <h1 className={classes.slideHead}>Capabilities</h1>
-          <Grid item xs direction="row" container className={classes.slideContent}>
-            <Grid item xs className={classes.slideText}>
-              <p>
-                This version of software provides a visual alarm when the oxygen
-                supply runs out, and it allows adjusting FiO2 and flow rate. Because
-                alarms do not generate sounds, the ventilator must always be watched
-                in case of alarms.
-              </p>
-              <p>
-                This ventilator has a small internal battery in case of power outage.
-                Because the current version of software does not have any way to
-                read the charge level of the battery, it will shut off without
-                warning if it runs out of power. Thus, the ventilator should never be
-                disconnected from its power source.
-              </p>
+          </div>,
+          <div>
+            <h1 className={classes.slideHead}>Capabilities</h1>
+            <Grid item xs direction="row" container className={classes.slideContent}>
+              <Grid item xs className={classes.slideText}>
+                <p>
+                  This version of software provides a visual alarm when the oxygen supply runs out,
+                  and it allows adjusting FiO2 and flow rate. Because alarms do not generate sounds,
+                  the ventilator must always be watched in case of alarms.
+                </p>
+                <p>
+                  This ventilator has a small internal battery in case of power outage. Because the
+                  current version of software does not have any way to read the charge level of the
+                  battery, it will shut off without warning if it runs out of power. Thus, the
+                  ventilator should never be disconnected from its power source.
+                </p>
+              </Grid>
             </Grid>
-          </Grid>
-        </div>,
-      ]} />
+          </div>,
+        ]}
+      />
     </div>
   );
 };

--- a/frontend/src/modules/logs/LogsPage.tsx
+++ b/frontend/src/modules/logs/LogsPage.tsx
@@ -129,7 +129,7 @@ export const LogsPage = ({ filter }: { filter?: boolean }): JSX.Element => {
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
   const loggedEvents = useSelector(getNextLogEvents, shallowEqual);
   const activeLogEventIds = useSelector(getActiveLogEventIds, shallowEqual);
-  const settingsAllowed = ['hr', 'spo2'];
+  const settingsAllowed = ['fio2', 'flow', 'hr', 'spo2'];
 
   const getDetails = useCallback(getEventDetails, []);
 

--- a/frontend/src/store/controller/reducers.ts
+++ b/frontend/src/store/controller/reducers.ts
@@ -27,7 +27,13 @@ import { MessageType } from './types';
 
 export const controllerReducer = combineReducers({
   // Message states from mcu_pb
-  alarmLimits: messageReducer<AlarmLimits>(MessageType.AlarmLimits, AlarmLimits),
+  alarmLimits: messageReducer<AlarmLimits>(MessageType.AlarmLimits, AlarmLimits, {
+    // Needed so that values aren't undefined when dashboard is loaded before redirecting to quickstart
+    spo2: { lower: 90, upper: 100 },
+    hr: { lower: 60, upper: 100 },
+    fio2: { lower: 78, upper: 82 },
+    flow: { lower: 28, upper: 32 },
+  }),
   alarmLimitsRequest: alarmLimitsReducer,
   alarmLimitsRequestStandby: alarmLimitsRequestStandbyReducer,
   alarmMuteRequest: alarmMuteRequestReducer,

--- a/frontend/src/store/controller/reducers/backend.ts
+++ b/frontend/src/store/controller/reducers/backend.ts
@@ -15,7 +15,8 @@ import {
 export const messageReducer = <T extends PBMessage>(
   messageType: MessageType,
   pbMessageType: PBMessageType,
-) => (state: T = pbMessageType.fromJSON({}) as T, action: StateUpdateAction): T => {
+  initializer: Record<string, unknown> = {},
+) => (state: T = pbMessageType.fromJSON(initializer) as T, action: StateUpdateAction): T => {
   switch (action.type) {
     case STATE_UPDATED:
       if (action.messageType === messageType) {

--- a/frontend/src/store/controller/reducers/components.ts
+++ b/frontend/src/store/controller/reducers/components.ts
@@ -31,8 +31,8 @@ export const alarmLimitsReducer = (
     spo2: { lower: 21, upper: 100 },
     hr: { lower: 0, upper: 200 },
     // Ignored
-    fio2: { lower: 21, upper: 100 },
-    flow: { upper: 100 },
+    fio2: { lower: 78, upper: 82 },
+    flow: { lower: 28, upper: 32 },
     rr: { upper: 100 },
     pip: { upper: 100 },
     peep: { upper: 100 },
@@ -55,8 +55,8 @@ export const alarmLimitsRequestStandbyReducer = (
       spo2: { lower: 90, upper: 100 },
       hr: { lower: 60, upper: 100 },
       // Ignored
-      fio2: { lower: 21, upper: 100 },
-      flow: { upper: 100 },
+      fio2: { lower: 78, upper: 82 },
+      flow: { lower: 28, upper: 32 },
       rr: { upper: 100 },
       pip: { upper: 100 },
       peep: { upper: 100 },

--- a/frontend/src/store/controller/reducers/components.ts
+++ b/frontend/src/store/controller/reducers/components.ts
@@ -28,20 +28,21 @@ import DECIMAL_RADIX from '../../../modules/app/AppConstants';
 
 export const alarmLimitsReducer = (
   state: AlarmLimitsRequest = AlarmLimitsRequest.fromJSON({
+    spo2: { lower: 21, upper: 100 },
+    hr: { lower: 0, upper: 200 },
+    // Ignored
+    fio2: { lower: 21, upper: 100 },
+    flow: { upper: 100 },
     rr: { upper: 100 },
     pip: { upper: 100 },
     peep: { upper: 100 },
     ipAbovePeep: { upper: 100 },
     inspTime: { upper: 100 },
-    fio2: { lower: 21, upper: 100 },
     paw: { upper: 100 },
     mve: { upper: 100 },
     tv: { upper: 100 },
     etco2: { upper: 100 },
-    flow: { upper: 100 },
     apnea: { upper: 100 },
-    spo2: { lower: 21, upper: 100 },
-    hr: { lower: 0, upper: 200 },
   }) as AlarmLimitsRequest,
   action: commitAction,
 ): AlarmLimitsRequest => {
@@ -51,20 +52,21 @@ export const alarmLimitsReducer = (
 export const alarmLimitsRequestStandbyReducer = (
   state: { alarmLimits: AlarmLimitsRequest } = {
     alarmLimits: AlarmLimitsRequest.fromJSON({
+      spo2: { lower: 90, upper: 100 },
+      hr: { lower: 60, upper: 100 },
+      // Ignored
+      fio2: { lower: 21, upper: 100 },
+      flow: { upper: 100 },
       rr: { upper: 100 },
       pip: { upper: 100 },
       peep: { upper: 100 },
       ipAbovePeep: { upper: 100 },
       inspTime: { upper: 100 },
-      fio2: { lower: 21, upper: 100 },
       paw: { upper: 100 },
       mve: { upper: 100 },
       tv: { upper: 100 },
       etco2: { upper: 100 },
-      flow: { upper: 100 },
       apnea: { upper: 100 },
-      spo2: { lower: 21, upper: 100 },
-      hr: { lower: 0, upper: 200 },
     }),
   } as { alarmLimits: AlarmLimitsRequest },
   action: commitAction,

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -3,6 +3,7 @@ import DECIMAL_RADIX from '../../modules/app/AppConstants';
 import { StoreState } from '../types';
 import { FrontendDisplaySetting, SystemSettingRequest } from './proto/frontend_pb';
 import {
+  AlarmLimits,
   AlarmLimitsRequest,
   AlarmMute,
   AlarmMuteRequest,
@@ -243,6 +244,10 @@ export const getPVLoop = createSelector(
 );
 
 // Alarm Limits
+export const getAlarmLimits = createSelector(
+  getController,
+  (states: ControllerStates): AlarmLimits | Record<string, Range> => states.alarmLimits,
+);
 export const getAlarmLimitsRequest = createSelector(
   getController,
   (states: ControllerStates): AlarmLimitsRequest | Record<string, Range> =>


### PR DESCRIPTION
This PR closes #309 by changing the layout of the HFNC-only dashboard (removing plots, and showing both set and measured values for FiO2 and flow rate) and increasing the size of text on the dashboard. Additionally, in preparation for the v0.7 release, it:

- Disables the screensaver
- Reenables the FDO2 sensor in the firmware by default
- Fixes unintuitive behavior between the set alarms screen and the "Start Ventilation" button in standby mode (see https://github.com/pez-globo/pufferfish-software/issues/324#issuecomment-825985574 for more details)
- Fixes parts of #307 
- Adds an emergency use notice to the landing screen