### PR TITLE
Fix frontend handling of rotary encoder changes with ValueClicker

### DIFF
--- a/frontend/src/modules/controllers/RotaryEncodeController.tsx
+++ b/frontend/src/modules/controllers/RotaryEncodeController.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import {
-  getRotaryEncoderButtonPressed,
+  // getRotaryEncoderButtonPressed,
   getRotaryEncoderStep,
   getRotaryEncoderStepDiff,
 } from '../../store/controller/selectors';
@@ -47,7 +47,7 @@ export const RotaryEncodeController = ({
 }: Props): JSX.Element => {
   const step = useSelector(getRotaryEncoderStep, shallowEqual);
   const stepDiff = useSelector(getRotaryEncoderStepDiff, shallowEqual);
-  const buttonPressed = useSelector(getRotaryEncoderButtonPressed, shallowEqual);
+  // const buttonPressed = useSelector(getRotaryEncoderButtonPressed, shallowEqual);
   const [prevStep, setPrevStep] = React.useState(step);
   const isInitialMount = useRef(true);
 

--- a/frontend/src/modules/controllers/RotaryEncodeController.tsx
+++ b/frontend/src/modules/controllers/RotaryEncodeController.tsx
@@ -46,7 +46,7 @@ export const RotaryEncodeController = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [rotaryEncoder?.step, rotaryEncoder?.buttonPressed, min, max, value],
+    [rotaryEncoder?.step, rotaryEncoder?.buttonPressed, min, max],
   );
 
   useEffect(() => {

--- a/frontend/src/modules/controllers/RotaryEncodeController.tsx
+++ b/frontend/src/modules/controllers/RotaryEncodeController.tsx
@@ -4,7 +4,11 @@
  */
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
-import { getRotaryEncoder } from '../../store/controller/selectors';
+import {
+  getRotaryEncoderButtonPressed,
+  getRotaryEncoderStep,
+  getRotaryEncoderStepDiff,
+} from '../../store/controller/selectors';
 
 /**
  * @typedef Props
@@ -41,31 +45,39 @@ export const RotaryEncodeController = ({
   max = 100,
   isActive,
 }: Props): JSX.Element => {
-  const rotaryEncoder = useSelector(getRotaryEncoder, shallowEqual);
+  const step = useSelector(getRotaryEncoderStep, shallowEqual);
+  const stepDiff = useSelector(getRotaryEncoderStepDiff, shallowEqual);
+  const buttonPressed = useSelector(getRotaryEncoderButtonPressed, shallowEqual);
+  const [prevStep, setPrevStep] = React.useState(step);
   const isInitialMount = useRef(true);
 
   const updateRotaryData = useCallback(
     () => {
-      if (isInitialMount.current) {
+      if (!isInitialMount.current) {
         isInitialMount.current = false;
-      } else if (!Number.isNaN(rotaryEncoder?.stepDiff)) {
-        const stepDiff = rotaryEncoder?.stepDiff || 0;
-        const valueClone = value >= min ? value : min;
-        const newValue = valueClone + stepDiff;
-        if (newValue < min) {
-          onClick(min);
-        } else if (newValue > max) {
-          onClick(max);
-        } else {
-          onClick(newValue);
-        }
-        // if (rotaryEncoder.buttonPressed) {
-        //   handleConfirm();
-        // }
+        return;
       }
+      if (Number.isNaN(stepDiff)) {
+        return;
+      }
+      if (step === prevStep) {
+        return;
+      }
+      setPrevStep(step);
+      const newValue = value + stepDiff;
+      if (newValue < min) {
+        onClick(min);
+      } else if (newValue > max) {
+        onClick(max);
+      } else {
+        onClick(newValue);
+      }
+      // if (buttonPressed) {
+      //   handleConfirm();
+      // }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [rotaryEncoder?.step, rotaryEncoder?.buttonPressed, min, max],
+    [step, min, max, value, prevStep, onClick],
   );
 
   useEffect(() => {

--- a/frontend/src/modules/controllers/RotaryEncodeController.tsx
+++ b/frontend/src/modules/controllers/RotaryEncodeController.tsx
@@ -3,7 +3,7 @@
  *
  */
 import React, { useCallback, useEffect, useRef } from 'react';
-import { useSelector, shallowEqual } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
   // getRotaryEncoderButtonPressed,
   getRotaryEncoderStep,
@@ -45,40 +45,36 @@ export const RotaryEncodeController = ({
   max = 100,
   isActive,
 }: Props): JSX.Element => {
-  const step = useSelector(getRotaryEncoderStep, shallowEqual);
-  const stepDiff = useSelector(getRotaryEncoderStepDiff, shallowEqual);
-  // const buttonPressed = useSelector(getRotaryEncoderButtonPressed, shallowEqual);
+  const step = useSelector(getRotaryEncoderStep);
+  const stepDiff = useSelector(getRotaryEncoderStepDiff);
+  // const buttonPressed = useSelector(getRotaryEncoderButtonPressed);
   const [prevStep, setPrevStep] = React.useState(step);
   const isInitialMount = useRef(true);
 
-  const updateRotaryData = useCallback(
-    () => {
-      if (!isInitialMount.current) {
-        isInitialMount.current = false;
-        return;
-      }
-      if (Number.isNaN(stepDiff)) {
-        return;
-      }
-      if (step === prevStep) {
-        return;
-      }
-      setPrevStep(step);
-      const newValue = value + stepDiff;
-      if (newValue < min) {
-        onClick(min);
-      } else if (newValue > max) {
-        onClick(max);
-      } else {
-        onClick(newValue);
-      }
-      // if (buttonPressed) {
-      //   handleConfirm();
-      // }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [step, min, max, value, prevStep, onClick],
-  );
+  const updateRotaryData = useCallback(() => {
+    if (!isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    if (Number.isNaN(stepDiff)) {
+      return;
+    }
+    if (step === prevStep) {
+      return;
+    }
+    setPrevStep(step);
+    const newValue = value + stepDiff;
+    if (newValue < min) {
+      onClick(min);
+    } else if (newValue > max) {
+      onClick(max);
+    } else {
+      onClick(newValue);
+    }
+    // if (buttonPressed) {
+    //   handleConfirm();
+    // }
+  }, [step, stepDiff, min, max, value, prevStep, onClick]);
 
   useEffect(() => {
     if (isActive) {

--- a/frontend/src/modules/controllers/ValueModal.tsx
+++ b/frontend/src/modules/controllers/ValueModal.tsx
@@ -4,6 +4,7 @@ import { shallowEqual, useSelector } from 'react-redux';
 import ValueClicker from './ValueClicker';
 import ModalPopup from './ModalPopup';
 import { getRotaryEncoder } from '../../store/controller/selectors';
+import { RotaryEncodeController } from './RotaryEncodeController';
 
 const useStyles = makeStyles((theme: Theme) => ({
   contentContainer: {
@@ -102,38 +103,6 @@ export const ValueModal = ({
     setOpen(false);
   };
 
-  const updateRotaryData = useCallback(
-    () => {
-      if (rotaryEncoder === null) {
-        return;
-      }
-
-      if (!open) {
-        return;
-      }
-
-      const stepDiff = rotaryEncoder.stepDiff || 0;
-      const valueClone = value >= min ? value : min;
-      const newValue = valueClone + stepDiff;
-      if (newValue < min) {
-        setValue(min);
-      } else if (newValue > max) {
-        setValue(max);
-      } else {
-        setValue(newValue);
-      }
-      if (rotaryEncoder.buttonPressed) {
-        handleConfirm();
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [rotaryEncoder, min, max],
-  );
-
-  useEffect(() => {
-    updateRotaryData();
-  }, [updateRotaryData]);
-
   function pipClarify(label: string) {
     if (label === 'PIP') return '*not PEEP compensated';
     return '';
@@ -181,6 +150,17 @@ export const ValueModal = ({
           </Button>
         )}
       </Grid>
+      {rotaryEncoder !== null ? (
+        <RotaryEncodeController
+          isActive={true}
+          value={value}
+          onClick={(num: number) => {
+            setValue(num);
+          }}
+          min={min}
+          max={max}
+        />
+      ) : null}
       <ModalPopup
         withAction={true}
         label="Set New"
@@ -209,6 +189,7 @@ export const SetValueContent = ({
   const rotaryEncoder = useSelector(getRotaryEncoder, shallowEqual);
   const [open, setOpen] = React.useState(openModal);
   const [value, setValue] = React.useState(committedSetting);
+  const [isRotaryActive, setIsRotaryActive] = React.useState(false);
 
   useEffect(() => {
     setOpen(openModal);
@@ -236,46 +217,18 @@ export const SetValueContent = ({
     requestCommitSetting(value);
   }, [requestCommitSetting, value]);
 
-  const handleConfirm = () => {
-    requestCommitSetting(value);
-  };
-
-  const updateRotaryData = useCallback(
-    () => {
-      if (rotaryEncoder === null) {
-        return;
-      }
-
-      if (!open || Number.isNaN(rotaryEncoder.stepDiff)) {
-        return;
-      }
-
-      const stepDiff = rotaryEncoder.stepDiff || 0;
-      const valueClone = value >= min ? value : min;
-      const newValue = valueClone + stepDiff;
-      if (newValue < min) {
-        setValue(min);
-      } else if (newValue > max) {
-        setValue(max);
-      } else {
-        setValue(newValue);
-      }
-      if (rotaryEncoder.buttonPressed) {
-        handleConfirm();
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [rotaryEncoder, min, max],
-  );
+  // const handleConfirm = () => {
+  //   requestCommitSetting(value);
+  // };
 
   useEffect(() => {
     // Disable on initial mount since multi step dialog will run everytime when dialog opens
     if (isInitialMount.current) {
       isInitialMount.current = false;
     } else {
-      updateRotaryData();
+      setIsRotaryActive(true);
     }
-  }, [updateRotaryData, rotaryEncoder]);
+  }, [rotaryEncoder]);
 
   function pipClarify(label: string) {
     if (label === 'PIP') return '*not PEEP compensated';
@@ -312,7 +265,20 @@ export const SetValueContent = ({
 
   return (
     <Grid container direction="column" alignItems="center" justify="center">
-      {modalContent}
+      {rotaryEncoder !== null ? (
+        <RotaryEncodeController
+          isActive={isRotaryActive}
+          value={value}
+          onClick={(num: number) => {
+            setValue(num);
+          }}
+          min={min}
+          max={max}
+        />
+      ) : null}
+      <Grid container direction="column" alignItems="center" justify="center">
+        {modalContent}
+      </Grid>
     </Grid>
   );
 };

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -334,6 +334,21 @@ export const getRotaryEncoder = createSelector(
   getController,
   (states: ControllerStates): RotaryEncoderParameter | null => states.rotaryEncoder,
 );
+export const getRotaryEncoderStep = createSelector(
+  getRotaryEncoder,
+  (rotaryEncoder: RotaryEncoderParameter | null) =>
+    rotaryEncoder === null ? 0 : rotaryEncoder.step,
+);
+export const getRotaryEncoderStepDiff = createSelector(
+  getRotaryEncoder,
+  (rotaryEncoder: RotaryEncoderParameter | null) =>
+    rotaryEncoder === null ? 0 : rotaryEncoder.stepDiff,
+);
+export const getRotaryEncoderButtonPressed = createSelector(
+  getRotaryEncoder,
+  (rotaryEncoder: RotaryEncoderParameter | null) =>
+    rotaryEncoder === null ? false : rotaryEncoder.buttonPressed,
+);
 
 // System Settings
 

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -337,17 +337,17 @@ export const getRotaryEncoder = createSelector(
 export const getRotaryEncoderStep = createSelector(
   getRotaryEncoder,
   (rotaryEncoder: RotaryEncoderParameter | null) =>
-    rotaryEncoder === null ? 0 : rotaryEncoder.step,
+    rotaryEncoder === null ? 0 : rotaryEncoder?.step,
 );
 export const getRotaryEncoderStepDiff = createSelector(
   getRotaryEncoder,
   (rotaryEncoder: RotaryEncoderParameter | null) =>
-    rotaryEncoder === null ? 0 : rotaryEncoder.stepDiff,
+    rotaryEncoder === null ? 0 : rotaryEncoder?.stepDiff,
 );
 export const getRotaryEncoderButtonPressed = createSelector(
   getRotaryEncoder,
   (rotaryEncoder: RotaryEncoderParameter | null) =>
-    rotaryEncoder === null ? false : rotaryEncoder.buttonPressed,
+    rotaryEncoder === null ? false : rotaryEncoder?.buttonPressed,
 );
 
 // System Settings


### PR DESCRIPTION
This PR fixes #356 
Regression from #296 

`Set Value` Modal in multistep popup wasn't affected by this regression as it has its own local function to update the rotary data that did not have the value dependency in `useCallback` hook