### PR TITLE
Open modal popup if sidebar is accessed from alarms screen

### DIFF
--- a/frontend/src/modules/app/layouts/SidebarSlideRoute.tsx
+++ b/frontend/src/modules/app/layouts/SidebarSlideRoute.tsx
@@ -125,6 +125,7 @@ const FullWidthToolBar = (): JSX.Element => {
   const handleDiscardConfirm = () => {
     setAlarmLimitsRequestDraft(alarmLimitsRequest);
     setOpenModal(false);
+    setToggle(true);
   };
 
   /**


### PR DESCRIPTION
This PR adds functionality to open confirmation dialog on clicking the `pufferfish icon` that opens the sidebar if there are `unsaved` changes on the alarm limits screen.