### PR TITLE
Add backend state segment to report device connection statuses

### DIFF
--- a/backend/ventserver/protocols/backend/backend.py
+++ b/backend/ventserver/protocols/backend/backend.py
@@ -37,6 +37,16 @@ OutputEvent = states.SendEvent
 SendEvent = states.SendEvent
 
 
+LOG_EVENT_TYPES = {
+    mcu_pb.LogEventCode.backend_mcu_connection_down:
+        mcu_pb.LogEventType.system,
+    mcu_pb.LogEventCode.backend_frontend_connection_down:
+        mcu_pb.LogEventType.system,
+    mcu_pb.LogEventCode.backend_frontend_connection_up:
+        mcu_pb.LogEventType.system
+}
+
+
 # Filters
 
 
@@ -117,15 +127,9 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, OutputEvent]):
 
         This includes active log events (active alarms).
         """
-        if event.code == mcu_pb.LogEventCode.mcu_connection_down:
-            event_type = mcu_pb.LogEventType.system
-        elif event.code == mcu_pb.LogEventCode.frontend_connection_down:
-            event_type = mcu_pb.LogEventType.system
-        elif event.code == mcu_pb.LogEventCode.mcu_connection_up:
-            event_type = mcu_pb.LogEventType.system
-        elif event.code == mcu_pb.LogEventCode.frontend_connection_up:
-            event_type = mcu_pb.LogEventType.system
-        else:
+        try:
+            event_type = LOG_EVENT_TYPES[event.code]
+        except KeyError:
             self._logger.error('Unrecognized local event type %s', event.code)
             return
 

--- a/backend/ventserver/protocols/backend/server.py
+++ b/backend/ventserver/protocols/backend/server.py
@@ -8,7 +8,7 @@ import attr
 from ventserver.protocols import events, exceptions
 from ventserver.protocols.backend import backend, connections
 from ventserver.protocols.devices import file, frontend, mcu, rotary_encoder
-from ventserver.protocols.protobuf import mcu_pb
+from ventserver.protocols.protobuf import frontend_pb, mcu_pb
 from ventserver.sansio import channels, protocols
 
 
@@ -123,23 +123,25 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, ReceiveOutputEvent]):
     """Filter which transforms receive bytes into high-level events."""
     _logger = logging.getLogger('.'.join((__name__, 'ReceiveFilter')))
 
+    # TODO: can we remove _buffer?
     _buffer: channels.DequeChannel[ReceiveEvent] =\
         attr.ib(factory=channels.DequeChannel)
 
     current_time: float = attr.ib(default=0)
+    _backend: backend.ReceiveFilter = attr.ib(factory=backend.ReceiveFilter)
 
+    # Devices
     _mcu: mcu.ReceiveFilter = attr.ib(factory=mcu.ReceiveFilter)
     _frontend: frontend.ReceiveFilter = attr.ib(factory=frontend.ReceiveFilter)
     _file: file.ReceiveFilter = attr.ib(factory=file.ReceiveFilter)
     _rotary_encoder: rotary_encoder.ReceiveFilter = attr.ib(
         factory=rotary_encoder.ReceiveFilter
     )
-    _backend: backend.ReceiveFilter = attr.ib(factory=backend.ReceiveFilter)
 
     _connections: connections.TimeoutHandler = \
         attr.ib(factory=connections.TimeoutHandler)
-    _mcu_connected: bool = attr.ib(default=False)
-    _frontend_connected: bool = attr.ib(default=False)
+    _connection_states: frontend_pb.BackendConnections = \
+        attr.ib(factory=frontend_pb.BackendConnections)
 
     def input(self, event: Optional[ReceiveEvent]) -> None:
         """Handle input events."""
@@ -224,12 +226,15 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, ReceiveOutputEvent]):
         self._connections.input(connections.UpdateEvent(
             current_time=self.current_time, type=connections.Update.MCU_RECEIVED
         ))
-        if not self._mcu_connected:
+        if not self._connection_states.has_mcu:
             self._backend.input(backend.ExternalLogEvent(
                 time=self.current_time, active=False,
                 code=mcu_pb.LogEventCode.backend_mcu_connection_down
             ))
-            self._mcu_connected = True
+            self._connection_states.has_mcu = True
+            self._backend.input(backend.ReceiveDataEvent(
+                time=self.current_time, server_receive=self._connection_states
+            ))
         return True
 
     def _process_frontend(self) -> bool:
@@ -245,7 +250,7 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, ReceiveOutputEvent]):
             current_time=self.current_time,
             type=connections.Update.FRONTEND_RECEIVED
         ))
-        if not self._frontend_connected:
+        if not self._connection_states.has_frontend:
             self._backend.input(backend.ExternalLogEvent(
                 time=self.current_time, active=False,
                 code=mcu_pb.LogEventCode.backend_frontend_connection_down
@@ -254,7 +259,10 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, ReceiveOutputEvent]):
                 time=self.current_time,
                 code=mcu_pb.LogEventCode.backend_frontend_connection_up
             ))
-            self._frontend_connected = True
+            self._connection_states.has_frontend = True
+            self._backend.input(backend.ReceiveDataEvent(
+                time=self.current_time, server_receive=self._connection_states
+            ))
         return True
 
     def _process_rotary_encoder(self) -> bool:
@@ -302,13 +310,19 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, ReceiveOutputEvent]):
                 time=self.current_time, active=True,
                 code=mcu_pb.LogEventCode.backend_mcu_connection_down
             ))
-            self._mcu_connected = False
+            self._connection_states.has_mcu = False
+            self._backend.input(backend.ReceiveDataEvent(
+                time=self.current_time, server_receive=self._connection_states
+            ))
         if actions.alarm_frontend:
             self._backend.input(backend.ExternalLogEvent(
                 time=self.current_time, active=True,
                 code=mcu_pb.LogEventCode.backend_frontend_connection_down
             ))
-            self._frontend_connected = False
+            self._connection_states.has_frontend = False
+            self._backend.input(backend.ReceiveDataEvent(
+                time=self.current_time, server_receive=self._connection_states
+            ))
         return actions.kill_frontend
 
     def input_serial(self, serial_receive: bytes) -> None:
@@ -342,10 +356,14 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, ReceiveOutputEvent]):
 class SendFilter(protocols.Filter[SendEvent, SendOutputEvent]):
     """Filter which transforms high-level events into send bytes."""
 
+    # TODO: can we remove _buffer?
     _buffer: channels.DequeChannel[SendEvent] = attr.ib(
         factory=channels.DequeChannel
     )
+
     _backend: backend.SendFilter = attr.ib(factory=backend.SendFilter)
+
+    # Devices
     _mcu: mcu.SendFilter = attr.ib(factory=mcu.SendFilter)
     _frontend: frontend.SendFilter = attr.ib(factory=frontend.SendFilter)
     _file: file.SendFilter = attr.ib(factory=file.SendFilter)

--- a/backend/ventserver/protocols/backend/server.py
+++ b/backend/ventserver/protocols/backend/server.py
@@ -227,11 +227,7 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, ReceiveOutputEvent]):
         if not self._mcu_connected:
             self._backend.input(backend.ExternalLogEvent(
                 time=self.current_time, active=False,
-                code=mcu_pb.LogEventCode.mcu_connection_down
-            ))
-            self._backend.input(backend.ExternalLogEvent(
-                time=self.current_time,
-                code=mcu_pb.LogEventCode.mcu_connection_up
+                code=mcu_pb.LogEventCode.backend_mcu_connection_down
             ))
             self._mcu_connected = True
         return True
@@ -252,11 +248,11 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, ReceiveOutputEvent]):
         if not self._frontend_connected:
             self._backend.input(backend.ExternalLogEvent(
                 time=self.current_time, active=False,
-                code=mcu_pb.LogEventCode.frontend_connection_down
+                code=mcu_pb.LogEventCode.backend_frontend_connection_down
             ))
             self._backend.input(backend.ExternalLogEvent(
                 time=self.current_time,
-                code=mcu_pb.LogEventCode.frontend_connection_up
+                code=mcu_pb.LogEventCode.backend_frontend_connection_up
             ))
             self._frontend_connected = True
         return True
@@ -304,13 +300,13 @@ class ReceiveFilter(protocols.Filter[ReceiveEvent, ReceiveOutputEvent]):
         if actions.alarm_mcu:
             self._backend.input(backend.ExternalLogEvent(
                 time=self.current_time, active=True,
-                code=mcu_pb.LogEventCode.mcu_connection_down
+                code=mcu_pb.LogEventCode.backend_mcu_connection_down
             ))
             self._mcu_connected = False
         if actions.alarm_frontend:
             self._backend.input(backend.ExternalLogEvent(
                 time=self.current_time, active=True,
-                code=mcu_pb.LogEventCode.frontend_connection_down
+                code=mcu_pb.LogEventCode.backend_frontend_connection_down
             ))
             self._frontend_connected = False
         return actions.kill_frontend

--- a/backend/ventserver/protocols/devices/frontend.py
+++ b/backend/ventserver/protocols/devices/frontend.py
@@ -26,7 +26,8 @@ UpperEvent = betterproto.Message
 
 MESSAGE_CLASSES: Mapping[int, Type[betterproto.Message]] = {
     **mcu.MESSAGE_CLASSES,
-    128: frontend_pb.RotaryEncoder,
+    128: frontend_pb.BackendConnections,
+    129: frontend_pb.RotaryEncoder,
     # 130: frontend_pb.SystemSetting,
     131: frontend_pb.SystemSettingRequest,
     132: frontend_pb.FrontendDisplaySetting,

--- a/backend/ventserver/protocols/protobuf/frontend_pb.py
+++ b/backend/ventserver/protocols/protobuf/frontend_pb.py
@@ -28,6 +28,12 @@ class RotaryEncoder(betterproto.Message):
 
 
 @dataclass
+class BackendConnections(betterproto.Message):
+    has_mcu: bool = betterproto.bool_field(1)
+    has_frontend: bool = betterproto.bool_field(2)
+
+
+@dataclass
 class FrontendDisplaySetting(betterproto.Message):
     """
     TODO: we also need a request version of this message,

