### PR TITLE
Initialize backend store from fallbacks when files aren't available

### DIFF
--- a/backend/ventserver/protocols/backend/server.py
+++ b/backend/ventserver/protocols/backend/server.py
@@ -45,7 +45,7 @@ class ReceiveDataEvent(events.Event):
     serial_receive: Optional[bytes] = attr.ib(default=None)
     websocket_receive: Optional[bytes] = attr.ib(default=None)
     rotary_encoder_receive: Tuple[int, bool] = attr.ib(default=None)
-    file_receive: Optional[file.StateData] = attr.ib(default=None)
+    file_receive: Optional[file.LowerReceiveEvent] = attr.ib(default=None)
 
     def has_data(self) -> bool:
         """Return whether the event has data."""

--- a/backend/ventserver/protocols/backend/states.py
+++ b/backend/ventserver/protocols/backend/states.py
@@ -104,10 +104,12 @@ FRONTEND_OUTPUT_SCHEDULE = collections.deque([
 ])
 
 FILE_INPUT_TYPES: Mapping[Type[betterproto.Message], StateSegment] = {
-    mcu_pb.Parameters: StateSegment.PARAMETERS,
     mcu_pb.ParametersRequest: StateSegment.PARAMETERS_REQUEST,
-    mcu_pb.AlarmLimits: StateSegment.ALARM_LIMITS,
     mcu_pb.AlarmLimitsRequest: StateSegment.ALARM_LIMITS_REQUEST,
+    mcu_pb.AlarmMuteRequest: StateSegment.ALARM_MUTE_REQUEST,
+    frontend_pb.SystemSettingRequest: StateSegment.SYSTEM_SETTING_REQUEST,
+    # Frontend protobuf message isn't defined yet:
+    # frontend_pb.FrontendDisplay: StateSegment.FRONTEND_DISPLAY_REQUEST,
 }
 FILE_OUTPUT_SCHEDULE = collections.deque([
     states.ScheduleEntry(time=0.3, type=StateSegment.PARAMETERS),

--- a/backend/ventserver/protocols/backend/states.py
+++ b/backend/ventserver/protocols/backend/states.py
@@ -112,10 +112,12 @@ FILE_INPUT_TYPES: Mapping[Type[betterproto.Message], StateSegment] = {
     # frontend_pb.FrontendDisplay: StateSegment.FRONTEND_DISPLAY_REQUEST,
 }
 FILE_OUTPUT_SCHEDULE = collections.deque([
-    states.ScheduleEntry(time=0.3, type=StateSegment.PARAMETERS),
-    states.ScheduleEntry(time=0.3, type=StateSegment.PARAMETERS_REQUEST),
-    states.ScheduleEntry(time=0.3, type=StateSegment.ALARM_LIMITS),
-    states.ScheduleEntry(time=0.3, type=StateSegment.ALARM_LIMITS_REQUEST),
+    states.ScheduleEntry(time=0.5, type=StateSegment.PARAMETERS_REQUEST),
+    states.ScheduleEntry(time=0.5, type=StateSegment.ALARM_LIMITS_REQUEST),
+    states.ScheduleEntry(time=0.5, type=StateSegment.ALARM_MUTE_REQUEST),
+    states.ScheduleEntry(time=0.5, type=StateSegment.SYSTEM_SETTING_REQUEST),
+    # Frontend protobuf message isn't defined yet:
+    # states.ScheduleEntry(time=0.5, type=StateSegment.FRONTEND_DISPLAY_REQUEST)
 ])
 
 

--- a/backend/ventserver/protocols/devices/file.py
+++ b/backend/ventserver/protocols/devices/file.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 import attr
 import betterproto
 
-from ventserver.protocols.devices import mcu
+from ventserver.protocols.devices import frontend
 from ventserver.protocols import events, exceptions
 from ventserver.protocols.transport import crcelements, messages
 from ventserver.sansio import channels, protocols
@@ -53,7 +53,7 @@ class ReceiveFilter(protocols.Filter[LowerReceiveEvent, UpperEvent]):
     def init_message_receiver(self) -> messages.MessageReceiver:  # pylint: disable=no-self-use
         """Initialize the mcu message receiver."""
         return messages.MessageReceiver(
-            message_classes=mcu.MESSAGE_CLASSES
+            message_classes=frontend.MESSAGE_CLASSES
         )
 
     def input(self, event: Optional[LowerReceiveEvent]) -> None:
@@ -116,7 +116,7 @@ class SendFilter(protocols.Filter[UpperEvent, LowerSendEvent]):
     def init_message_sender(self) -> messages.MessageSender:  # pylint: disable=no-self-use
         """Initialize the message sender."""
         return messages.MessageSender(
-            message_types=mcu.MESSAGE_TYPES
+            message_types=frontend.MESSAGE_TYPES
         )
 
     def input(self, event: Optional[UpperEvent]) -> None:

--- a/backend/ventserver/simulator.py
+++ b/backend/ventserver/simulator.py
@@ -72,6 +72,7 @@ INITIAL_VALUES = {
         theme=frontend_pb.ThemeVariant.dark,
         unit=frontend_pb.Unit.metric,
     )
+    # TODO: initial value for FrontendDisplayRequest, which isn't defined yet
 }
 
 


### PR DESCRIPTION
This PR adds the following functionality to the backend: If the backend starts and there are no files in the filesystem (in the `statestore` directory), then `ventserver.application` should initialize its store with some default values. This bootstraps the store so that those values will be written to the filesystem for the next time the backend is started. Until #340, we relied on the frontend to initialize those values, so this issue was not visible in `ventserver.application`; and `ventserver.simulator` doesn't use the filesystem to initialize its store, so this issue wasn't visible there either.

For records-keeping:
1. This project is licensed under Apache License v2.0 for any software, and Solderpad Hardware License v2.1 for any hardware - do you agree that your contributions to this project will be under these licenses, too? **Yes**
2. Were any of these contributions also part of work you did for an employer or a client? **No**
3. Does this work include, or is it based on, any third-party work which you did not create? **No**