### PR TITLE
Prevent upper alarm limit from being set below lower limit in the frontend

### DIFF
--- a/frontend/src/modules/alarms/AlarmsPage.tsx
+++ b/frontend/src/modules/alarms/AlarmsPage.tsx
@@ -219,16 +219,8 @@ const Alarm = ({
    * are the current AlarmLimits
    */
   useEffect(() => {
-    if (rangeValues[1] <= rangeValues[0]) {
-      setDisableDecrement(true);
-    } else {
-      setDisableDecrement(false);
-    }
-    if (rangeValues[0] >= rangeValues[1]) {
-      setDisableIncrement(true);
-    } else {
-      setDisableIncrement(false);
-    }
+    setDisableDecrement(rangeValues[1] <= rangeValues[0]);
+    setDisableIncrement(rangeValues[0] >= rangeValues[1]);
   }, [rangeValues]);
 
   /**

--- a/frontend/src/modules/alarms/AlarmsPage.tsx
+++ b/frontend/src/modules/alarms/AlarmsPage.tsx
@@ -200,6 +200,11 @@ const Alarm = ({
     setActiveRotaryReference(
       type === SliderType.LOWER ? `${stateKey}_LOWER` : `${stateKey}_HIGHER`,
     );
+    if (type === SliderType.LOWER) {
+      setDisableIncrement(value >= rangeValues[1]);
+    } else {
+      setDisableDecrement(value <= rangeValues[0]);
+    }
     setAlarmLimits({
       [stateKey]: {
         lower: type === SliderType.LOWER ? value : rangeValues[0],

--- a/frontend/src/modules/alarms/AlarmsPage.tsx
+++ b/frontend/src/modules/alarms/AlarmsPage.tsx
@@ -207,6 +207,21 @@ const Alarm = ({
       },
     });
   };
+  const [disableDecrement, setDisableDecrement] = useState(false);
+  const [disableIncrement, setDisableIncrement] = useState(false);
+
+  useEffect(() => {
+    if (rangeValues[1] <= rangeValues[0]) {
+      setDisableDecrement(true);
+    } else {
+      setDisableDecrement(false);
+    }
+    if (rangeValues[0] >= rangeValues[1]) {
+      setDisableIncrement(true);
+    } else {
+      setDisableIncrement(false);
+    }
+  }, [rangeValues]);
 
   /**
    * Calls on initalization of the component
@@ -257,6 +272,7 @@ const Alarm = ({
                 onClick={(value: number) => onClick(value, SliderType.LOWER)}
                 min={min}
                 max={max}
+                disableMin={disableIncrement}
                 direction="column"
               />
             </Grid>
@@ -289,6 +305,7 @@ const Alarm = ({
                 onClick={(value: number) => onClick(value, SliderType.UPPER)}
                 min={min}
                 max={max}
+                disableMax={disableDecrement}
                 direction="column"
               />
             </Grid>

--- a/frontend/src/modules/alarms/AlarmsPage.tsx
+++ b/frontend/src/modules/alarms/AlarmsPage.tsx
@@ -207,9 +207,17 @@ const Alarm = ({
       },
     });
   };
+
+  /**
+   * Local state to pass to ValueClicker to disable increment/decrement buttons
+   */
   const [disableDecrement, setDisableDecrement] = useState(false);
   const [disableIncrement, setDisableIncrement] = useState(false);
 
+  /**
+   * This is a changeListener that sets disableDecrement, disableIncrement on change in RangeValues which
+   * are the current AlarmLimits
+   */
   useEffect(() => {
     if (rangeValues[1] <= rangeValues[0]) {
       setDisableDecrement(true);

--- a/frontend/src/modules/alarms/AlarmsPage.tsx
+++ b/frontend/src/modules/alarms/AlarmsPage.tsx
@@ -7,7 +7,7 @@
 import { Button, Grid, Typography } from '@material-ui/core';
 import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import Pagination from '@material-ui/lab/Pagination';
-import React, { RefObject, useEffect, useRef, useState } from 'react';
+import React, { RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { commitRequest, commitDraftRequest } from '../../store/controller/actions';
 import { AlarmLimitsRequest, VentilationMode, Range } from '../../store/controller/proto/mcu_pb';
@@ -165,10 +165,10 @@ const Alarm = ({
     alarmLimits === null
       ? undefined
       : ((alarmLimits as unknown) as Record<string, Range>)[stateKey];
-  const rangeValues: number[] = [
-    range === undefined ? NaN : range.lower,
-    range === undefined ? NaN : range.upper,
-  ];
+  const rangeValues: number[] = useMemo(
+    () => [range === undefined ? NaN : range.lower, range === undefined ? NaN : range.upper],
+    [range],
+  );
   /**
    * State to manage Wrapper HTML reference of Alarm's lower & higher Controls(ValueSlider & ValueClicker)
    * This wrapper's HTML border is added or removed based on user's interaction with Alarm Controls

--- a/frontend/src/modules/controllers/AlarmModal.tsx
+++ b/frontend/src/modules/controllers/AlarmModal.tsx
@@ -163,6 +163,16 @@ export const AlarmModal = ({
   const [disableDecrement, setDisableDecrement] = React.useState(false);
   const [disableIncrement, setDisableIncrement] = React.useState(false);
 
+  const setUpperLimit = (value: number) => {
+    setRangeValue(Object.assign([], rangeValue, { 1: value }));
+    setDisableDecrement(value <= rangeValue[0]);
+  };
+
+  const setLowerLimit = (value: number) => {
+    setRangeValue(Object.assign([], rangeValue, { 0: value }));
+    setDisableIncrement(value >= rangeValue[1]);
+  };
+
   const initSetValue = useCallback(() => {
     setOpen(openModal);
   }, [openModal]);
@@ -289,7 +299,7 @@ export const AlarmModal = ({
                 min={committedMin}
                 max={committedMax}
                 disableMin={disableIncrement}
-                onClick={(value) => setRangeValue(Object.assign([], rangeValue, { 0: value }))}
+                onClick={setLowerLimit}
                 direction="column"
               />
             </Grid>
@@ -328,7 +338,7 @@ export const AlarmModal = ({
                 min={committedMin}
                 max={committedMax}
                 disableMax={disableDecrement}
-                onClick={(value) => setRangeValue(Object.assign([], rangeValue, { 1: value }))}
+                onClick={setUpperLimit}
                 direction="column"
               />
             </Grid>

--- a/frontend/src/modules/controllers/AlarmModal.tsx
+++ b/frontend/src/modules/controllers/AlarmModal.tsx
@@ -172,16 +172,8 @@ export const AlarmModal = ({
    * are the current AlarmLimits
    */
   useEffect(() => {
-    if (rangeValue[1] <= rangeValue[0]) {
-      setDisableDecrement(true);
-    } else {
-      setDisableDecrement(false);
-    }
-    if (rangeValue[0] >= rangeValue[1]) {
-      setDisableIncrement(true);
-    } else {
-      setDisableIncrement(false);
-    }
+    setDisableDecrement(rangeValue[1] <= rangeValue[0]);
+    setDisableIncrement(rangeValue[0] >= rangeValue[1]);
   }, [rangeValue]);
 
   useEffect(() => {

--- a/frontend/src/modules/controllers/AlarmModal.tsx
+++ b/frontend/src/modules/controllers/AlarmModal.tsx
@@ -157,10 +157,25 @@ export const AlarmModal = ({
     [`${stateKey}_LOWER`]: useRef(null),
     [`${stateKey}_HIGHER`]: useRef(null),
   });
+  const [disableDecrement, setDisableDecrement] = React.useState(false);
+  const [disableIncrement, setDisableIncrement] = React.useState(false);
 
   const initSetValue = useCallback(() => {
     setOpen(openModal);
   }, [openModal]);
+
+  useEffect(() => {
+    if (rangeValue[1] <= rangeValue[0]) {
+      setDisableDecrement(true);
+    } else {
+      setDisableDecrement(false);
+    }
+    if (rangeValue[0] >= rangeValue[1]) {
+      setDisableIncrement(true);
+    } else {
+      setDisableIncrement(false);
+    }
+  }, [rangeValue]);
 
   useEffect(() => {
     initRefListener(refs);
@@ -274,6 +289,7 @@ export const AlarmModal = ({
                 step={step}
                 min={committedMin}
                 max={committedMax}
+                disableMin={disableIncrement}
                 onClick={(value) => setRangeValue(Object.assign([], rangeValue, { 0: value }))}
                 direction="column"
               />
@@ -312,6 +328,7 @@ export const AlarmModal = ({
                 step={step}
                 min={committedMin}
                 max={committedMax}
+                disableMax={disableDecrement}
                 onClick={(value) => setRangeValue(Object.assign([], rangeValue, { 1: value }))}
                 direction="column"
               />

--- a/frontend/src/modules/controllers/AlarmModal.tsx
+++ b/frontend/src/modules/controllers/AlarmModal.tsx
@@ -157,6 +157,9 @@ export const AlarmModal = ({
     [`${stateKey}_LOWER`]: useRef(null),
     [`${stateKey}_HIGHER`]: useRef(null),
   });
+  /**
+   * Local state to pass to ValueClicker to disable increment/decrement buttons
+   */
   const [disableDecrement, setDisableDecrement] = React.useState(false);
   const [disableIncrement, setDisableIncrement] = React.useState(false);
 
@@ -164,6 +167,10 @@ export const AlarmModal = ({
     setOpen(openModal);
   }, [openModal]);
 
+  /**
+   * This is a changeListener that sets disableDecrement, disableIncrement on change in RangeValues which
+   * are the current AlarmLimits
+   */
   useEffect(() => {
     if (rangeValue[1] <= rangeValue[0]) {
       setDisableDecrement(true);

--- a/frontend/src/modules/controllers/RotaryEncodeController.tsx
+++ b/frontend/src/modules/controllers/RotaryEncodeController.tsx
@@ -27,7 +27,6 @@ interface Props {
   min?: number;
   max?: number;
   isActive: boolean;
-  disableChange?: boolean;
 }
 
 /**
@@ -45,7 +44,6 @@ export const RotaryEncodeController = ({
   min = 0,
   max = 100,
   isActive,
-  disableChange,
 }: Props): JSX.Element => {
   const step = useSelector(getRotaryEncoderStep);
   const stepDiff = useSelector(getRotaryEncoderStepDiff);
@@ -64,9 +62,6 @@ export const RotaryEncodeController = ({
     if (step === prevStep) {
       return;
     }
-    if (disableChange) {
-      return;
-    }
     setPrevStep(step);
     const newValue = value + stepDiff;
     if (newValue < min) {
@@ -79,7 +74,7 @@ export const RotaryEncodeController = ({
     // if (buttonPressed) {
     //   handleConfirm();
     // }
-  }, [step, stepDiff, disableChange, min, max, value, prevStep, onClick]);
+  }, [step, stepDiff, min, max, value, prevStep, onClick]);
 
   useEffect(() => {
     if (isActive) {

--- a/frontend/src/modules/controllers/RotaryEncodeController.tsx
+++ b/frontend/src/modules/controllers/RotaryEncodeController.tsx
@@ -79,7 +79,7 @@ export const RotaryEncodeController = ({
     // if (buttonPressed) {
     //   handleConfirm();
     // }
-  }, [step, stepDiff, min, max, value, prevStep, onClick]);
+  }, [step, stepDiff, disableChange, min, max, value, prevStep, onClick]);
 
   useEffect(() => {
     if (isActive) {

--- a/frontend/src/modules/controllers/RotaryEncodeController.tsx
+++ b/frontend/src/modules/controllers/RotaryEncodeController.tsx
@@ -27,6 +27,7 @@ interface Props {
   min?: number;
   max?: number;
   isActive: boolean;
+  disableChange?: boolean;
 }
 
 /**
@@ -44,6 +45,7 @@ export const RotaryEncodeController = ({
   min = 0,
   max = 100,
   isActive,
+  disableChange,
 }: Props): JSX.Element => {
   const step = useSelector(getRotaryEncoderStep);
   const stepDiff = useSelector(getRotaryEncoderStepDiff);
@@ -60,6 +62,9 @@ export const RotaryEncodeController = ({
       return;
     }
     if (step === prevStep) {
+      return;
+    }
+    if (disableChange) {
       return;
     }
     setPrevStep(step);

--- a/frontend/src/modules/controllers/ValueClicker.tsx
+++ b/frontend/src/modules/controllers/ValueClicker.tsx
@@ -53,6 +53,8 @@ interface Props {
   direction?: Direction;
   step?: number;
   referenceKey: string;
+  disableMax?: boolean;
+  disableMin?: boolean;
 }
 enum Type {
   INCREMENT,
@@ -75,6 +77,8 @@ export const ValueClicker = ({
   direction = 'column',
   step = 1,
   referenceKey,
+  disableMax = false,
+  disableMin = false,
 }: Props): JSX.Element => {
   const classes = useStyles();
   const [disabledInterval] = useState(100);
@@ -103,7 +107,9 @@ export const ValueClicker = ({
   useEffect(() => {
     setDisableIncrement(value >= max);
     setDisableDecrement(value <= min);
-  }, [min, max, value]);
+    setDisableDecrement(disableMax);
+    setDisableIncrement(disableMin);
+  }, [min, max, value, disableMax, disableMin]);
 
   /**
    * Click handler for Increment button

--- a/frontend/src/modules/controllers/ValueClicker.tsx
+++ b/frontend/src/modules/controllers/ValueClicker.tsx
@@ -191,6 +191,7 @@ export const ValueClicker = ({
         onClick={(num: number) => {
           onClick(num);
         }}
+        disableChange={disableMin || disableMax}
         min={min}
         max={max}
       />

--- a/frontend/src/modules/controllers/ValueClicker.tsx
+++ b/frontend/src/modules/controllers/ValueClicker.tsx
@@ -105,11 +105,9 @@ export const ValueClicker = ({
    * Validating & disabling button when reached min/max value
    */
   useEffect(() => {
-    setDisableIncrement(value >= max);
-    setDisableDecrement(value <= min);
-    setDisableDecrement(disableMax);
-    setDisableIncrement(disableMin);
-  }, [min, max, value, disableMax, disableMin]);
+    setDisableIncrement(value >= max || disableMin);
+    setDisableDecrement(value <= min || disableMax);
+  }, [min, max, value, disableMin, disableMax]);
 
   /**
    * Click handler for Increment button

--- a/frontend/src/modules/controllers/ValueClicker.tsx
+++ b/frontend/src/modules/controllers/ValueClicker.tsx
@@ -191,7 +191,6 @@ export const ValueClicker = ({
         onClick={(num: number) => {
           onClick(num);
         }}
-        disableChange={disableMin || disableMax}
         min={min}
         max={max}
       />


### PR DESCRIPTION
This PR fixes #373 
- disables alarm upper limit to go below the lower limit
- disables alarm lower limit to go above the upper limit