### PR TITLE
Prevent the rotary encoder from setting min limit above max limit in the frontend

### DIFF
--- a/frontend/src/modules/alarms/AlarmsPage.tsx
+++ b/frontend/src/modules/alarms/AlarmsPage.tsx
@@ -218,6 +218,8 @@ const Alarm = ({
    */
   const [disableDecrement, setDisableDecrement] = useState(false);
   const [disableIncrement, setDisableIncrement] = useState(false);
+  const [rotaryMin, setRotaryMin] = React.useState(min);
+  const [rotaryMax, setRotaryMax] = React.useState(max);
 
   /**
    * This is a changeListener that sets disableDecrement, disableIncrement on change in RangeValues which
@@ -226,7 +228,9 @@ const Alarm = ({
   useEffect(() => {
     setDisableDecrement(rangeValues[1] <= rangeValues[0]);
     setDisableIncrement(rangeValues[0] >= rangeValues[1]);
-  }, [rangeValues]);
+    if (disableIncrement) setRotaryMin(rangeValues[0]);
+    if (disableDecrement) setRotaryMax(rangeValues[1]);
+  }, [rangeValues, disableIncrement, disableDecrement]);
 
   /**
    * Calls on initalization of the component
@@ -276,7 +280,7 @@ const Alarm = ({
                 value={rangeValues[0]}
                 onClick={(value: number) => onClick(value, SliderType.LOWER)}
                 min={min}
-                max={max}
+                max={disableIncrement ? rotaryMax : max}
                 disableMin={disableIncrement}
                 direction="column"
               />
@@ -308,7 +312,7 @@ const Alarm = ({
                 referenceKey={`${stateKey}_HIGHER`}
                 value={rangeValues[1]}
                 onClick={(value: number) => onClick(value, SliderType.UPPER)}
-                min={min}
+                min={disableDecrement ? rotaryMin : min}
                 max={max}
                 disableMax={disableDecrement}
                 direction="column"

--- a/frontend/src/modules/alarms/AlarmsPage.tsx
+++ b/frontend/src/modules/alarms/AlarmsPage.tsx
@@ -218,8 +218,6 @@ const Alarm = ({
    */
   const [disableDecrement, setDisableDecrement] = useState(false);
   const [disableIncrement, setDisableIncrement] = useState(false);
-  const [rotaryMin, setRotaryMin] = React.useState(min);
-  const [rotaryMax, setRotaryMax] = React.useState(max);
 
   /**
    * This is a changeListener that sets disableDecrement, disableIncrement on change in RangeValues which
@@ -228,9 +226,7 @@ const Alarm = ({
   useEffect(() => {
     setDisableDecrement(rangeValues[1] <= rangeValues[0]);
     setDisableIncrement(rangeValues[0] >= rangeValues[1]);
-    if (disableIncrement) setRotaryMin(rangeValues[0]);
-    if (disableDecrement) setRotaryMax(rangeValues[1]);
-  }, [rangeValues, disableIncrement, disableDecrement]);
+  }, [rangeValues]);
 
   /**
    * Calls on initalization of the component
@@ -280,7 +276,7 @@ const Alarm = ({
                 value={rangeValues[0]}
                 onClick={(value: number) => onClick(value, SliderType.LOWER)}
                 min={min}
-                max={disableIncrement ? rotaryMax : max}
+                max={rangeValues[1]}
                 disableMin={disableIncrement}
                 direction="column"
               />
@@ -312,7 +308,7 @@ const Alarm = ({
                 referenceKey={`${stateKey}_HIGHER`}
                 value={rangeValues[1]}
                 onClick={(value: number) => onClick(value, SliderType.UPPER)}
-                min={disableDecrement ? rotaryMin : min}
+                min={rangeValues[0]}
                 max={max}
                 disableMax={disableDecrement}
                 direction="column"

--- a/frontend/src/modules/alarms/AlarmsPage.tsx
+++ b/frontend/src/modules/alarms/AlarmsPage.tsx
@@ -200,11 +200,6 @@ const Alarm = ({
     setActiveRotaryReference(
       type === SliderType.LOWER ? `${stateKey}_LOWER` : `${stateKey}_HIGHER`,
     );
-    if (type === SliderType.LOWER) {
-      setDisableIncrement(value >= rangeValues[1]);
-    } else {
-      setDisableDecrement(value <= rangeValues[0]);
-    }
     setAlarmLimits({
       [stateKey]: {
         lower: type === SliderType.LOWER ? value : rangeValues[0],
@@ -212,21 +207,6 @@ const Alarm = ({
       },
     });
   };
-
-  /**
-   * Local state to pass to ValueClicker to disable increment/decrement buttons
-   */
-  const [disableDecrement, setDisableDecrement] = useState(false);
-  const [disableIncrement, setDisableIncrement] = useState(false);
-
-  /**
-   * This is a changeListener that sets disableDecrement, disableIncrement on change in RangeValues which
-   * are the current AlarmLimits
-   */
-  useEffect(() => {
-    setDisableDecrement(rangeValues[1] <= rangeValues[0]);
-    setDisableIncrement(rangeValues[0] >= rangeValues[1]);
-  }, [rangeValues]);
 
   /**
    * Calls on initalization of the component
@@ -277,7 +257,6 @@ const Alarm = ({
                 onClick={(value: number) => onClick(value, SliderType.LOWER)}
                 min={min}
                 max={rangeValues[1]}
-                disableMin={disableIncrement}
                 direction="column"
               />
             </Grid>
@@ -310,7 +289,6 @@ const Alarm = ({
                 onClick={(value: number) => onClick(value, SliderType.UPPER)}
                 min={rangeValues[0]}
                 max={max}
-                disableMax={disableDecrement}
                 direction="column"
               />
             </Grid>

--- a/frontend/src/modules/app/EventAlerts.tsx
+++ b/frontend/src/modules/app/EventAlerts.tsx
@@ -291,7 +291,10 @@ export const EventAlerts = ({ label }: Props): JSX.Element => {
   useEffect(() => {
     if (alarmMuteRemaining === 0 || remaining === 0) {
       dispatch(
-        commitRequest<AlarmMuteRequest>(MessageType.AlarmMuteRequest, { active: false }),
+        commitRequest<AlarmMuteRequest>(MessageType.AlarmMuteRequest, {
+          active: false,
+          remaining: 120,
+        }),
       );
     }
   }, [dispatch, alarmMuteRemaining, remaining]);

--- a/frontend/src/modules/app/EventAlerts.tsx
+++ b/frontend/src/modules/app/EventAlerts.tsx
@@ -290,6 +290,8 @@ export const EventAlerts = ({ label }: Props): JSX.Element => {
    */
   useEffect(() => {
     if (alarmMuteRemaining === 0 || remaining === 0) {
+      // we need to dispatch 'remaining' field as well to properly initialize AlarmMuteRequest,
+      // or else there could be a race condition where the backend kills the frontend.
       dispatch(
         commitRequest<AlarmMuteRequest>(MessageType.AlarmMuteRequest, {
           active: false,

--- a/frontend/src/modules/controllers/AlarmModal.tsx
+++ b/frontend/src/modules/controllers/AlarmModal.tsx
@@ -142,8 +142,6 @@ export const AlarmModal = ({
   /**
    * State to pass as min/max to RotaryEncoderController
    */
-  const [rotaryMin, setRotaryMin] = React.useState(min);
-  const [rotaryMax, setRotaryMax] = React.useState(max);
   const alarmLimits = useSelector(getAlarmLimitsRequest, shallowEqual);
   const range =
     alarmLimits === null
@@ -189,9 +187,7 @@ export const AlarmModal = ({
   useEffect(() => {
     setDisableDecrement(rangeValue[1] <= rangeValue[0]);
     setDisableIncrement(rangeValue[0] >= rangeValue[1]);
-    if (disableIncrement) setRotaryMin(rangeValue[0]);
-    if (disableDecrement) setRotaryMax(rangeValue[1]);
-  }, [rangeValue, disableIncrement, disableDecrement]);
+  }, [rangeValue]);
 
   useEffect(() => {
     initRefListener(refs);
@@ -304,7 +300,7 @@ export const AlarmModal = ({
                 value={rangeValue[0]}
                 step={step}
                 min={committedMin}
-                max={disableIncrement ? rotaryMax : committedMax}
+                max={rangeValue[1]}
                 disableMin={disableIncrement}
                 onClick={setLowerLimit}
                 direction="column"
@@ -342,7 +338,7 @@ export const AlarmModal = ({
                 referenceKey={`${stateKey}_HIGHER`}
                 value={rangeValue[1]}
                 step={step}
-                min={disableDecrement ? rotaryMin : committedMin}
+                min={rangeValue[0]}
                 max={committedMax}
                 disableMax={disableDecrement}
                 onClick={setUpperLimit}

--- a/frontend/src/modules/controllers/AlarmModal.tsx
+++ b/frontend/src/modules/controllers/AlarmModal.tsx
@@ -157,34 +157,18 @@ export const AlarmModal = ({
     [`${stateKey}_LOWER`]: useRef(null),
     [`${stateKey}_HIGHER`]: useRef(null),
   });
-  /**
-   * Local state to pass to ValueClicker to disable increment/decrement buttons
-   */
-  const [disableDecrement, setDisableDecrement] = React.useState(false);
-  const [disableIncrement, setDisableIncrement] = React.useState(false);
 
   const setUpperLimit = (value: number) => {
     setRangeValue(Object.assign([], rangeValue, { 1: value }));
-    setDisableDecrement(value <= rangeValue[0]);
   };
 
   const setLowerLimit = (value: number) => {
     setRangeValue(Object.assign([], rangeValue, { 0: value }));
-    setDisableIncrement(value >= rangeValue[1]);
   };
 
   const initSetValue = useCallback(() => {
     setOpen(openModal);
   }, [openModal]);
-
-  /**
-   * This is a changeListener that sets disableDecrement, disableIncrement on change in RangeValues which
-   * are the current AlarmLimits
-   */
-  useEffect(() => {
-    setDisableDecrement(rangeValue[1] <= rangeValue[0]);
-    setDisableIncrement(rangeValue[0] >= rangeValue[1]);
-  }, [rangeValue]);
 
   useEffect(() => {
     initRefListener(refs);
@@ -298,7 +282,6 @@ export const AlarmModal = ({
                 step={step}
                 min={committedMin}
                 max={rangeValue[1]}
-                disableMin={disableIncrement}
                 onClick={setLowerLimit}
                 direction="column"
               />
@@ -337,7 +320,6 @@ export const AlarmModal = ({
                 step={step}
                 min={rangeValue[0]}
                 max={committedMax}
-                disableMax={disableDecrement}
                 onClick={setUpperLimit}
                 direction="column"
               />

--- a/frontend/src/modules/controllers/AlarmModal.tsx
+++ b/frontend/src/modules/controllers/AlarmModal.tsx
@@ -139,6 +139,11 @@ export const AlarmModal = ({
    * State to initalize Upper Set value
    */
   const [max] = React.useState(committedMax);
+  /**
+   * State to pass as min/max to RotaryEncoderController
+   */
+  const [rotaryMin, setRotaryMin] = React.useState(min);
+  const [rotaryMax, setRotaryMax] = React.useState(max);
   const alarmLimits = useSelector(getAlarmLimitsRequest, shallowEqual);
   const range =
     alarmLimits === null
@@ -184,7 +189,9 @@ export const AlarmModal = ({
   useEffect(() => {
     setDisableDecrement(rangeValue[1] <= rangeValue[0]);
     setDisableIncrement(rangeValue[0] >= rangeValue[1]);
-  }, [rangeValue]);
+    if (disableIncrement) setRotaryMin(rangeValue[0]);
+    if (disableDecrement) setRotaryMax(rangeValue[1]);
+  }, [rangeValue, disableIncrement, disableDecrement]);
 
   useEffect(() => {
     initRefListener(refs);
@@ -297,7 +304,7 @@ export const AlarmModal = ({
                 value={rangeValue[0]}
                 step={step}
                 min={committedMin}
-                max={committedMax}
+                max={disableIncrement ? rotaryMax : committedMax}
                 disableMin={disableIncrement}
                 onClick={setLowerLimit}
                 direction="column"
@@ -335,7 +342,7 @@ export const AlarmModal = ({
                 referenceKey={`${stateKey}_HIGHER`}
                 value={rangeValue[1]}
                 step={step}
-                min={committedMin}
+                min={disableDecrement ? rotaryMin : committedMin}
                 max={committedMax}
                 disableMax={disableDecrement}
                 onClick={setUpperLimit}

--- a/frontend/src/modules/controllers/AlarmModal.tsx
+++ b/frontend/src/modules/controllers/AlarmModal.tsx
@@ -139,9 +139,6 @@ export const AlarmModal = ({
    * State to initalize Upper Set value
    */
   const [max] = React.useState(committedMax);
-  /**
-   * State to pass as min/max to RotaryEncoderController
-   */
   const alarmLimits = useSelector(getAlarmLimitsRequest, shallowEqual);
   const range =
     alarmLimits === null

--- a/frontend/src/modules/controllers/ValueClicker.tsx
+++ b/frontend/src/modules/controllers/ValueClicker.tsx
@@ -96,7 +96,8 @@ export const ValueClicker = ({
     setDisableDecrement(change <= min);
     if (change >= max) {
       return onClick(max);
-    } else if (change <= min) {
+    }
+    if (change <= min) {
       return onClick(min);
     }
     return onClick(change);

--- a/frontend/src/modules/controllers/ValueClicker.tsx
+++ b/frontend/src/modules/controllers/ValueClicker.tsx
@@ -53,8 +53,6 @@ interface Props {
   direction?: Direction;
   step?: number;
   referenceKey: string;
-  disableMax?: boolean;
-  disableMin?: boolean;
 }
 enum Type {
   INCREMENT,
@@ -77,8 +75,6 @@ export const ValueClicker = ({
   direction = 'column',
   step = 1,
   referenceKey,
-  disableMax = false,
-  disableMin = false,
 }: Props): JSX.Element => {
   const classes = useStyles();
   const [disabledInterval] = useState(100);
@@ -102,18 +98,17 @@ export const ValueClicker = ({
       return onClick(max);
     } else if (change <= min) {
       return onClick(min);
-    } else {
-      return onClick(change);
     }
+    return onClick(change);
   };
 
   /**
    * Validating & disabling button when reached min/max value
    */
   useEffect(() => {
-    setDisableIncrement(value >= max || disableMin);
-    setDisableDecrement(value <= min || disableMax);
-  }, [min, max, value, disableMin, disableMax]);
+    setDisableIncrement(value >= max);
+    setDisableDecrement(value <= min);
+  }, [min, max, value]);
 
   /**
    * Click handler for Increment button

--- a/frontend/src/modules/controllers/ValueClicker.tsx
+++ b/frontend/src/modules/controllers/ValueClicker.tsx
@@ -98,7 +98,13 @@ export const ValueClicker = ({
     const change = value + step;
     setDisableIncrement(change >= max);
     setDisableDecrement(change <= min);
-    return onClick(change);
+    if (change >= max) {
+      return onClick(max);
+    } else if (change <= min) {
+      return onClick(min);
+    } else {
+      return onClick(change);
+    }
   };
 
   /**


### PR DESCRIPTION
This PR adds #374 fix for rotary encoder