--- a/backend/ventserver/protocols/protobuf/mcu_pb.py
+++ b/backend/ventserver/protocols/protobuf/mcu_pb.py
@@ -18,8 +18,6 @@ class VentilationMode(betterproto.Enum):
 
 
 class LogEventCode(betterproto.Enum):
-    """Log Events"""
-
     # Patient alarms
     fio2_too_low = 0
     fio2_too_high = 1

--- a/backend/ventserver/protocols/protobuf/mcu_pb.py
+++ b/backend/ventserver/protocols/protobuf/mcu_pb.py
@@ -41,14 +41,30 @@ class LogEventCode(betterproto.Enum):
     hr_alarm_limits_changed = 83
     # System settings & alarms
     screen_locked = 129
-    mcu_connection_down = 130
-    backend_connection_down = 131
-    frontend_connection_down = 132
-    mcu_connection_up = 133
-    backend_connection_up = 134
-    frontend_connection_up = 135
-    battery_low = 136
-    charger_disconnected = 137
+    mcu_backend_connection_down = 130
+    backend_mcu_connection_down = 131
+    backend_frontend_connection_down = 132
+    frontend_backend_connection_down = 133
+    mcu_backend_connection_up = 134
+    # The following code isn't actually used, but we reserve space for it. We
+    # don't use it because if the backend received an mcu_backend_connection_up
+    # event from the MCU, then we know that the backend received a connection
+    # from the MCU. We only care for technical troubleshooting (of the UART
+    # wires) about the case where the backend receives a connection from the MCU
+    # but the MCU hasn't received a connection from the backend; it would be good
+    # to log it, but we don't need to show it in the frontend, and right now the
+    # frontend has no way to filter out events from its display.
+    # backend_mcu_connection_up = 135;  // backend detected mcu
+    backend_frontend_connection_up = 136
+    # The following code isn't actually used, but we reserve space for it. We
+    # don't use it because the frontend can't generate LogEvents with IDs.
+    # frontend_backend_connection_up = 137;
+    battery_low = 138
+    charger_disconnected = 139
+    mcu_started = 140
+    backend_started = 141
+    mcu_shutdown = 142
+    backend_shutdown = 143
 
 
 class LogEventType(betterproto.Enum):

--- a/backend/ventserver/simulator.py
+++ b/backend/ventserver/simulator.py
@@ -20,9 +20,7 @@ from ventserver.io.trio import channels, fileio, rotaryencoder, websocket
 from ventserver.io.subprocess import frozen_frontend
 from ventserver.protocols import exceptions
 from ventserver.protocols.application import debouncing, lists
