### PR TITLE
Play audio in frontend for all active alarms

### DIFF
--- a/frontend/src/modules/app/OverlayScreen.tsx
+++ b/frontend/src/modules/app/OverlayScreen.tsx
@@ -77,8 +77,10 @@ const AudioAlarm = (): JSX.Element => {
   const alarmMuteStatus = useSelector(getAlarmMuteStatus, shallowEqual);
   const [audio] = useState(new Audio(`${process.env.PUBLIC_URL}/alarm.mp3`));
   audio.loop = true;
+  const storeData = store.getState();
+  const events = storeData.controller.eventLog.nextLogEvents.elements;
   const [playing, setPlaying] = useState(alarmMuteStatus.active);
-
+  const patientLogEvent = events.find((el: LogEvent) => (el.type as number) < 2);
   useEffect(() => {
     if (playing) {
       audio.play();
@@ -93,22 +95,21 @@ const AudioAlarm = (): JSX.Element => {
   useEffect(() => {
     if (popupEventLog) {
       setPlaying(false);
-      if (popupEventLog.code === BACKEND_CONNECTION_LOST_CODE) {
+      if (popupEventLog && patientLogEvent) {
         setPlaying(true);
+        dispatch({ type: RED_BORDER, status: true });
       }
-      dispatch({ type: RED_BORDER, status: true });
     } else {
       setPlaying(false);
       dispatch({ type: RED_BORDER, status: false });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [popupEventLog]);
+  }, [popupEventLog, patientLogEvent, dispatch]);
 
   useEffect(() => {
     if (popupEventLog) {
       dispatch({ type: RED_BORDER, status: !alarmMuteStatus.active });
     }
-    if (popupEventLog && popupEventLog.code === BACKEND_CONNECTION_LOST_CODE) {
+    if (popupEventLog && patientLogEvent) {
       setPlaying(!alarmMuteStatus.active);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/modules/app/OverlayScreen.tsx
+++ b/frontend/src/modules/app/OverlayScreen.tsx
@@ -7,6 +7,7 @@ import { getClock } from '../../store/app/selectors';
 import { RED_BORDER } from '../../store/app/types';
 import { LogEvent, LogEventType } from '../../store/controller/proto/mcu_pb';
 import {
+  getAlarmLogEvents,
   getAlarmMuteStatus,
   getPopupEventLog,
   getScreenStatus,
@@ -77,10 +78,8 @@ const AudioAlarm = (): JSX.Element => {
   const alarmMuteStatus = useSelector(getAlarmMuteStatus, shallowEqual);
   const [audio] = useState(new Audio(`${process.env.PUBLIC_URL}/alarm.mp3`));
   audio.loop = true;
-  const storeData = store.getState();
-  const events = storeData.controller.eventLog.nextLogEvents.elements;
-  const [playing, setPlaying] = useState(alarmMuteStatus.active);
-  const patientLogEvent = events.find((el: LogEvent) => (el.type as number) < 2);
+  const alarmLogEvents = useSelector(getAlarmLogEvents, shallowEqual);
+  const [playing, setPlaying] = useState<boolean>(alarmMuteStatus.active);
   useEffect(() => {
     if (playing) {
       audio.play();
@@ -95,7 +94,7 @@ const AudioAlarm = (): JSX.Element => {
   useEffect(() => {
     if (popupEventLog) {
       setPlaying(false);
-      if (popupEventLog && patientLogEvent) {
+      if (alarmLogEvents) {
         setPlaying(true);
         dispatch({ type: RED_BORDER, status: true });
       }
@@ -103,13 +102,13 @@ const AudioAlarm = (): JSX.Element => {
       setPlaying(false);
       dispatch({ type: RED_BORDER, status: false });
     }
-  }, [popupEventLog, patientLogEvent, dispatch]);
+  }, [popupEventLog, alarmLogEvents, dispatch]);
 
   useEffect(() => {
     if (popupEventLog) {
       dispatch({ type: RED_BORDER, status: !alarmMuteStatus.active });
     }
-    if (popupEventLog && patientLogEvent) {
+    if (popupEventLog && alarmLogEvents) {
       setPlaying(!alarmMuteStatus.active);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/modules/app/OverlayScreen.tsx
+++ b/frontend/src/modules/app/OverlayScreen.tsx
@@ -6,7 +6,11 @@ import store from '../../store';
 import { getClock } from '../../store/app/selectors';
 import { RED_BORDER } from '../../store/app/types';
 import { LogEvent, LogEventType } from '../../store/controller/proto/mcu_pb';
-import { getAlarmMuteStatus, getAlarms, getScreenStatus } from '../../store/controller/selectors';
+import {
+  getAlarmMuteStatus,
+  getHasActiveAlarms,
+  getScreenStatus,
+} from '../../store/controller/selectors';
 import {
   BACKEND_CONNECTION_LOST,
   BACKEND_CONNECTION_LOST_CODE,
@@ -69,7 +73,7 @@ export const HeartbeatBackendListener = (): JSX.Element => {
 
 const AudioAlarm = (): JSX.Element => {
   const dispatch = useDispatch();
-  const activeAlarms = useSelector(getAlarms, shallowEqual);
+  const activeAlarms = useSelector(getHasActiveAlarms, shallowEqual);
   const alarmMuteStatus = useSelector(getAlarmMuteStatus, shallowEqual);
   const [audio] = useState(new Audio(`${process.env.PUBLIC_URL}/alarm.mp3`));
   audio.loop = true;

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -278,12 +278,6 @@ export const getNextLogEvents = createSelector(
   (states: ControllerStates): LogEvent[] => states.eventLog.nextLogEvents.elements,
 );
 
-export const getAlarmLogEvents = createSelector(getController, (states: ControllerStates):
-  | LogEvent
-  | undefined => {
-  return states.eventLog.nextLogEvents.elements.find((el: LogEvent) => (el.type as number) < 2);
-});
-
 // Patient Alarm Event
 export const getExpectedLogEvent = createSelector(
   getController,
@@ -299,6 +293,11 @@ export const getActiveLogEventIds = createSelector(
   getController,
   (states: ControllerStates): number[] => states.eventLog.activeLogEvents.id,
 );
+
+// Active Alarms
+export const getAlarms = createSelector(getActiveLogEventIds, (activeId: number[]): boolean => {
+  return activeId.length > 0;
+});
 
 // Active popup event log
 export const getPopupEventLog = createSelector(getController, (states: ControllerStates):

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -295,9 +295,12 @@ export const getActiveLogEventIds = createSelector(
 );
 
 // Active Alarms
-export const getAlarms = createSelector(getActiveLogEventIds, (activeId: number[]): boolean => {
-  return activeId.length > 0;
-});
+export const getHasActiveAlarms = createSelector(
+  getActiveLogEventIds,
+  (activeId: number[]): boolean => {
+    return activeId.length > 0;
+  },
+);
 
 // Active popup event log
 export const getPopupEventLog = createSelector(getController, (states: ControllerStates):

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -278,6 +278,12 @@ export const getNextLogEvents = createSelector(
   (states: ControllerStates): LogEvent[] => states.eventLog.nextLogEvents.elements,
 );
 
+export const getAlarmLogEvents = createSelector(getController, (states: ControllerStates):
+  | LogEvent
+  | undefined => {
+  return states.eventLog.nextLogEvents.elements.find((el: LogEvent) => (el.type as number) < 2);
+});
+
 // Patient Alarm Event
 export const getExpectedLogEvent = createSelector(
   getController,


### PR DESCRIPTION
Currently:
- plays alarms for the patient and system log events

**Bugs:**
- start ventilation -> pause ventilation -> start ventilation again-> in dashboard alarm gets triggered, to mute we need to toggle `mute icon` twice to get it working.

Can be reproduced on develop as well.
seems to be a state issue or useEffect