### PR TITLE
Fix compiler warnings for unit test cases in firmware

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp
@@ -27,7 +27,6 @@ SCENARIO(
   using TestCRCElementProps = PF::Protocols::CRCElementProps<buffer_size>;
   using TestCRCElement = PF::Protocols::CRCElement<TestCRCElementProps::PayloadBuffer>;
   using TestCRCElementHeaderProps = PF::Protocols::CRCElementHeaderProps;
-  using TestParsedCRCElement = PF::Protocols::ParsedCRCElement<buffer_size>;
 
   PF::HAL::SoftCRC32 crc32c{PF::HAL::crc32c_params};
   GIVEN("The CRCElement::compute_body_crc static method") {

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/Chunks.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/Chunks.cpp
@@ -12,8 +12,6 @@
 
 #include "Pufferfish/Protocols/Chunks.h"
 
-#include <iostream>
-
 #include "Pufferfish/Test/Util.h"
 #include "Pufferfish/Util/Array.h"
 #include "Pufferfish/Util/Vector.h"
@@ -29,7 +27,7 @@ SCENARIO(
     "[chunks]") {
   constexpr size_t buffer_size = 256;
   PF::Protocols::ChunkSplitter<buffer_size, uint8_t> chunks;
-  PF::Protocols::ChunkInputStatus status;
+  PF::Protocols::ChunkInputStatus input_status;
   PF::Protocols::ChunkOutputStatus output_status;
   PF::Util::ByteVector<buffer_size> output_buffer;
   bool input_overwritten = false;
@@ -42,8 +40,6 @@ SCENARIO(
         "102 non-delimiter bytes are passed as input, and 103rd byte is passed as a delimiter, and "
         "output is called between each input") {
       uint8_t val = 128;
-      bool input_overwritten = false;
-      PF::Protocols::ChunkInputStatus input_status;
 
       for (size_t i = 0; i < buffer_size; ++i) {
         input_status = chunks.input(val, input_overwritten);
@@ -71,7 +67,6 @@ SCENARIO(
 
   GIVEN("A uint8_t chunksplitter with an empty internal buffer of capacity 256 bytes") {
     PF::Protocols::ChunkInputStatus status;
-    bool input_overwritten = false;
     PF::Util::ByteVector<buffer_size> output_buffer;
     REQUIRE(output_buffer.empty() == true);
 
@@ -688,7 +683,6 @@ SCENARIO(
       "of capacity 256 bytes") {
     constexpr size_t buffer_size = 256;
     PF::Protocols::ChunkSplitter<buffer_size, uint8_t> chunks{};
-    uint8_t val = 128;
     PF::Protocols::ChunkInputStatus input_status;
     PF::Protocols::ChunkOutputStatus output_status;
     PF::Util::ByteVector<buffer_size> output_buffer;
@@ -912,7 +906,6 @@ SCENARIO(
     constexpr size_t buffer_size = 256;
     bool include_delimiter = true;
     PF::Protocols::ChunkSplitter<buffer_size, uint8_t> chunks{0x00, include_delimiter};
-    uint8_t val = 128;
     PF::Protocols::ChunkInputStatus input_status;
     PF::Protocols::ChunkOutputStatus output_status;
     PF::Util::ByteVector<buffer_size> output_buffer;
@@ -1022,12 +1015,10 @@ SCENARIO("Protocols::ChunkMerger behaves correctly", "[chunks]") {
     constexpr size_t buffer_size = 30;
     PF::Protocols::ChunkMerger chunk_merger{};
     PF::Protocols::ChunkOutputStatus output_status;
-    bool input_overwritten = false;
 
     WHEN("A partially full buffer of size 10 bytes is passed as input to transform method") {
       constexpr size_t size = 10;
       PF::Util::ByteVector<size> buffer;
-      PF::IndexStatus index_status;
 
       for (size_t i = 0; i < size - 1; ++i) {
         uint8_t val = 10;
@@ -1065,7 +1056,6 @@ SCENARIO("Protocols::ChunkMerger behaves correctly", "[chunks]") {
     WHEN("An input data with it's last byte equal to the delimiter is passed to transform") {
       constexpr size_t size = 10;
       PF::Util::ByteVector<size> buffer;
-      PF::IndexStatus index_status;
 
       for (size_t i = 0; i < size - 2; ++i) {
         uint8_t val = 10;
@@ -1088,7 +1078,6 @@ SCENARIO("Protocols::ChunkMerger behaves correctly", "[chunks]") {
     WHEN("An input data with it's first byte equal to the delimiter is passed to transform") {
       constexpr size_t size = 10;
       PF::Util::ByteVector<size> buffer;
-      PF::IndexStatus index_status;
 
       buffer.push_back(0x00);
 
@@ -1111,7 +1100,6 @@ SCENARIO("Protocols::ChunkMerger behaves correctly", "[chunks]") {
     WHEN("An input data with multiple delimited chunks is passed as input to transform") {
       constexpr size_t size = 10;
       PF::Util::ByteVector<size> buffer;
-      PF::IndexStatus index_status;
 
       auto data =
           PF::Util::make_array<uint8_t>(0x01, 0x02, 0x00, 0x03, 0x00, 0x04, 0x05, 0x00, 0x07);
@@ -1136,12 +1124,10 @@ SCENARIO("Protocols::ChunkMerger behaves correctly", "[chunks]") {
     constexpr size_t buffer_size = 30;
     PF::Protocols::ChunkMerger chunk_merger{0x01};
     PF::Protocols::ChunkOutputStatus output_status;
-    bool input_overwritten = false;
 
     WHEN("A partially full buffer of size 10 bytes is passed as input to transform method") {
       constexpr size_t size = 10;
       PF::Util::ByteVector<size> buffer;
-      PF::IndexStatus index_status;
 
       for (size_t i = 0; i < size - 1; ++i) {
         uint8_t val = 10;

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/Datagrams.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/Datagrams.cpp
@@ -183,7 +183,7 @@ SCENARIO(
     // as payload buffer is a ByteVector of size 252
     int payload_size = GENERATE(0, 252);
 
-    for (size_t i = 0; i < payload_size; ++i) {
+    for (int i = 0; i < payload_size; ++i) {
       uint8_t val = 9;
       input_payload.push_back(val);
     }
@@ -205,7 +205,7 @@ SCENARIO(
       }
       THEN("The payload returned by the paylaod accessor method remains unchanged") {
         auto buffer = datagram.payload();
-        for (size_t i = 0; i < payload_size; ++i) {
+        for (int i = 0; i < payload_size; ++i) {
           uint8_t val = 9;
           REQUIRE(buffer.operator[](i) == val);
         }
@@ -223,7 +223,7 @@ SCENARIO(
       THEN(
           "The body's payload section correctly stores the paylaod as '0x09 ...' for varying "
           "payload lengths") {
-        for (size_t i = 2; i < payload_size + 1; ++i) {
+        for (int i = 2; i < payload_size + 1; ++i) {
           uint8_t val = 9;
           REQUIRE(output_buffer.operator[](i) == val);
         }
@@ -231,7 +231,7 @@ SCENARIO(
       THEN("The output buffer is as expected for all the different paylaod buffers") {
         REQUIRE(output_buffer.operator[](0) == 0);
         REQUIRE(output_buffer.operator[](1) == payload_size);
-        for (size_t i = 2; i < payload_size + 1; ++i) {
+        for (int i = 2; i < payload_size + 1; ++i) {
           uint8_t val = 9;
           REQUIRE(output_buffer.operator[](i) == val);
         }
@@ -1767,7 +1767,6 @@ SCENARIO(
 
     WHEN("The input payload to the transform method is '0x00 0x00'") {
       using TestDatagramProps = PF::Protocols::DatagramProps<buffer_size>;
-      using TestDatagram = PF::Protocols::Datagram<TestDatagramProps::PayloadBuffer>;
 
       auto data = std::string("\x00\x00", 2);
 
@@ -1798,7 +1797,6 @@ SCENARIO(
     "[DatagramSender]") {
   constexpr size_t buffer_size = 254UL;
   using TestDatagramProps = PF::Protocols::DatagramProps<buffer_size>;
-  using TestDatagram = PF::Protocols::Datagram<TestDatagramProps::PayloadBuffer>;
   using TestDatagramSender = PF::Protocols::DatagramSender<buffer_size>;
   using TestDatagramHeaderProps = PF::Protocols::DatagramHeaderProps;
   TestDatagramSender datagram_sender{};

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/Datagrams.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/Datagrams.cpp
@@ -181,9 +181,9 @@ SCENARIO(
       "A Datagram constructed with a non-empty payload buffer of any length from 0 to 252 and "
       "sequence equal to 0") {
     // as payload buffer is a ByteVector of size 252
-    int payload_size = GENERATE(0, 252);
+    size_t payload_size = GENERATE(0, 252);
 
-    for (int i = 0; i < payload_size; ++i) {
+    for (size_t i = 0; i < payload_size; ++i) {
       uint8_t val = 9;
       input_payload.push_back(val);
     }
@@ -205,7 +205,7 @@ SCENARIO(
       }
       THEN("The payload returned by the paylaod accessor method remains unchanged") {
         auto buffer = datagram.payload();
-        for (int i = 0; i < payload_size; ++i) {
+        for (size_t i = 0; i < payload_size; ++i) {
           uint8_t val = 9;
           REQUIRE(buffer.operator[](i) == val);
         }
@@ -223,7 +223,7 @@ SCENARIO(
       THEN(
           "The body's payload section correctly stores the paylaod as '0x09 ...' for varying "
           "payload lengths") {
-        for (int i = 2; i < payload_size + 1; ++i) {
+        for (size_t i = 2; i < payload_size + 1; ++i) {
           uint8_t val = 9;
           REQUIRE(output_buffer.operator[](i) == val);
         }
@@ -231,7 +231,7 @@ SCENARIO(
       THEN("The output buffer is as expected for all the different paylaod buffers") {
         REQUIRE(output_buffer.operator[](0) == 0);
         REQUIRE(output_buffer.operator[](1) == payload_size);
-        for (int i = 2; i < payload_size + 1; ++i) {
+        for (size_t i = 2; i < payload_size + 1; ++i) {
           uint8_t val = 9;
           REQUIRE(output_buffer.operator[](i) == val);
         }

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/Messages.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/Messages.cpp
@@ -131,7 +131,6 @@ SCENARIO(
         REQUIRE(test_message.payload.tag == PF::Application::MessageTypes::unknown);
       }
       THEN("The payload.values field data remains unchanged") {
-        ParametersRequest parameters_request;
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access);
         REQUIRE(test_message.payload.value.parameters_request.flow == 0);
       }
@@ -595,7 +594,6 @@ SCENARIO(
         REQUIRE(test_message.payload.tag == PF::Application::MessageTypes::sensor_measurements);
       }
       THEN("The payload.values field data remains unchanged") {
-        ParametersRequest parameters_request;
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access);
         REQUIRE(test_message.payload.value.parameters_request.flow == 0);
       }
@@ -1392,7 +1390,6 @@ SCENARIO(
     WHEN(
         "A body with an empty payload and 1 byte header of value equal to the message descriptor "
         "array size is parsed") {
-      constexpr size_t num_descriptors = 4;
       constexpr auto message_descriptors = PF::Util::make_array<PF::Util::ProtobufDescriptor>(
           // array index should match the type code value
           PF::Util::get_protobuf_descriptor<PF::Util::UnrecognizedMessage>(),  // 0
@@ -1819,7 +1816,6 @@ SCENARIO(
     const auto exp_alarm_limits = std::string("\x06\x12\x04\x08\x15\x10\x64"s);
     const auto exp_alarm_limits_request = std::string("\x07\x12\x04\x08\x32\x10\x5C"s);
 
-    using TestTaggedUnion = PF::Application::StateSegment;
     constexpr size_t payload_max_size = 252UL;
     using TestMessage = PF::Protocols::Message<
         PF::Application::StateSegment,

--- a/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/States.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/States.cpp
@@ -177,12 +177,8 @@ SCENARIO(
     using BackendStateSynchronizer = PF::Protocols::
         StateSynchronizer<Store, StateSegment, MessageTypes, state_sync_schedule.size()>;
 
-    const BackendStateSynchronizer::OutputStatus output_ok =
-        BackendStateSynchronizer::OutputStatus::ok;
     const BackendStateSynchronizer::OutputStatus invalid_type =
         BackendStateSynchronizer::OutputStatus::invalid_type;
-    const BackendStateSynchronizer::OutputStatus waiting =
-        BackendStateSynchronizer::OutputStatus::waiting;
 
     Store store{};
 
@@ -224,8 +220,6 @@ SCENARIO(
 
     const BackendStateSynchronizer::OutputStatus output_ok =
         BackendStateSynchronizer::OutputStatus::ok;
-    const BackendStateSynchronizer::OutputStatus waiting =
-        BackendStateSynchronizer::OutputStatus::waiting;
 
     Store store{};
 
@@ -486,8 +480,6 @@ SCENARIO(
 
     const BackendStateSynchronizer::OutputStatus output_ok =
         BackendStateSynchronizer::OutputStatus::ok;
-    const BackendStateSynchronizer::OutputStatus waiting =
-        BackendStateSynchronizer::OutputStatus::waiting;
 
     Store store{};
 
@@ -681,8 +673,6 @@ SCENARIO(
 
     const BackendStateSynchronizer::OutputStatus output_ok =
         BackendStateSynchronizer::OutputStatus::ok;
-    const BackendStateSynchronizer::OutputStatus waiting =
-        BackendStateSynchronizer::OutputStatus::waiting;
 
     Store store{};
 
@@ -780,8 +770,6 @@ SCENARIO(
 
     const BackendStateSynchronizer::OutputStatus output_ok =
         BackendStateSynchronizer::OutputStatus::ok;
-    const BackendStateSynchronizer::OutputStatus waiting =
-        BackendStateSynchronizer::OutputStatus::waiting;
 
     Store store{};
 


### PR DESCRIPTION
This PR fixes: 
- compiler warnings generated in catch2 test coverage which are basically unused variables that were left out among some other warnings.
- few examples:
`/home/runner/work/pufferfish-software/pufferfish-software/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/CRCElements.cpp:30:9: warning: typedef ‘using TestParsedCRCElement = Pufferfish::Protocols::ParsedCRCElement<254>’ locally defined but not used [-Wunused-local-typedefs]
   30 |   using TestParsedCRCElement = PF::Protocols::ParsedCRCElement<buffer_size>;
      |         ^~~~~~~~~~~~~~~~~~~~`

  `/home/runner/work/pufferfish-software/pufferfish-software/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/Chunks.cpp: In function ‘void ____C_A_T_C_H____T_E_S_T____0()’:
  /home/runner/work/pufferfish-software/pufferfish-software/firmware/ventilator-controller-stm32/Core/Test/Pufferfish/Protocols/Chunks.cpp:32:35: warning: unused variable ‘status’ [-Wunused-variable]
     32 |   PF::Protocols::ChunkInputStatus status;
        |                                   ^~~~~~`

The full log can be viewed here - [under 'Run make'](https://github.com/pez-globo/pufferfish-software/runs/2694611104)