### PR TITLE
Generate firmware log events & alarms for connection/disconnection to backend

### DIFF
--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/LogEvents.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/LogEvents.h
@@ -25,6 +25,7 @@ class IncrementalEventsSender {
   // the provided event is not modified.
   void add_event(Element event, uint32_t &id);
   void add_event(const Element &event);
+  void add_event(LogEventCode code, LogEventType type);
 
  private:
   LogEventsSender &sender_;

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/LogEvents.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/LogEvents.tpp
@@ -34,4 +34,12 @@ void IncrementalEventsSender<ListSender>::add_event(const Element &event) {
   add_event(event, id_discard);
 }
 
+template <typename ListSender>
+void IncrementalEventsSender<ListSender>::add_event(LogEventCode code, LogEventType type) {
+  Element event;
+  event.code = code;
+  event.type = type;
+  add_event(event);
+}
+
 }  // namespace Pufferfish::Application

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Application/States.h
@@ -88,6 +88,7 @@ struct StateSegments {
 
   // Internal States
   SensorMeasurements sensor_measurements_raw;
+  bool backend_connected;
 };
 
 class Store {
@@ -114,6 +115,7 @@ class Store {
 
   // Internal States
   SensorMeasurements &sensor_measurements_raw();
+  bool &backend_connected();
 
   InputStatus input(const StateSegment &input, bool default_initialization = false);
   OutputStatus output(MessageTypes type, StateSegment &output) const;

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/AlarmsService.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/BreathingCircuit/AlarmsService.h
@@ -31,7 +31,6 @@ class AlarmsService {
       const Parameters &parameters,
       const AlarmLimits &alarm_limits,
       const SensorMeasurements &sensor_measurements,
-      ActiveLogEvents &active_log_events,
       Application::AlarmsManager &alarms_manager);
 };
 
@@ -43,7 +42,6 @@ class HFNCAlarms : public AlarmsService {
       const Parameters &parameters,
       const AlarmLimits &alarm_limits,
       const SensorMeasurements &sensor_measurements,
-      ActiveLogEvents &active_log_events,
       Application::AlarmsManager &alarms_manager) override;
 };
 
