### PR TITLE
Initialize frontend rotary encoder state from the backend

### DIFF
--- a/frontend/src/store/controller/reducers/backend.ts
+++ b/frontend/src/store/controller/reducers/backend.ts
@@ -158,11 +158,14 @@ export const rotaryEncoderReducer = (
       }
 
       const newState = action.state as RotaryEncoder;
+      if (state === null) {
+        // initialize the store with the backend's value
+        return { ...newState, stepDiff: 0 };
+      }
+
       const oldState = state as RotaryEncoder;
       const stepDiff = newState.step - oldState.step;
-      const stateCopy = { ...newState } as RotaryEncoderParameter;
-      stateCopy.stepDiff = stepDiff;
-      return stateCopy;
+      return { ...newState, stepDiff };
     }
     default:
       return state;


### PR DESCRIPTION
This PR fixes #349 by making the frontend's rotary encoder reducer handle the case where its state is null (which is always how the frontend starts) and it receives a RotaryEncoder message from the backend. This is a very tiny hotfix and I've tested it on my Raspberry Pi setup; @raavilagoo once you test it and confirm that the frontend responds when you turn the rotary dial, I'll merge in this PR. For records-keeping:

1. This project is licensed under Apache License v2.0 for any software, and Solderpad Hardware License v2.1 for any hardware - do you agree that your contributions to this project will be under these licenses, too? **Yes**
2. Were any of these contributions also part of work you did for an employer or a client? **No**
3. Does this work include, or is it based on, any third-party work which you did not create? **No**