### PR TITLE
frontend: show correct values in HFNCControl

### DIFF
--- a/frontend/src/modules/displays/MultiStepWizard.tsx
+++ b/frontend/src/modules/displays/MultiStepWizard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { Subscription } from 'rxjs';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles, Theme, Grid, Tabs, Tab, Button, Typography } from '@material-ui/core';
 import ReplyIcon from '@material-ui/icons/Reply';
 // import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
@@ -12,6 +12,7 @@ import {
   roundValue,
   getParametersRequestDraftFlow,
   getParametersRequestDraftFiO2,
+  getAlarmLimitsRequestUnsaved,
 } from '../../store/controller/selectors';
 import { SetValueContent } from '../controllers/ValueModal';
 import { a11yProps, TabPanel } from '../controllers/TabPanel';
@@ -280,6 +281,7 @@ const determineInput = (stateKey: string): Data | undefined => {
 const MultiStepWizard = (): JSX.Element => {
   const classes = useStyles();
   const dispatch = useDispatch();
+  const alarmLimitsRequestUnsaved = useSelector(getAlarmLimitsRequestUnsaved);
   const [open, setOpen] = React.useState(false);
   const [confirmOpen, setConfirmOpen] = React.useState(false);
   const [cancelOpen, setCancelOpen] = React.useState(false);
@@ -368,9 +370,9 @@ const MultiStepWizard = (): JSX.Element => {
       if (param) param.alarmValues = [min, max];
       parameter.alarmValues = [min, max];
       // we want to dispatch commitDraftRequest to AlarmLimitsRequest to show the unsaved alarm limit changes
-      // in the HFNC control (value info right corner), but doing so when in set alarms page will discard the unsaved changes
-      // which is unwanted, thus only do this when we are on dashboard.
-      if (open) {
+      // in the HFNC control (value info right corner), but only dispatch the update if there are no unsaved changes
+      // and multiPopup window is open.
+      if (open && !alarmLimitsRequestUnsaved) {
         const update = {
           [parameter.stateKey]: {
             lower: min,


### PR DESCRIPTION
This PR fixes the remaining parts of #307  :
- Fixes bug introduced in #338 where unsaved changes from alarm limits modal only showed in the hfnc control in dashboard,
This bug was fixed by checking if multiPopUp window is `open` using the `getMultiPopupOpenState` whereas previously it was checking if we are on the dashboard, 
if it's not open the dispatch to `store.controller.alarmLimits.draft` is not made.
The same thing applies for parametersRequest, 
for alarms there is another check which checks if there are any `unsaved` changes using the `getAlarmLimitsRequestUnsaved` selector, this was done to fix the following scenario:
make some unsaved change in alarms page -> open alarms modal from multipopup and close without doing any change (before the check it would already dispatch the local state to store.controller.alarmLimits.draft, which would discard the unsaved changes) made in alarms page
- so any increment is dispatched only if those checks are passed.
- fixes HFNC control for FIO2 and Flow showing measurements instead of showing setting change.