-from ventserver.protocols.backend import (
-    alarms, connections, log, server, states
-)
+from ventserver.protocols.backend import alarms, log, server, states
 from ventserver.protocols.protobuf import frontend_pb, mcu_pb
 from ventserver.simulation import (
     alarm_limits, alarm_mute, alarms as sim_alarms,

--- a/backend/ventserver/simulator.py
+++ b/backend/ventserver/simulator.py
@@ -20,7 +20,9 @@ from ventserver.io.trio import channels, fileio, rotaryencoder, websocket
 from ventserver.io.subprocess import frozen_frontend
 from ventserver.protocols import exceptions
 from ventserver.protocols.application import debouncing, lists
-from ventserver.protocols.backend import alarms, log, server, states
+from ventserver.protocols.backend import (
+    alarms, connections, log, server, states
+)
 from ventserver.protocols.protobuf import frontend_pb, mcu_pb
 from ventserver.simulation import (
     alarm_limits, alarm_mute, alarms as sim_alarms,
@@ -212,6 +214,9 @@ async def main() -> None:
         _event_log_receiver.  # pylint: disable=protected-access
         _log_events_receiver
     )
+
+    # Make server protocol think the MCU is connnected
+    protocol.receive._connection_states.has_mcu = True
 
     try:
         async with channel.push_endpoint:

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
@@ -20,7 +20,6 @@ typedef enum _VentilationMode {
     VentilationMode_prvc = 6 
 } VentilationMode;
 
-/* Log Events */
 typedef enum _LogEventCode { 
     /* Patient alarms */
     LogEventCode_fio2_too_low = 0, 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/mcu_pb.h
@@ -10,241 +10,257 @@
 #endif
 
 /* Enum definitions */
-typedef enum _VentilationMode {
-    VentilationMode_hfnc = 0,
-    VentilationMode_pc_ac = 1,
-    VentilationMode_vc_ac = 2,
-    VentilationMode_niv_pc = 3,
-    VentilationMode_niv_ps = 4,
-    VentilationMode_psv = 5,
-    VentilationMode_prvc = 6
+typedef enum _VentilationMode { 
+    VentilationMode_hfnc = 0, 
+    VentilationMode_pc_ac = 1, 
+    VentilationMode_vc_ac = 2, 
+    VentilationMode_niv_pc = 3, 
+    VentilationMode_niv_ps = 4, 
+    VentilationMode_psv = 5, 
+    VentilationMode_prvc = 6 
 } VentilationMode;
 
 /* Log Events */
-typedef enum _LogEventCode {
+typedef enum _LogEventCode { 
     /* Patient alarms */
-    LogEventCode_fio2_too_low = 0,
-    LogEventCode_fio2_too_high = 1,
-    LogEventCode_flow_too_low = 2,
-    LogEventCode_flow_too_high = 3,
-    LogEventCode_spo2_too_low = 4,
-    LogEventCode_spo2_too_high = 5,
-    LogEventCode_hr_too_low = 6,
-    LogEventCode_hr_too_high = 7,
+    LogEventCode_fio2_too_low = 0, 
+    LogEventCode_fio2_too_high = 1, 
+    LogEventCode_flow_too_low = 2, 
+    LogEventCode_flow_too_high = 3, 
+    LogEventCode_spo2_too_low = 4, 
+    LogEventCode_spo2_too_high = 5, 
+    LogEventCode_hr_too_low = 6, 
+    LogEventCode_hr_too_high = 7, 
     /* Control settings */
-    LogEventCode_ventilation_operation_changed = 64,
-    LogEventCode_ventilation_mode_changed = 65,
-    LogEventCode_fio2_setting_changed = 66,
-    LogEventCode_flow_setting_changed = 67,
+    LogEventCode_ventilation_operation_changed = 64, 
+    LogEventCode_ventilation_mode_changed = 65, 
+    LogEventCode_fio2_setting_changed = 66, 
+    LogEventCode_flow_setting_changed = 67, 
     /* Alarm limits settings */
-    LogEventCode_fio2_alarm_limits_changed = 80,
-    LogEventCode_flow_alarm_limits_changed = 81,
-    LogEventCode_spo2_alarm_limits_changed = 82,
-    LogEventCode_hr_alarm_limits_changed = 83,
+    LogEventCode_fio2_alarm_limits_changed = 80, 
+    LogEventCode_flow_alarm_limits_changed = 81, 
+    LogEventCode_spo2_alarm_limits_changed = 82, 
+    LogEventCode_hr_alarm_limits_changed = 83, 
     /* System settings & alarms */
-    LogEventCode_screen_locked = 129,
-    LogEventCode_mcu_connection_down = 130,
-    LogEventCode_backend_connection_down = 131,
-    LogEventCode_frontend_connection_down = 132,
-    LogEventCode_mcu_connection_up = 133,
-    LogEventCode_backend_connection_up = 134,
-    LogEventCode_frontend_connection_up = 135,
-    LogEventCode_battery_low = 136,
-    LogEventCode_charger_disconnected = 137
+    LogEventCode_screen_locked = 129, 
+    LogEventCode_mcu_backend_connection_down = 130, /* mcu lost backend */
+    LogEventCode_backend_mcu_connection_down = 131, /* backend lost mcu */
+    LogEventCode_backend_frontend_connection_down = 132, /* backend lost frontend */
+    LogEventCode_frontend_backend_connection_down = 133, /* frontend lost backend */
+    LogEventCode_mcu_backend_connection_up = 134, /* mcu detected backend */
+    /* The following code isn't actually used, but we reserve space for it.
+ We don't use it because if the backend received an mcu_backend_connection_up
+ event from the MCU, then we know that the backend received a connection from
+ the MCU. We only care for technical troubleshooting (of the UART wires) about
+ the case where the backend receives a connection from the MCU but the MCU
+ hasn't received a connection from the backend; it would be good to log it,
+ but we don't need to show it in the frontend, and right now the frontend has
+ no way to filter out events from its display.
+ backend_mcu_connection_up = 135;  // backend detected mcu */
+    LogEventCode_backend_frontend_connection_up = 136, /* backend detected frontend */
+    /* The following code isn't actually used, but we reserve space for it.
+ We don't use it because the frontend can't generate LogEvents with IDs.
+ frontend_backend_connection_up = 137; */
+    LogEventCode_battery_low = 138, 
+    LogEventCode_charger_disconnected = 139, 
+    LogEventCode_mcu_started = 140, 
+    LogEventCode_backend_started = 141, 
+    LogEventCode_mcu_shutdown = 142, 
+    LogEventCode_backend_shutdown = 143 
 } LogEventCode;
 
-typedef enum _LogEventType {
-    LogEventType_patient = 0,
-    LogEventType_control = 1,
-    LogEventType_alarm_limits = 2,
-    LogEventType_system = 3
+typedef enum _LogEventType { 
+    LogEventType_patient = 0, 
+    LogEventType_control = 1, 
+    LogEventType_alarm_limits = 2, 
+    LogEventType_system = 3 
 } LogEventType;
 
 /* Struct definitions */
-typedef struct _ActiveLogEvents {
+typedef struct _ActiveLogEvents { 
     pb_size_t id_count;
-    uint32_t id[32];
+    uint32_t id[32]; 
 } ActiveLogEvents;
 
-typedef struct _AlarmMute {
-    bool active;
-    uint64_t remaining;
+typedef struct _AlarmMute { 
+    bool active; 
+    uint64_t remaining; 
 } AlarmMute;
 
-typedef struct _AlarmMuteRequest {
-    bool active;
-    uint64_t remaining;
+typedef struct _AlarmMuteRequest { 
+    bool active; 
+    uint64_t remaining; 
 } AlarmMuteRequest;
 
 typedef PB_BYTES_ARRAY_T(64) Announcement_announcement_t;
-typedef struct _Announcement {
-    uint64_t time;
-    Announcement_announcement_t announcement;
+typedef struct _Announcement { 
+    uint64_t time; 
+    Announcement_announcement_t announcement; 
 } Announcement;
 
-typedef struct _CycleMeasurements {
-    uint64_t time;
-    float vt;
-    float rr;
-    float peep;
-    float pip;
-    float ip;
-    float ve;
+typedef struct _CycleMeasurements { 
+    uint64_t time; 
+    float vt; 
+    float rr; 
+    float peep; 
+    float pip; 
+    float ip; 
+    float ve; 
 } CycleMeasurements;
 
-typedef struct _ExpectedLogEvent {
-    uint32_t id;
+typedef struct _ExpectedLogEvent { 
+    uint32_t id; 
     uint32_t session_id; /* used when the sender's log is ephemeral */
 } ExpectedLogEvent;
 
-typedef struct _MCUPowerStatus {
-    float power_left;
-    bool charging;
+typedef struct _MCUPowerStatus { 
+    float power_left; 
+    bool charging; 
 } MCUPowerStatus;
 
-typedef struct _Parameters {
-    uint64_t time;
-    bool ventilating;
-    VentilationMode mode;
-    float fio2;
-    float flow;
-    float pip;
-    float peep;
-    float vt;
-    float rr;
-    float ie;
+typedef struct _Parameters { 
+    uint64_t time; 
+    bool ventilating; 
+    VentilationMode mode; 
+    float fio2; 
+    float flow; 
+    float pip; 
+    float peep; 
+    float vt; 
+    float rr; 
+    float ie; 
 } Parameters;
 
-typedef struct _ParametersRequest {
-    uint64_t time;
-    bool ventilating;
-    VentilationMode mode;
-    float fio2;
-    float flow;
-    float pip;
-    float peep;
-    float vt;
-    float rr;
-    float ie;
+typedef struct _ParametersRequest { 
+    uint64_t time; 
+    bool ventilating; 
+    VentilationMode mode; 
+    float fio2; 
+    float flow; 
+    float pip; 
+    float peep; 
+    float vt; 
+    float rr; 
+    float ie; 
 } ParametersRequest;
 
-typedef struct _Ping {
-    uint64_t time;
-    uint32_t id;
+typedef struct _Ping { 
+    uint64_t time; 
+    uint32_t id; 
 } Ping;
 
-typedef struct _Range {
-    int32_t lower;
-    int32_t upper;
+typedef struct _Range { 
+    int32_t lower; 
+    int32_t upper; 
 } Range;
 
-typedef struct _ScreenStatus {
-    bool lock;
+typedef struct _ScreenStatus { 
+    bool lock; 
 } ScreenStatus;
 
-typedef struct _SensorMeasurements {
-    uint64_t time;
-    uint32_t cycle;
-    float fio2;
-    float flow;
-    float spo2;
-    float hr;
-    float paw;
-    float volume;
+typedef struct _SensorMeasurements { 
+    uint64_t time; 
+    uint32_t cycle; 
+    float fio2; 
+    float flow; 
+    float spo2; 
+    float hr; 
+    float paw; 
+    float volume; 
 } SensorMeasurements;
 
-typedef struct _AlarmLimits {
-    uint64_t time;
+typedef struct _AlarmLimits { 
+    uint64_t time; 
     bool has_fio2;
-    Range fio2;
+    Range fio2; 
     bool has_flow;
-    Range flow;
+    Range flow; 
     bool has_spo2;
-    Range spo2;
+    Range spo2; 
     bool has_hr;
-    Range hr;
+    Range hr; 
     bool has_rr;
-    Range rr;
+    Range rr; 
     bool has_pip;
-    Range pip;
+    Range pip; 
     bool has_peep;
-    Range peep;
+    Range peep; 
     bool has_ip_above_peep;
-    Range ip_above_peep;
+    Range ip_above_peep; 
     bool has_insp_time;
-    Range insp_time;
+    Range insp_time; 
     bool has_paw;
-    Range paw;
+    Range paw; 
     bool has_mve;
-    Range mve;
+    Range mve; 
     bool has_tv;
-    Range tv;
+    Range tv; 
     bool has_etco2;
-    Range etco2;
+    Range etco2; 
     bool has_apnea;
-    Range apnea;
+    Range apnea; 
 } AlarmLimits;
 
-typedef struct _AlarmLimitsRequest {
-    uint64_t time;
+typedef struct _AlarmLimitsRequest { 
+    uint64_t time; 
     bool has_fio2;
-    Range fio2;
+    Range fio2; 
     bool has_flow;
-    Range flow;
+    Range flow; 
     bool has_spo2;
-    Range spo2;
+    Range spo2; 
     bool has_hr;
-    Range hr;
+    Range hr; 
     bool has_rr;
-    Range rr;
+    Range rr; 
     bool has_pip;
-    Range pip;
+    Range pip; 
     bool has_peep;
-    Range peep;
+    Range peep; 
     bool has_ip_above_peep;
-    Range ip_above_peep;
+    Range ip_above_peep; 
     bool has_insp_time;
-    Range insp_time;
+    Range insp_time; 
     bool has_paw;
-    Range paw;
+    Range paw; 
     bool has_mve;
-    Range mve;
+    Range mve; 
     bool has_tv;
-    Range tv;
+    Range tv; 
     bool has_etco2;
-    Range etco2;
+    Range etco2; 
     bool has_apnea;
-    Range apnea;
+    Range apnea; 
 } AlarmLimitsRequest;
 
-typedef struct _LogEvent {
-    uint32_t id;
-    uint64_t time;
-    LogEventCode code;
-    LogEventType type;
+typedef struct _LogEvent { 
+    uint32_t id; 
+    uint64_t time; 
+    LogEventCode code; 
+    LogEventType type; 
     bool has_alarm_limits;
-    Range alarm_limits;
-    float old_float;
-    float new_float;
-    uint32_t old_uint32;
-    uint32_t new_uint32;
-    bool old_bool;
-    bool new_bool;
+    Range alarm_limits; 
+    float old_float; 
+    float new_float; 
+    uint32_t old_uint32; 
+    uint32_t new_uint32; 
+    bool old_bool; 
+    bool new_bool; 
     bool has_old_range;
-    Range old_range;
+    Range old_range; 
     bool has_new_range;
-    Range new_range;
-    VentilationMode old_mode;
-    VentilationMode new_mode;
+    Range new_range; 
+    VentilationMode old_mode; 
+    VentilationMode new_mode; 
 } LogEvent;
 
-typedef struct _NextLogEvents {
-    uint32_t next_expected;
-    uint32_t total;
-    uint32_t remaining;
+typedef struct _NextLogEvents { 
+    uint32_t next_expected; 
+    uint32_t total; 
+    uint32_t remaining; 
     uint32_t session_id; /* used when the sender's log is ephemeral */
     pb_size_t elements_count;
-    LogEvent elements[2];
+    LogEvent elements[2]; 
 } NextLogEvents;
 
 
@@ -254,8 +270,8 @@ typedef struct _NextLogEvents {
 #define _VentilationMode_ARRAYSIZE ((VentilationMode)(VentilationMode_prvc+1))
 
 #define _LogEventCode_MIN LogEventCode_fio2_too_low
-#define _LogEventCode_MAX LogEventCode_charger_disconnected
-#define _LogEventCode_ARRAYSIZE ((LogEventCode)(LogEventCode_charger_disconnected+1))
+#define _LogEventCode_MAX LogEventCode_backend_shutdown
+#define _LogEventCode_ARRAYSIZE ((LogEventCode)(LogEventCode_backend_shutdown+1))
 
 #define _LogEventType_MIN LogEventType_patient
 #define _LogEventType_MAX LogEventType_system

--- a/frontend/src/modules/app/OverlayScreen.tsx
+++ b/frontend/src/modules/app/OverlayScreen.tsx
@@ -70,7 +70,7 @@ export const HeartbeatBackendListener = (): JSX.Element => {
           type: BACKEND_CONNECTION_DOWN,
           clock: new Date(),
           update: {
-            code: LogEventCode.backend_connection_down,
+            code: LogEventCode.frontend_backend_connection_down,
             type: LogEventType.system,
             time: new Date().getTime(),
           },

--- a/frontend/src/modules/app/OverlayScreen.tsx
+++ b/frontend/src/modules/app/OverlayScreen.tsx
@@ -12,7 +12,7 @@ import { BACKEND_CONNECTION_DOWN, RED_BORDER } from '../../store/app/types';
 import {
   getAlarmMuteActive,
   getAlarmMuteRequestActive,
-  getBackendDown,
+  getBackendDownEvent,
   getHasActiveAlarms,
   getScreenStatusLock,
 } from '../../store/controller/selectors';
@@ -61,7 +61,12 @@ export const HeartbeatBackendListener = (): JSX.Element => {
   const dispatch = useDispatch();
   const heartbeat = useSelector(getBackendHeartBeat);
   const diff = Math.abs(new Date().valueOf() - new Date(heartbeat).valueOf());
-  const lostConnectionAlarm = useSelector(getBackendDown);
+  // Because the backend connection lost event is generated in the frontend and
+  // not sent to or persisted by the backend, we can use getBackendDownEvent as
+  // a reliable indicator of whether there is currently already an alarm displayed
+  // for a lost backend connection. Everywhere else, we should use the selector
+  // from store/app/selectors.ts for getBackendConnected.
+  const lostConnectionAlarm = useSelector(getBackendDownEvent);
 
   useEffect(() => {
     if (diff > BACKEND_CONNECTION_TIMEOUT) {

--- a/frontend/src/modules/app/ToolBar.tsx
+++ b/frontend/src/modules/app/ToolBar.tsx
@@ -24,7 +24,7 @@ import {
   getParametersRequestMode,
   getParametersRequestDraft,
   getAlarmLimitsRequestDraft,
-  getBackendInitialized,
+  getStoreReady,
   getAlarmLimitsRequestUnsaved,
   getAlarmLimitsUnsavedKeys,
   getAlarmLimitsRequest,
@@ -157,7 +157,7 @@ export const ToolBar = ({
   const dispatch = useDispatch();
   const history = useHistory();
   const currentMode = useSelector(getParametersRequestMode);
-  const backendInitialized = useSelector(getBackendInitialized);
+  const storeReady = useSelector(getStoreReady);
   const parameterRequestDraft = useSelector(getParametersRequestDraft, shallowEqual);
   const ventilating = useSelector(getParametersIsVentilating);
   const alarmLimitsRequestDraftSelect = useSelector(getAlarmLimitsRequestDraft);
@@ -261,7 +261,7 @@ export const ToolBar = ({
    * Disabled Start/Pause Ventilation button when backend connection is lost
    */
   useEffect(() => {
-    if (backendInitialized) {
+    if (storeReady) {
       setLandingLabel('Start');
       setIsDisabled(false);
       setLabel(ventilating ? 'Pause Ventilation' : 'Start Ventilation');
@@ -273,7 +273,7 @@ export const ToolBar = ({
       setIsDisabled(true);
       setLabel('Loading...');
     }
-  }, [backendInitialized, ventilatingStatus, ventilating]);
+  }, [storeReady, ventilatingStatus, ventilating]);
 
   useEffect(() => {
     if (ventilating) {

--- a/frontend/src/modules/logs/EventType.tsx
+++ b/frontend/src/modules/logs/EventType.tsx
@@ -63,23 +63,23 @@ export const getEventDetails = (event: LogEvent, eventType: EventType): string =
     }
     return '';
   } else if (event.type === LogEventType.system) {
-    if (event.code === LogEventCode.mcu_connection_down) {
-      return 'Lost connection to hardware controller';
+    if (event.code === LogEventCode.mcu_backend_connection_down) {
+      return 'Hardware controller lost connection';
     }
-    if (event.code === LogEventCode.backend_connection_down) {
-      return 'Lost connection to backend server';
+    if (event.code === LogEventCode.backend_mcu_connection_down) {
+      return 'Backend server lost connection from hardware controller';
     }
-    if (event.code === LogEventCode.frontend_connection_down) {
-      return 'Lost connection to user interface';
+    if (event.code === LogEventCode.backend_frontend_connection_down) {
+      return 'User interface lost connection';
     }
-    if (event.code === LogEventCode.mcu_connection_up) {
-      return 'Connected to hardware controller';
+    if (event.code === LogEventCode.frontend_backend_connection_down) {
+      return 'User interface lost connection';
     }
-    if (event.code === LogEventCode.backend_connection_up) {
-      return 'Connected to backend server';
+    if (event.code === LogEventCode.mcu_backend_connection_up) {
+      return 'Hardware controller connected';
     }
-    if (event.code === LogEventCode.frontend_connection_up) {
-      return 'Connected to user interface';
+    if (event.code === LogEventCode.backend_frontend_connection_up) {
+      return 'User interface connected';
     }
     if (event.code === LogEventCode.charger_disconnected) {
       return 'Battery charger is disconnected';
@@ -223,37 +223,37 @@ export const getEventType = (code: LogEventCode): EventType => {
         label: 'Screen is locked',
         unit: '',
       };
-    case LogEventCode.mcu_connection_down:
+    case LogEventCode.mcu_backend_connection_down:
       return {
         type: LogEventType.system,
         label: 'Software connectivity lost',
         unit: '',
       };
-    case LogEventCode.backend_connection_down:
+    case LogEventCode.backend_mcu_connection_down:
       return {
         type: LogEventType.system,
         label: 'Software connectivity lost',
         unit: '',
       };
-    case LogEventCode.frontend_connection_down:
+    case LogEventCode.backend_frontend_connection_down:
       return {
         type: LogEventType.system,
         label: 'Software connectivity lost',
         unit: '',
       };
-    case LogEventCode.mcu_connection_up:
+    case LogEventCode.frontend_backend_connection_down:
+      return {
+        type: LogEventType.system,
+        label: 'Software connectivity lost',
+        unit: '',
+      };
+    case LogEventCode.mcu_backend_connection_up:
       return {
         type: LogEventType.system,
         label: 'Software connected',
         unit: '',
       };
-    case LogEventCode.backend_connection_up:
-      return {
-        type: LogEventType.system,
-        label: 'Software connected',
-        unit: '',
-      };
-    case LogEventCode.frontend_connection_up:
+    case LogEventCode.backend_frontend_connection_up:
       return {
         type: LogEventType.system,
         label: 'Software connected',

--- a/frontend/src/store/app/selectors.ts
+++ b/frontend/src/store/app/selectors.ts
@@ -31,6 +31,7 @@ export const getAlarmNotifyStatus = createSelector(
   getApp,
   (app: AppState): boolean => app.notifyAlarm,
 );
+// TODO: the "B" in "getBackendHeartBeat" should not be capitalized
 export const getBackendHeartBeat = createSelector(
   getApp,
   (app: AppState): Date => app.backendHeartbeat,

--- a/frontend/src/store/controller/proto/frontend_pb.ts
+++ b/frontend/src/store/controller/proto/frontend_pb.ts
@@ -77,6 +77,11 @@ export interface RotaryEncoder {
   lastButtonUp: number;
 }
 
+export interface BackendConnections {
+  hasMcu: boolean;
+  hasFrontend: boolean;
+}
+
 /** TODO: we also need a request version of this message, FrontendDisplaySettingsRequest */
 export interface FrontendDisplaySetting {
   theme: ThemeVariant;
@@ -220,6 +225,82 @@ export const RotaryEncoder = {
       message.lastButtonUp = object.lastButtonUp;
     } else {
       message.lastButtonUp = 0;
+    }
+    return message;
+  },
+};
+
+const baseBackendConnections: object = { hasMcu: false, hasFrontend: false };
+
+export const BackendConnections = {
+  encode(
+    message: BackendConnections,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.hasMcu === true) {
+      writer.uint32(8).bool(message.hasMcu);
+    }
+    if (message.hasFrontend === true) {
+      writer.uint32(16).bool(message.hasFrontend);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): BackendConnections {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseBackendConnections } as BackendConnections;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.hasMcu = reader.bool();
+          break;
+        case 2:
+          message.hasFrontend = reader.bool();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BackendConnections {
+    const message = { ...baseBackendConnections } as BackendConnections;
+    if (object.hasMcu !== undefined && object.hasMcu !== null) {
+      message.hasMcu = Boolean(object.hasMcu);
+    } else {
+      message.hasMcu = false;
+    }
+    if (object.hasFrontend !== undefined && object.hasFrontend !== null) {
+      message.hasFrontend = Boolean(object.hasFrontend);
+    } else {
+      message.hasFrontend = false;
+    }
+    return message;
+  },
+
+  toJSON(message: BackendConnections): unknown {
+    const obj: any = {};
+    message.hasMcu !== undefined && (obj.hasMcu = message.hasMcu);
+    message.hasFrontend !== undefined &&
+      (obj.hasFrontend = message.hasFrontend);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<BackendConnections>): BackendConnections {
+    const message = { ...baseBackendConnections } as BackendConnections;
+    if (object.hasMcu !== undefined && object.hasMcu !== null) {
+      message.hasMcu = object.hasMcu;
+    } else {
+      message.hasMcu = false;
+    }
+    if (object.hasFrontend !== undefined && object.hasFrontend !== null) {
+      message.hasFrontend = object.hasFrontend;
+    } else {
+      message.hasFrontend = false;
     }
     return message;
   },

--- a/frontend/src/store/controller/proto/mcu_pb.ts
+++ b/frontend/src/store/controller/proto/mcu_pb.ts
@@ -89,14 +89,39 @@ export enum LogEventCode {
   hr_alarm_limits_changed = 83,
   /** screen_locked - System settings & alarms */
   screen_locked = 129,
-  mcu_connection_down = 130,
-  backend_connection_down = 131,
-  frontend_connection_down = 132,
-  mcu_connection_up = 133,
-  backend_connection_up = 134,
-  frontend_connection_up = 135,
-  battery_low = 136,
-  charger_disconnected = 137,
+  /** mcu_backend_connection_down - mcu lost backend */
+  mcu_backend_connection_down = 130,
+  /** backend_mcu_connection_down - backend lost mcu */
+  backend_mcu_connection_down = 131,
+  /** backend_frontend_connection_down - backend lost frontend */
+  backend_frontend_connection_down = 132,
+  /** frontend_backend_connection_down - frontend lost backend */
+  frontend_backend_connection_down = 133,
+  /** mcu_backend_connection_up - mcu detected backend */
+  mcu_backend_connection_up = 134,
+  /**
+   * backend_frontend_connection_up - The following code isn't actually used, but we reserve space for it.
+   * We don't use it because if the backend received an mcu_backend_connection_up
+   * event from the MCU, then we know that the backend received a connection from
+   * the MCU. We only care for technical troubleshooting (of the UART wires) about
+   * the case where the backend receives a connection from the MCU but the MCU
+   * hasn't received a connection from the backend; it would be good to log it,
+   * but we don't need to show it in the frontend, and right now the frontend has
+   * no way to filter out events from its display.
+   * backend_mcu_connection_up = 135;  // backend detected mcu
+   */
+  backend_frontend_connection_up = 136,
+  /**
+   * battery_low - The following code isn't actually used, but we reserve space for it.
+   * We don't use it because the frontend can't generate LogEvents with IDs.
+   * frontend_backend_connection_up = 137;
+   */
+  battery_low = 138,
+  charger_disconnected = 139,
+  mcu_started = 140,
+  backend_started = 141,
+  mcu_shutdown = 142,
+  backend_shutdown = 143,
   UNRECOGNIZED = -1,
 }
 
@@ -154,29 +179,41 @@ export function logEventCodeFromJSON(object: any): LogEventCode {
     case "screen_locked":
       return LogEventCode.screen_locked;
     case 130:
-    case "mcu_connection_down":
-      return LogEventCode.mcu_connection_down;
+    case "mcu_backend_connection_down":
+      return LogEventCode.mcu_backend_connection_down;
     case 131:
-    case "backend_connection_down":
-      return LogEventCode.backend_connection_down;
+    case "backend_mcu_connection_down":
+      return LogEventCode.backend_mcu_connection_down;
     case 132:
-    case "frontend_connection_down":
-      return LogEventCode.frontend_connection_down;
+    case "backend_frontend_connection_down":
+      return LogEventCode.backend_frontend_connection_down;
     case 133:
-    case "mcu_connection_up":
-      return LogEventCode.mcu_connection_up;
+    case "frontend_backend_connection_down":
+      return LogEventCode.frontend_backend_connection_down;
     case 134:
-    case "backend_connection_up":
-      return LogEventCode.backend_connection_up;
-    case 135:
-    case "frontend_connection_up":
-      return LogEventCode.frontend_connection_up;
+    case "mcu_backend_connection_up":
+      return LogEventCode.mcu_backend_connection_up;
     case 136:
+    case "backend_frontend_connection_up":
+      return LogEventCode.backend_frontend_connection_up;
+    case 138:
     case "battery_low":
       return LogEventCode.battery_low;
-    case 137:
+    case 139:
     case "charger_disconnected":
       return LogEventCode.charger_disconnected;
+    case 140:
+    case "mcu_started":
+      return LogEventCode.mcu_started;
+    case 141:
+    case "backend_started":
+      return LogEventCode.backend_started;
+    case 142:
+    case "mcu_shutdown":
+      return LogEventCode.mcu_shutdown;
+    case 143:
+    case "backend_shutdown":
+      return LogEventCode.backend_shutdown;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -220,22 +257,30 @@ export function logEventCodeToJSON(object: LogEventCode): string {
       return "hr_alarm_limits_changed";
     case LogEventCode.screen_locked:
       return "screen_locked";
-    case LogEventCode.mcu_connection_down:
-      return "mcu_connection_down";
-    case LogEventCode.backend_connection_down:
-      return "backend_connection_down";
-    case LogEventCode.frontend_connection_down:
-      return "frontend_connection_down";
-    case LogEventCode.mcu_connection_up:
-      return "mcu_connection_up";
-    case LogEventCode.backend_connection_up:
-      return "backend_connection_up";
-    case LogEventCode.frontend_connection_up:
-      return "frontend_connection_up";
+    case LogEventCode.mcu_backend_connection_down:
+      return "mcu_backend_connection_down";
+    case LogEventCode.backend_mcu_connection_down:
+      return "backend_mcu_connection_down";
+    case LogEventCode.backend_frontend_connection_down:
+      return "backend_frontend_connection_down";
+    case LogEventCode.frontend_backend_connection_down:
+      return "frontend_backend_connection_down";
+    case LogEventCode.mcu_backend_connection_up:
+      return "mcu_backend_connection_up";
+    case LogEventCode.backend_frontend_connection_up:
+      return "backend_frontend_connection_up";
     case LogEventCode.battery_low:
       return "battery_low";
     case LogEventCode.charger_disconnected:
       return "charger_disconnected";
+    case LogEventCode.mcu_started:
+      return "mcu_started";
+    case LogEventCode.backend_started:
+      return "backend_started";
+    case LogEventCode.mcu_shutdown:
+      return "mcu_shutdown";
+    case LogEventCode.backend_shutdown:
+      return "backend_shutdown";
     default:
       return "UNKNOWN";
   }

--- a/frontend/src/store/controller/proto/mcu_pb.ts
+++ b/frontend/src/store/controller/proto/mcu_pb.ts
@@ -66,7 +66,6 @@ export function ventilationModeToJSON(object: VentilationMode): string {
   }
 }
 
-/** Log Events */
 export enum LogEventCode {
   /** fio2_too_low - Patient alarms */
   fio2_too_low = 0,

--- a/frontend/src/store/controller/reducers.ts
+++ b/frontend/src/store/controller/reducers.ts
@@ -11,7 +11,11 @@ import {
   MCUPowerStatus,
   ScreenStatus,
 } from './proto/mcu_pb';
-import { SystemSettingRequest, FrontendDisplaySetting } from './proto/frontend_pb';
+import {
+  BackendConnections,
+  SystemSettingRequest,
+  FrontendDisplaySetting,
+} from './proto/frontend_pb';
 import {
   messageReducer,
   requestReducer,
@@ -51,6 +55,7 @@ export const controllerReducer = combineReducers({
   mcuPowerStatus: messageReducer<MCUPowerStatus>(MessageType.MCUPowerStatus),
 
   // Message states from frontend_pb
+  backendConnections: messageReducer<BackendConnections>(MessageType.BackendConnections),
   screenStatus: messageReducer<ScreenStatus>(MessageType.ScreenStatus),
   rotaryEncoder: rotaryEncoderReducer,
   systemSettingRequest: requestReducer<SystemSettingRequest>(

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -271,8 +271,8 @@ const getLogEventCode = (logEventCode: number) =>
     events.find((el: LogEvent) => (el.code as number) === logEventCode),
   );
 
-export const getBackendDown = getLogEventCode(LogEventCode.backend_connection_down);
-export const getFirmwareDown = getLogEventCode(LogEventCode.mcu_connection_down);
+export const getBackendDown = getLogEventCode(LogEventCode.frontend_backend_connection_down);
+export const getFirmwareDown = getLogEventCode(LogEventCode.backend_mcu_connection_down);
 // TODO: this selector returns "true" in a scenario where mcu is disconnected and plugged back in,
 // replace the implementation with a "firmwareConnection" protobuf message once available
 export const getFirmwareDisconnected = createSelector(

--- a/frontend/src/store/controller/selectors.ts
+++ b/frontend/src/store/controller/selectors.ts
@@ -2,7 +2,6 @@ import { createSelector, OutputSelector } from 'reselect';
 import DECIMAL_RADIX from '../../modules/app/AppConstants';
 import { getBackendConnected } from '../app/selectors';
 import { StoreState } from '../types';
-import { FrontendDisplaySetting, SystemSettingRequest } from './proto/frontend_pb';
 import {
   AlarmLimits,
   AlarmLimitsRequest,
@@ -20,6 +19,11 @@ import {
   MCUPowerStatus,
   LogEventCode,
 } from './proto/mcu_pb';
+import {
+  BackendConnections,
+  FrontendDisplaySetting,
+  SystemSettingRequest,
+} from './proto/frontend_pb';
 import {
   Measurements,
   ParametersRequestResponse,
@@ -270,26 +274,10 @@ const getLogEventCode = (logEventCode: number) =>
   createSelector(getNextLogEvents, (events: LogEvent[]): LogEvent | undefined =>
     events.find((el: LogEvent) => (el.code as number) === logEventCode),
   );
-
-export const getBackendDown = getLogEventCode(LogEventCode.frontend_backend_connection_down);
-export const getFirmwareDown = getLogEventCode(LogEventCode.backend_mcu_connection_down);
-// TODO: this selector returns "true" in a scenario where mcu is disconnected and plugged back in,
-// replace the implementation with a "firmwareConnection" protobuf message once available
-export const getFirmwareDisconnected = createSelector(
-  getFirmwareDown,
-  (event: LogEvent | undefined): boolean => event !== undefined,
-);
-// Backend Initialized
-export const getBackendInitialized = createSelector(
-  getParametersRequest,
-  getAlarmLimitsRequest,
-  getBackendConnected,
-  (
-    parametersRequest: ParametersRequest | null,
-    alarmLimitsRequest: AlarmLimitsRequest | null,
-    backendConnected: boolean,
-  ): boolean => parametersRequest !== null && alarmLimitsRequest !== null && backendConnected,
-);
+// Note: this selector should only be used to check whether the frontend's event log
+// has a temporary event indicating that the backend is down. The proper selector to
+// check whether the backend is connected is store/app/selector.ts's getBackendConnected
+export const getBackendDownEvent = getLogEventCode(LogEventCode.frontend_backend_connection_down);
 
 // Changing Ventilating Status
 export const getVentilatingStatusChanging = createSelector(
@@ -347,6 +335,38 @@ export const getChargingStatus = createSelector(
 
 // MESSAGE STATES FROM frontend_pb
 // TODO: split this section off into a new file
+
+// Connection Statuses
+export const getBackendConnections = createSelector(
+  getController,
+  (states: ControllerStates): BackendConnections | null => states.backendConnections,
+);
+
+// getBackendConnected is a selector defined in store/app/selectors.ts
+export const getFirmwareConnected = createSelector(
+  getBackendConnections,
+  (backendConnections: BackendConnections | null): boolean =>
+    backendConnections === null ? false : backendConnections.hasMcu,
+);
+export const getStoreReady = createSelector(
+  getParametersRequest,
+  getAlarmLimitsRequest,
+  getAlarmMuteRequest,
+  getBackendConnected,
+  getFirmwareConnected,
+  (
+    parametersRequest: ParametersRequest | null,
+    alarmLimitsRequest: AlarmLimitsRequest | null,
+    alarmMuteRequest: AlarmMuteRequest | null,
+    backendConnected: boolean,
+    firmwareConnected: boolean,
+  ): boolean =>
+    parametersRequest !== null &&
+    alarmLimitsRequest !== null &&
+    alarmMuteRequest !== null &&
+    backendConnected &&
+    firmwareConnected,
+);
 
 // Screen Status
 

--- a/frontend/src/store/controller/types.ts
+++ b/frontend/src/store/controller/types.ts
@@ -17,7 +17,7 @@ import {
   BackendConnections,
   RotaryEncoder,
   SystemSettingRequest,
-  FrontendDisplaySetting
+  FrontendDisplaySetting,
 } from './proto/frontend_pb';
 
 // MESSAGES

--- a/frontend/src/store/controller/types.ts
+++ b/frontend/src/store/controller/types.ts
@@ -13,7 +13,12 @@ import {
   MCUPowerStatus,
   ScreenStatus,
 } from './proto/mcu_pb';
-import { RotaryEncoder, SystemSettingRequest, FrontendDisplaySetting } from './proto/frontend_pb';
+import {
+  BackendConnections,
+  RotaryEncoder,
+  SystemSettingRequest,
+  FrontendDisplaySetting
+} from './proto/frontend_pb';
 
 // MESSAGES
 
@@ -33,6 +38,7 @@ export type PBMessage =
   | MCUPowerStatus
   | ScreenStatus
   // frontend_pb
+  | BackendConnections
   | RotaryEncoder
   | SystemSettingRequest
   | FrontendDisplaySetting;
@@ -53,6 +59,7 @@ export type PBMessageType =
   | typeof MCUPowerStatus
   | typeof ScreenStatus
   // frontend_pb
+  | typeof BackendConnections
   | typeof RotaryEncoder
   | typeof SystemSettingRequest
   | typeof FrontendDisplaySetting;
@@ -73,7 +80,8 @@ export enum MessageType {
   MCUPowerStatus = 20,
   ScreenStatus = 65,
   // frontend_pb
-  RotaryEncoder = 128,
+  BackendConnections = 128,
+  RotaryEncoder = 129,
   SystemSetting = 130,
   SystemSettingRequest = 131,
   FrontendDisplaySetting = 132,
@@ -96,11 +104,13 @@ export const MessageClass = new Map<MessageType, PBMessageType>([
   [MessageType.MCUPowerStatus, MCUPowerStatus],
   [MessageType.ScreenStatus, ScreenStatus],
   // frontend_pb
+  [MessageType.BackendConnections, BackendConnections],
+  [MessageType.RotaryEncoder, RotaryEncoder],
   [MessageType.SystemSettingRequest, SystemSettingRequest],
   [MessageType.FrontendDisplaySetting, FrontendDisplaySetting],
-  [MessageType.RotaryEncoder, RotaryEncoder],
 ]);
 
+// TODO: can we auto-generate this from MessageClass?
 export const MessageTypes = new Map<PBMessageType, MessageType>([
   // mcu_pb
   [SensorMeasurements, MessageType.SensorMeasurements],
@@ -117,9 +127,10 @@ export const MessageTypes = new Map<PBMessageType, MessageType>([
   [MCUPowerStatus, MessageType.MCUPowerStatus],
   [ScreenStatus, MessageType.ScreenStatus],
   // frontend_pb
+  [BackendConnections, MessageType.BackendConnections],
+  [RotaryEncoder, MessageType.RotaryEncoder],
   [SystemSettingRequest, MessageType.SystemSettingRequest],
   [FrontendDisplaySetting, MessageType.FrontendDisplaySetting],
-  [RotaryEncoder, MessageType.RotaryEncoder],
 ]);
 
 // STATES
@@ -221,6 +232,7 @@ export interface ControllerStates {
   heartbeatBackend: { time: Date };
 
   // Message states from frontend_pb
+  backendConnections: BackendConnections | null;
   rotaryEncoder: RotaryEncoderParameter | null;
 
   // Derived states

--- a/proto/frontend_pb.proto
+++ b/proto/frontend_pb.proto
@@ -8,6 +8,15 @@ message RotaryEncoder {
   float last_button_up = 5;
 }
 
+// Connection statuses
+
+message BackendConnections {
+  bool has_mcu = 1;
+  bool has_frontend = 2;
+}
+
+// Display Settings
+
 // TODO: should metric be 0? (i.e. the default)
 enum Unit {
   imperial = 0;
@@ -24,6 +33,8 @@ message FrontendDisplaySetting {
   ThemeVariant theme = 1;
   Unit unit = 2;
 }
+
+// System Settings
 
 // TODO: we also need a response version of this message, SystemSettings
 message SystemSettingRequest {

--- a/proto/mcu_pb.proto
+++ b/proto/mcu_pb.proto
@@ -133,14 +133,30 @@ enum LogEventCode {
   hr_alarm_limits_changed = 83;
   // System settings & alarms
   screen_locked = 129;
-  mcu_connection_down = 130;
-  backend_connection_down = 131;
-  frontend_connection_down = 132;
-  mcu_connection_up = 133;
-  backend_connection_up = 134;
-  frontend_connection_up = 135;
-  battery_low = 136;
-  charger_disconnected = 137;
+  mcu_backend_connection_down = 130;  // mcu lost backend
+  backend_mcu_connection_down = 131;  // backend lost mcu
+  backend_frontend_connection_down = 132;  // backend lost frontend
+  frontend_backend_connection_down = 133;  // frontend lost backend
+  mcu_backend_connection_up = 134;  // mcu detected backend
+  // The following code isn't actually used, but we reserve space for it.
+  // We don't use it because if the backend received an mcu_backend_connection_up
+  // event from the MCU, then we know that the backend received a connection from
+  // the MCU. We only care for technical troubleshooting (of the UART wires) about
+  // the case where the backend receives a connection from the MCU but the MCU
+  // hasn't received a connection from the backend; it would be good to log it,
+  // but we don't need to show it in the frontend, and right now the frontend has
+  // no way to filter out events from its display.
+  // backend_mcu_connection_up = 135;  // backend detected mcu
+  backend_frontend_connection_up = 136;  // backend detected frontend
+  // The following code isn't actually used, but we reserve space for it.
+  // We don't use it because the frontend can't generate LogEvents with IDs.
+  // frontend_backend_connection_up = 137;
+  battery_low = 138;
+  charger_disconnected = 139;
+  mcu_started = 140;
+  backend_started = 141;
+  mcu_shutdown = 142;
+  backend_shutdown = 143;
 }
 
 enum LogEventType {

--- a/proto/mcu_pb.proto
+++ b/proto/mcu_pb.proto
@@ -111,6 +111,7 @@ message Announcement {
 }
 
 // Log Events
+
 enum LogEventCode {
   // Patient alarms
   fio2_too_low = 0;


### PR DESCRIPTION
This PR fixes #371 by adding a new `BackendConnections` message type in `proto/frontend_pb.proto` so that the backend's server protocol can report whether the MCU and frontend are currently connected. This PR also updates the frontend's selectors to use this message type.

For records-keeping:
1. This project is licensed under Apache License v2.0 for any software, and Solderpad Hardware License v2.1 for any hardware - do you agree that your contributions to this project will be under these licenses, too? **Yes**
2. Were any of these contributions also part of work you did for an employer or a client? **No**
3. Does this work include, or is it based on, any third-party work which you did not create? **No**