@@ -53,7 +51,6 @@ class AlarmsServices {
       const Parameters &parameters,
       const AlarmLimits &alarm_limits,
       const SensorMeasurements &sensor_measurements,
-      ActiveLogEvents &active_log_events,
       Application::AlarmsManager &alarms_manager);
 
  private:

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Power/AlarmsService.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Power/AlarmsService.h
@@ -18,7 +18,7 @@ static constexpr auto alarm_codes =
 
 class AlarmsService {
  public:
-  void transform(
+  static void transform(
       const MCUPowerStatus &mcu_power_status, Application::AlarmsManager &alarms_manager);
 };
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Power/AlarmsService.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Power/AlarmsService.h
@@ -18,9 +18,8 @@ static constexpr auto alarm_codes =
 
 class AlarmsService {
  public:
-  virtual void transform(
+  void transform(
       const MCUPowerStatus &mcu_power_status,
-      ActiveLogEvents &active_log_events,
       Application::AlarmsManager &alarms_manager);
 };
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Power/AlarmsService.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Power/AlarmsService.h
@@ -19,8 +19,7 @@ static constexpr auto alarm_codes =
 class AlarmsService {
  public:
   void transform(
-      const MCUPowerStatus &mcu_power_status,
-      Application::AlarmsManager &alarms_manager);
+      const MCUPowerStatus &mcu_power_status, Application::AlarmsManager &alarms_manager);
 };
 
 }  // namespace Pufferfish::Driver::Power

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/AlarmsService.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/AlarmsService.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020, the Pez Globo team and the Pufferfish project contributors
+ *
+ */
+
+#pragma once
+
+#include "Pufferfish/Application/Alarms.h"
+#include "Pufferfish/Application/LogEvents.h"
+#include "Pufferfish/Protocols/Application/Debouncing.h"
+#include "Pufferfish/Util/Containers/Array.h"
+
+namespace Pufferfish::Driver::Serial::Backend {
+
+// All alarm codes for power management need to be registered in the following array:
+static constexpr auto alarm_codes =
+    Util::Containers::make_array<LogEventCode>(
+        LogEventCode::LogEventCode_mcu_backend_connection_up,
+        LogEventCode::LogEventCode_mcu_backend_connection_down);
+
+class AlarmsService {
+ public:
+  void transform(
+      bool connected,
+      Application::AlarmsManager &alarms_manager,
+      Application::LogEventsManager &log_manager);
+
+ private:
+  Protocols::Application::EdgeDetector edge_;
+};
+
+}  // namespace Pufferfish::Driver::Serial::Backend

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/AlarmsService.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/AlarmsService.h
@@ -13,10 +13,9 @@
 namespace Pufferfish::Driver::Serial::Backend {
 
 // All alarm codes for power management need to be registered in the following array:
-static constexpr auto alarm_codes =
-    Util::Containers::make_array<LogEventCode>(
-        LogEventCode::LogEventCode_mcu_backend_connection_up,
-        LogEventCode::LogEventCode_mcu_backend_connection_down);
+static constexpr auto alarm_codes = Util::Containers::make_array<LogEventCode>(
+    LogEventCode::LogEventCode_mcu_backend_connection_up,
+    LogEventCode::LogEventCode_mcu_backend_connection_down);
 
 class AlarmsService {
  public:

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
@@ -21,6 +21,7 @@
 #include "Pufferfish/Util/Containers/Array.h"
 #include "Pufferfish/Util/Containers/EnumMap.h"
 #include "Pufferfish/Util/Enums.h"
+#include "Pufferfish/Util/Timeouts.h"
 
 namespace Pufferfish::Driver::Serial::Backend {
 
@@ -75,6 +76,7 @@ static const auto state_sync_schedule =
         StateOutputScheduleEntry{10, MessageTypes::mcu_power_status});
 
 // Backend
+
 using CRCElementProps =
     Protocols::Transport::CRCElementProps<Driver::Serial::Backend::FrameProps::payload_max_size>;
 using DatagramProps = Protocols::Transport::DatagramProps<CRCElementProps::payload_max_size>;
@@ -160,6 +162,8 @@ class Sender {
   FrameSender frame_;
 };
 
+static const uint32_t connection_timeout = 500;
+
 class Backend {
  public:
   enum class Status { ok = 0, waiting, invalid };
@@ -180,6 +184,8 @@ class Backend {
   void update_list_senders();
   Status output(FrameProps::ChunkBuffer &output_buffer);
 
+  bool connected() const;
+
  private:
   using StateSynchronizer = Protocols::Application::StateSynchronizer<
       Application::Store,
@@ -192,6 +198,9 @@ class Backend {
   Application::Store &store_;
   StateSynchronizer synchronizer_;
   Application::LogEventsSender &log_events_sender_;
+
+  uint32_t current_time_;
+  Util::MsTimer connection_timer_{connection_timeout};
 };
 
 }  // namespace Pufferfish::Driver::Serial::Backend

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.h
@@ -184,7 +184,7 @@ class Backend {
   void update_list_senders();
   Status output(FrameProps::ChunkBuffer &output_buffer);
 
-  bool connected() const;
+  [[nodiscard]] bool connected() const;
 
  private:
   using StateSynchronizer = Protocols::Application::StateSynchronizer<
@@ -199,7 +199,7 @@ class Backend {
   StateSynchronizer synchronizer_;
   Application::LogEventsSender &log_events_sender_;
 
-  uint32_t current_time_;
+  uint32_t current_time_{};
   Util::MsTimer connection_timer_{connection_timeout};
 };
 

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/Backend.tpp
@@ -178,6 +178,7 @@ Backend::Status Backend::input(uint8_t new_byte) {
     return Status::invalid;
   }
 
+  connection_timer_.reset(current_time_);
   // Input into state synchronization
   switch (store_.input(message.payload)) {
     case Application::Store::InputStatus::ok:
@@ -192,6 +193,7 @@ Backend::Status Backend::input(uint8_t new_byte) {
 
 void Backend::update_clock(uint32_t current_time) {
   synchronizer_.input(current_time);
+  current_time_ = current_time;
 }
 
 void Backend::update_list_senders() {
@@ -231,6 +233,10 @@ Backend::Status Backend::output(FrameProps::ChunkBuffer &output_buffer) {
   }
 
   return Status::ok;
+}
+
+bool Backend::connected() const {
+  return connection_timer_.within_timeout(current_time_);
 }
 
 }  // namespace Pufferfish::Driver::Serial::Backend

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/UART.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/UART.h
@@ -28,7 +28,7 @@ class UARTBackend {
   void setup_irq();
   void receive();
   void update_clock(uint32_t current_time);
-  bool connected() const;
+  [[nodiscard]] bool connected() const;
   void send();
 
  private:

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/UART.h
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/UART.h
@@ -28,6 +28,7 @@ class UARTBackend {
   void setup_irq();
   void receive();
   void update_clock(uint32_t current_time);
+  bool connected() const;
   void send();
 
  private:

--- a/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/UART.tpp
+++ b/firmware/ventilator-controller-stm32/Core/Inc/Pufferfish/Driver/Serial/Backend/UART.tpp
@@ -46,6 +46,10 @@ void UARTBackend::update_clock(uint32_t current_time) {
   backend_.update_clock(current_time);
 }
 
+bool UARTBackend::connected() const {
+  return backend_.connected();
+}
+
 void UARTBackend::send() {
   // Create a new output to write if needed
   if (sent_ >= send_output_.size()) {

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Application/States.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Application/States.cpp
@@ -115,6 +115,10 @@ SensorMeasurements &Store::sensor_measurements_raw() {
   return state_segments_.sensor_measurements_raw;
 }
 
+bool &Store::backend_connected() {
+  return state_segments_.backend_connected;
+}
+
 Store::InputStatus Store::input(const StateSegment &input, bool default_initialization) {
   switch (input.tag) {
     case MessageTypes::sensor_measurements:

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/AlarmsService.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/AlarmsService.cpp
@@ -70,8 +70,7 @@ void HFNCAlarms::transform(
     const AlarmLimits &alarm_limits,
     const SensorMeasurements &sensor_measurements,
     Application::AlarmsManager &alarms_manager) {
-  AlarmsService::transform(
-      parameters, alarm_limits, sensor_measurements, alarms_manager);
+  AlarmsService::transform(parameters, alarm_limits, sensor_measurements, alarms_manager);
   if (!parameters.ventilating) {
     return;
   }
@@ -106,8 +105,7 @@ void AlarmsServices::transform(
     return;
   }
 
-  active_service_->transform(
-      parameters, alarm_limits, sensor_measurements, alarms_manager);
+  active_service_->transform(parameters, alarm_limits, sensor_measurements, alarms_manager);
 }
 
 }  // namespace Pufferfish::Driver::BreathingCircuit

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/AlarmsService.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/BreathingCircuit/AlarmsService.cpp
@@ -38,12 +38,8 @@ void AlarmsService::transform(
     const Parameters &parameters,
     const AlarmLimits &alarm_limits,
     const SensorMeasurements &sensor_measurements,
-    ActiveLogEvents &active_log_events,
     Application::AlarmsManager &alarms_manager) {
   if (!parameters.ventilating) {
-    // ParametersService already reset the alarms in AlarmsManager, so AlarmsService just needs to
-    // update active_log_events
-    alarms_manager.transform(active_log_events);
     return;
   }
 
@@ -65,8 +61,6 @@ void AlarmsService::transform(
       LogEventCode::LogEventCode_fio2_too_low,
       LogEventCode::LogEventCode_fio2_too_high,
       alarms_manager);
-
-  alarms_manager.transform(active_log_events);
 }
 
 // HFNCAlarms
@@ -75,10 +69,9 @@ void HFNCAlarms::transform(
     const Parameters &parameters,
     const AlarmLimits &alarm_limits,
     const SensorMeasurements &sensor_measurements,
-    ActiveLogEvents &active_log_events,
     Application::AlarmsManager &alarms_manager) {
   AlarmsService::transform(
-      parameters, alarm_limits, sensor_measurements, active_log_events, alarms_manager);
+      parameters, alarm_limits, sensor_measurements, alarms_manager);
   if (!parameters.ventilating) {
     return;
   }
@@ -89,8 +82,6 @@ void HFNCAlarms::transform(
       LogEventCode::LogEventCode_flow_too_low,
       LogEventCode::LogEventCode_flow_too_high,
       alarms_manager);
-
-  alarms_manager.transform(active_log_events);
 }
 
 // AlarmsServices
@@ -99,7 +90,6 @@ void AlarmsServices::transform(
     const Parameters &parameters,
     const AlarmLimits &alarm_limits,
     const SensorMeasurements &sensor_measurements,
-    ActiveLogEvents &active_log_events,
     Application::AlarmsManager &alarms_manager) {
   switch (parameters.mode) {
     case VentilationMode_pc_ac:
@@ -117,7 +107,7 @@ void AlarmsServices::transform(
   }
 
   active_service_->transform(
-      parameters, alarm_limits, sensor_measurements, active_log_events, alarms_manager);
+      parameters, alarm_limits, sensor_measurements, alarms_manager);
 }
 
 }  // namespace Pufferfish::Driver::BreathingCircuit

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Power/AlarmsService.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Power/AlarmsService.cpp
@@ -11,8 +11,7 @@ namespace Pufferfish::Driver::Power {
 
 // AlarmsService
 void AlarmsService::transform(
-    const MCUPowerStatus &mcu_power_status,
-    Application::AlarmsManager &alarms_manager) {
+    const MCUPowerStatus &mcu_power_status, Application::AlarmsManager &alarms_manager) {
   if (!mcu_power_status.charging) {
     alarms_manager.activate_alarm(
         LogEventCode_charger_disconnected, LogEventType::LogEventType_system);

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Power/AlarmsService.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Power/AlarmsService.cpp
@@ -12,7 +12,6 @@ namespace Pufferfish::Driver::Power {
 // AlarmsService
 void AlarmsService::transform(
     const MCUPowerStatus &mcu_power_status,
-    ActiveLogEvents &active_log_events,
     Application::AlarmsManager &alarms_manager) {
   if (!mcu_power_status.charging) {
     alarms_manager.activate_alarm(
@@ -20,7 +19,6 @@ void AlarmsService::transform(
   } else {
     alarms_manager.deactivate_alarm(LogEventCode_charger_disconnected);
   }
-  alarms_manager.transform(active_log_events);
 }
 
 }  // namespace Pufferfish::Driver::Power

--- a/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/Backend/AlarmsService.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/Pufferfish/Driver/Serial/Backend/AlarmsService.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020, the Pez Globo team and the Pufferfish project contributors
+ *
+ */
+
+#include "Pufferfish/Driver/Serial/Backend/AlarmsService.h"
+
+namespace Pufferfish::Driver::Serial::Backend {
+
+// AlarmsService
+void AlarmsService::transform(
+    bool connected,
+    Application::AlarmsManager &alarms_manager,
+    Application::LogEventsManager &log_manager) {
+  using EdgeState = Protocols::Application::EdgeDetector::State;
+  EdgeState edge;
+  edge_.transform(connected, edge);
+  switch (edge) {
+    case EdgeState::rising_edge:
+      alarms_manager.deactivate_alarm(LogEventCode_mcu_backend_connection_down);
+      log_manager.add_event(
+          LogEventCode_mcu_backend_connection_up, LogEventType::LogEventType_system);
+      break;
+    case EdgeState::falling_edge:
+      alarms_manager.activate_alarm(
+          LogEventCode_mcu_backend_connection_down, LogEventType::LogEventType_system);
+      break;
+    default:
+      return;
+  }
+}
+
+}  // namespace Pufferfish::Driver::Serial::Backend

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -670,11 +670,11 @@ int main(void)
 
     // Indicators for debugging
     static constexpr float valve_opening_indicator_threshold = 0.00001;
-    if (hfnc.actuator_vars().valve_air_opening > valve_opening_indicator_threshold) {
+    /*if (hfnc.actuator_vars().valve_air_opening > valve_opening_indicator_threshold) {
       board_led1.write(dimmer.output());
     } else {
       board_led1.write(false);
-    }
+    }*/
     /*if (hfnc.sensor_vars().flow_o2 > 1 || hfnc.sensor_vars().flow_air > 1) {
       board_led1.write(true);
     } else if (hfnc.sensor_vars().flow_o2 < -1 || hfnc.sensor_vars().flow_air < -1) {
@@ -685,6 +685,12 @@ int main(void)
 
     // Alarms
     alarms_manager.transform(store.active_log_events());
+    if (store.active_log_events().id_count > 0) {
+      board_led1.write(true);
+    } else {
+      blinker.input(current_time);
+      board_led1.write(blinker.output());
+    }
 
     // Backend Communication Protocol
     backend.receive();

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -669,8 +669,8 @@ int main(void)
     power_alarms.transform(store.mcu_power_status(), alarms_manager);
 
     // Indicators for debugging
-    static constexpr float valve_opening_indicator_threshold = 0.00001;
-    /*if (hfnc.actuator_vars().valve_air_opening > valve_opening_indicator_threshold) {
+    /*static constexpr float valve_opening_indicator_threshold = 0.00001;
+    if (hfnc.actuator_vars().valve_air_opening > valve_opening_indicator_threshold) {
       board_led1.write(dimmer.output());
     } else {
       board_led1.write(false);

--- a/firmware/ventilator-controller-stm32/Core/Src/main.cpp
+++ b/firmware/ventilator-controller-stm32/Core/Src/main.cpp
@@ -666,7 +666,7 @@ int main(void)
       ltc4015.output(store.mcu_power_status());
     }
 
-    power_alarms.transform(store.mcu_power_status(), alarms_manager);
+    PF::Driver::Power::AlarmsService::transform(store.mcu_power_status(), alarms_manager);
 
     // Indicators for debugging
     /*static constexpr float valve_opening_indicator_threshold = 0.00001;


### PR DESCRIPTION
This PR fixes #353 by adding a message receipt timer to the `Driver::Serial::Backend::Backend` class with a timeout of 500 ms and using it to set a boolean flag in the store about whether the connection is active, and by adding a `Driver::Serial::Backend::AlarmsService` class to update the events log on rising and falling edges for that flag.

This PR also lightly refactors the various `AlarmsService` classes by taking the responsibility for updating `store.active_log_events()` out of their transform methods; instead, `main.cpp` calls `alarms_manager.transform(store.active_log_events())` once during every iteration of the main loop.

Finally, this PR changes the behavior of the Nucleo's LED LD1 so that it blinks slowly when running normally and is solid-on when an alarm is active. This allows some visibility into the state of alarms on the Nucleo board when it's not connected to the frontend.

For records-keeping:
1. This project is licensed under Apache License v2.0 for any software, and Solderpad Hardware License v2.1 for any hardware - do you agree that your contributions to this project will be under these licenses, too? **Yes**
2. Were any of these contributions also part of work you did for an employer or a client? **No**
3. Does this work include, or is it based on, any third-party work which you did not create? **No**